### PR TITLE
Handling of datetime type and parsing errors. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ would pass the row as-is to the next directive.
 
 **Specification**
 ```
-  filter-row-by-condition {condition}
+  filter-row-if-true {condition}
 ```
 
 * condition - A JEXL expression.
@@ -173,13 +173,13 @@ would pass the row as-is to the next directive.
 **Example**
 ```
   set columns id,fname,lname,email,address,city,state,zip
-  filter-row-by-condition id > 200
+  filter-row-if-true id > 200
 ```
 
 Regular expression based filtering applies an regular expression on the value of a column specified in the
 directive.
 ```
-  filter-row-by-regex {column-name} {regex}
+  filter-row-if-matched {column-name} {regex}
 ```
 
 **Specification**
@@ -189,7 +189,7 @@ directive.
 **Example**
 ```
   set columns id,fname,lname,email,address,city,state,zip
-  filter-row-by-condition email .*@joltie.io
+  filter-row-if-matched email .*@joltie.io
 ```
 
 ### Set Column with expression
@@ -300,14 +300,14 @@ To convert from unix timestamp to a date format use the following directive
 **Specificaton**
 
 ```
-  format-unixtimestamp {column-name} {date-format}
+  format-unix-timestamp {column-name} {date-format}
 ```
 * column-name - Name of the column that contains unix timestamp that needs to be converted to date-format
 * date-format - Format to convert from unix timestamp.
 
 **Example**
 ```
-  format-unixtimestamp timestamp MM/dd/yyyy
+  format-unix-timestamp timestamp MM/dd/yyyy
 ```
 
 ## How to add a new Directive

--- a/docs/Wrangler-transform.md
+++ b/docs/Wrangler-transform.md
@@ -155,7 +155,7 @@ would pass the row as-is to the next directive.
 
 **Specification**
 ```
-  filter-row-by-condition {condition}
+  filter-row-if-true {condition}
 ```
 
 * condition - A JEXL expression.
@@ -163,13 +163,13 @@ would pass the row as-is to the next directive.
 **Example**
 ```
   set columns id,fname,lname,email,address,city,state,zip
-  filter-row-by-condition id > 200
+  filter-row-if-true id > 200
 ```
 
 Regular expression based filtering applies an regular expression on the value of a column specified in the
 directive. If the {condition} is true, the row will be skipped else it will be passed down to next step.
 ```
-  filter-row-by-regex {column-name} {regex}
+  filter-row-if-matched {column-name} {regex}
 ```
 
 **Specification**
@@ -179,7 +179,7 @@ directive. If the {condition} is true, the row will be skipped else it will be p
 **Example**
 ```
   set columns id,fname,lname,email,address,city,state,zip
-  filter-row-by-condition email .*@joltie.io
+  filter-row-if-matched email .*@joltie.io
 ```
 
 ### Set Column with expression
@@ -290,12 +290,12 @@ To convert from unix timestamp to a date format use the following directive
 **Specificaton**
 
 ```
-  format-unixtimestamp {column-name} {date-format}
+  format-unix-timestamp {column-name} {date-format}
 ```
 * column-name - Name of the column that contains unix timestamp that needs to be converted to date-format
 * date-format - Format to convert from unix timestamp.
 
 **Example**
 ```
-  format-unixtimestamp timestamp MM/dd/yyyy
+  format-unix-timestamp timestamp MM/dd/yyyy
 ```

--- a/src/main/java/co/cask/wrangler/api/SpecificationParseException.java
+++ b/src/main/java/co/cask/wrangler/api/SpecificationParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,19 +16,13 @@
 
 package co.cask.wrangler.api;
 
-import java.util.List;
-
 /**
- * A specification for how {@link Pipeline} will process.
+ * An exception thrown when there is error in parsing specification.
  */
-public interface Specification {
-  // Column definition for the start of processing.
-  public static final String STARTING_COLUMN = "__col";
+public class SpecificationParseException extends Exception {
 
-  /**
-   * Generates a configured set of {@link Step} to be executed.
-   *
-   * @return List of {@link Step}.
-   */
-  List<Step> getSteps() throws SpecificationParseException;
+  public SpecificationParseException(String message) {
+    super(message);
+  }
 }
+

--- a/src/main/java/co/cask/wrangler/internal/DefaultPipeline.java
+++ b/src/main/java/co/cask/wrangler/internal/DefaultPipeline.java
@@ -24,10 +24,10 @@ import co.cask.wrangler.api.PipelineException;
 import co.cask.wrangler.api.Row;
 import co.cask.wrangler.api.SkipRowException;
 import co.cask.wrangler.api.Specification;
+import co.cask.wrangler.api.SpecificationParseException;
 import co.cask.wrangler.api.Step;
 import co.cask.wrangler.api.StepException;
 
-import java.text.ParseException;
 import java.util.List;
 
 /**
@@ -57,7 +57,7 @@ public final class DefaultPipeline implements Pipeline<Row, StructuredRecord> {
       }
     } catch (StepException e) {
       throw new PipelineException(e);
-    } catch (ParseException e) {
+    } catch (SpecificationParseException e) {
       throw new PipelineException(e);
     }
 

--- a/src/main/java/co/cask/wrangler/internal/TextSpecification.java
+++ b/src/main/java/co/cask/wrangler/internal/TextSpecification.java
@@ -294,7 +294,7 @@ public class TextSpecification implements Specification {
 
         default:
           throw new SpecificationParseException(
-            String.format("Unknown command '%s' found in specification at line %d", command, lineno)
+            String.format("Unknown directive '%s' found in the specification at line %d", command, lineno)
           );
       }
       lineno++;

--- a/src/main/java/co/cask/wrangler/steps/Expression.java
+++ b/src/main/java/co/cask/wrangler/steps/Expression.java
@@ -133,9 +133,9 @@ public class Expression extends AbstractStep {
       // to check if there is a inner exception, if there is wrap it in 'StepException'
       // else just print the error message.
       if (e.getCause() != null) {
-        throw new StepException(toString() + " : " + e.getMessage(), e.getCause());
+        throw new StepException(toString() + " : " + e.getLocalizedMessage(), e.getCause());
       } else {
-        throw new StepException(toString() + " : " + e.getMessage());
+        throw new StepException(toString() + " : " + e.getLocalizedMessage());
       }
     }
     return modified;

--- a/src/main/java/co/cask/wrangler/steps/FormatDate.java
+++ b/src/main/java/co/cask/wrangler/steps/FormatDate.java
@@ -65,16 +65,28 @@ public class FormatDate extends AbstractStep {
     int idx = dt.find(column);
     if (idx != -1) {
       try {
-        Date date;
-        String datetimestamp = (String) row.getValue(idx);
-        if (datetimestamp.matches("[1-9][0-9]{9}")) {
-          date = new Date(Long.parseLong(datetimestamp) * 1000);
-        } else if (datetimestamp.matches("[1-9][0-9]{12}")) {
-          date = new Date(Long.parseLong(datetimestamp));
-        } else {
-          date = sourceFmt.parse((String) row.getValue(idx));
+        Date date = null;
+        Object value = row.getValue(idx);
+        if (value instanceof String) {
+          String datetimestamp = (String) row.getValue(idx);
+          if (datetimestamp.matches("[1-9][0-9]{9}")) {
+            date = new Date(Long.parseLong(datetimestamp) * 1000);
+          } else if (datetimestamp.matches("[1-9][0-9]{12}")) {
+            date = new Date(Long.parseLong(datetimestamp));
+          } else {
+            date = sourceFmt.parse((String) row.getValue(idx));
+          }
+        } else if (value instanceof Long) {
+          date = new Date((Long) value);
+        } else if (value instanceof Integer) {
+          date = new Date((Integer) value);
         }
-        dt.setValue(idx, destinationFmt.format(date));
+
+        // In-case the object doesn't match the condition above, then date object is
+        // null, in that case, we don't apply the date transformation.
+        if (date != null) {
+          dt.setValue(idx, destinationFmt.format(date));
+        }
       } catch (ParseException e) {
         throw new StepException(toString() + " : '" +
                                   column + ", " + e.getMessage(), e);

--- a/src/test/java/co/cask/wrangler/internal/TextSpecificationTest.java
+++ b/src/test/java/co/cask/wrangler/internal/TextSpecificationTest.java
@@ -87,5 +87,4 @@ public class TextSpecificationTest {
     }
     Assert.assertEquals(12, errorcount);
   }
-
 }

--- a/src/test/java/co/cask/wrangler/internal/TextSpecificationTest.java
+++ b/src/test/java/co/cask/wrangler/internal/TextSpecificationTest.java
@@ -28,7 +28,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.StringTokenizer;
 
 /**
  * Tests {@link TextSpecification} class.
@@ -53,19 +52,6 @@ public class TextSpecificationTest {
     Assert.assertEquals(Columns.class, steps.get(2).getClass());
     Assert.assertEquals(Rename.class, steps.get(3).getClass());
     Assert.assertEquals(Drop.class, steps.get(4).getClass());
-  }
-
-  @Test
-  public void testParsingOfDateFormat() throws Exception {
-    String str = "format-date datetime yyyy/MM/dd HH:mm:ss to MM/dd/YY";
-    StringTokenizer tokenizer = new StringTokenizer(str, " ");
-    String command = tokenizer.nextToken();
-    String col = tokenizer.nextToken();
-    String all = tokenizer.nextToken("\n");
-    StringTokenizer t = new StringTokenizer(all, " to ");
-    String srcFmt = t.nextToken();
-    String destFmt = t.nextToken();
-    Assert.assertEquals("format-date", command);
   }
 
   @Test

--- a/src/test/java/co/cask/wrangler/steps/PipelineTest.java
+++ b/src/test/java/co/cask/wrangler/steps/PipelineTest.java
@@ -238,8 +238,8 @@ public class PipelineTest {
     String[] directives = new String[] {
       "set format csv , false",
       "set columns id,first,last,dob,email,age,hrlywage,address,city,state,country,zip",
-      "filter-row-by-regex email .*@joltie.io",
-      "filter-row-by-condition id > 1092"
+      "filter-row-if-matched email .*@joltie.io",
+      "filter-row-if-true id > 1092"
     };
 
     Row[] rows = new Row[] {
@@ -347,5 +347,5 @@ public class PipelineTest {
     Assert.assertEquals(1, high);
     Assert.assertEquals(1, notfound);
   }
-
 }
+

--- a/widgets/Wrangler-transform.json
+++ b/widgets/Wrangler-transform.json
@@ -15,6 +15,14 @@
           "widget-type": "textarea",
           "label": "Wrangler Specification",
           "name": "specification"
+        },
+        {
+          "widget-type": "textbox",
+          "label" : "Max number of errored events before stopping pipeline",
+          "name": "threshold",
+          "widget-attributes": {
+            "default": "5"
+          }
         }
       ]
     }


### PR DESCRIPTION
### List of 
- [x] Date format can now accept fields of type 'string', 'int' and 'long'.
- [x] Proper handling TextSpecification parsing (see below for type of error messages)

### Error Message Formats during parsing. 
> Missing field '[csv|json]' at line number 1 for directive <set format> (usage: set format [csv|json] <delimiter> <skip empty lines>)
Missing field 'delimiter' at line number 1 for directive <set format> (usage: set format [csv|json] <delimiter> <skip empty lines>)
Missing field 'destination' at line number 1 for directive <rename> (usage: rename <source> <destination>)
Missing field 'column-name' at line number 1 for directive <drop> (usage: drop <column-name>)
Missing field 'col' at line number 1 for directive <uppercase> (usage: uppercase <col>)
Missing field 'col' at line number 1 for directive <titlecase> (usage: titlecase <col>)
Missing field 'source-column-name' at line number 1 for directive <indexsplit> (usage: indexsplit <source-column-name> <start> <end> <destination-column-name>)
Missing field 'start' at line number 1 for directive <indexsplit> (usage: indexsplit <source-column-name> <start> <end> <destination-column-name>)
Missing field 'end' at line number 1 for directive <indexsplit> (usage: indexsplit <source-column-name> <start> <end> <destination-column-name>)
Missing field 'destination-column-name' at line number 1 for directive <indexsplit> (usage: indexsplit <source-column-name> <start> <end> <destination-column-name>)
Missing field 'condition' at line number 1 for directive <filter-row-if-true> (usage: filter-row-if-true <condition>)
Missing field 'destination-format' at line number 1 for directive <format-unix-timestamp> (usage: format-unix-timestamp <column> <destination-format>)