### PR TITLE
Refactor Schema generation, for future code reuse.

### DIFF
--- a/service/src/main/test/TableLookupTest.java
+++ b/service/src/main/test/TableLookupTest.java
@@ -16,37 +16,22 @@
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.etl.mock.test.HydratorTestBase;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.ServiceManager;
-import co.cask.common.http.HttpRequest;
-import co.cask.common.http.HttpRequests;
-import co.cask.common.http.HttpResponse;
 import co.cask.wrangler.WranglerApp;
-import com.google.common.base.Joiner;
+import co.cask.wrangler.service.WranglerServiceTestBase;
 import com.google.common.collect.ImmutableList;
-import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Tests {@link co.cask.wrangler.steps.transformation.TableLookup}.
  */
-public class TableLookupTest extends HydratorTestBase {
-
-  private static final class ExecuteResponse {
-    List<String> headers;
-    String message;
-    int items;
-    List<Map<String, String>> value;
-    int status;
-  }
+public class TableLookupTest extends WranglerServiceTestBase {
 
   @Test
   public void test() throws Exception {
@@ -84,27 +69,5 @@ public class TableLookupTest extends HydratorTestBase {
     Assert.assertEquals("joe", executeResponse.value.get(1).get("fname"));
     Assert.assertEquals("34", executeResponse.value.get(1).get("fname_age"));
     Assert.assertEquals("Palo Alto, CA", executeResponse.value.get(1).get("fname_city"));
-  }
-
-  private void createAndUploadWorkspace(URL baseURL, String workspace, List<String> lines) throws Exception {
-    HttpResponse response = HttpRequests.execute(HttpRequest.put(new URL(baseURL, "workspaces/" + workspace)).build());
-    Assert.assertEquals(200, response.getResponseCode());
-    response = HttpRequests.execute(
-      HttpRequest.post(new URL(baseURL, "workspaces/" + workspace +"/upload"))
-        .withBody(Joiner.on(URLEncoder.encode("\n", "UTF-8")).join(lines))
-        .addHeader("recorddelimiter", URLEncoder.encode("\n", "UTF-8"))
-        .build());
-    Assert.assertEquals(200, response.getResponseCode());
-  }
-
-  private ExecuteResponse execute(URL baseURL, String workspace, String[] directives) throws Exception {
-    String directivesHeader = "";
-    for (String directive : directives) {
-      directivesHeader += "&directive=" + URLEncoder.encode(directive, "UTF-8");
-    }
-    URL url = new URL(baseURL, "workspaces/" + workspace + "/execute?limit=10" + directivesHeader);
-    HttpResponse response = HttpRequests.execute(HttpRequest.get(url).build());
-    Assert.assertEquals(200, response.getResponseCode());
-    return new Gson().fromJson(response.getResponseBodyAsString(), ExecuteResponse.class);
   }
 }

--- a/service/src/main/test/co/cask/wrangler/service/WranglerServiceTest.java
+++ b/service/src/main/test/co/cask/wrangler/service/WranglerServiceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.service;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.ServiceManager;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import co.cask.wrangler.WranglerApp;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.collections.KeyValue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link WranglerService}.
+ */
+public class WranglerServiceTest extends WranglerServiceTestBase {
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
+
+  @Test
+  public void test() throws Exception {
+    ApplicationManager wrangerApp = deployApplication(WranglerApp.class);
+    ServiceManager serviceManager = wrangerApp.getServiceManager("service").start();
+    // should throw exception, instead of returning null
+    URL baseURL = serviceManager.getServiceURL();
+
+
+    List<String> uploadContents = ImmutableList.of("bob,anderson", "joe,mchall");
+    createAndUploadWorkspace(baseURL, "test_ws", uploadContents);
+
+    List<String> directives =
+      ImmutableList.of("split-to-columns test_ws ,",
+                       "drop test_ws",
+                       "rename test_ws_1 fname",
+                       "rename test_ws_2 lname");
+
+    Schema schema = schema(baseURL, "test_ws", directives);
+
+    Schema expectedSchema =
+      Schema.recordOf("avroSchema",
+                      Schema.Field.of("fname", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                      Schema.Field.of("lname", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+
+    Assert.assertEquals(expectedSchema, schema);
+  }
+
+  public Schema schema(URL baseURL, String workspace, List<String> directives) throws Exception {
+    List<Map.Entry<String, String>> queryParams = new ArrayList<>();
+    for (String directive : directives) {
+      queryParams.add(new AbstractMap.SimpleEntry<>("directive", URLEncoder.encode(directive, "UTF-8")));
+    }
+
+    URL url = new URL(baseURL, "workspaces/" + workspace + "/schema" + createQueryParams(queryParams));
+    HttpResponse response = HttpRequests.execute(HttpRequest.get(url).build());
+    Assert.assertEquals(200, response.getResponseCode());
+
+    // we have to do this, simply because of how the service REST API returns only the Fields of the Schema
+    return GSON.fromJson("{ \"name\": \"avroSchema\", \"type\": \"record\", \"fields\":"
+                           + response.getResponseBodyAsString() + " }", Schema.class);
+  }
+}

--- a/service/src/main/test/co/cask/wrangler/service/WranglerServiceTestBase.java
+++ b/service/src/main/test/co/cask/wrangler/service/WranglerServiceTestBase.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.service;
+
+import co.cask.cdap.test.TestBase;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import com.google.common.base.Joiner;
+import com.google.gson.Gson;
+import org.junit.Assert;
+
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base class which exposes utility functions for interacting with {@link WranglerService}.
+ */
+public class WranglerServiceTestBase extends TestBase {
+
+  protected static final class ExecuteResponse {
+    public List<String> headers;
+    public String message;
+    public int items;
+    public List<Map<String, String>> value;
+    public int status;
+  }
+
+  protected void createAndUploadWorkspace(URL baseURL, String workspace, List<String> lines) throws Exception {
+    HttpResponse response = HttpRequests.execute(HttpRequest.put(new URL(baseURL, "workspaces/" + workspace)).build());
+    Assert.assertEquals(200, response.getResponseCode());
+    response = HttpRequests.execute(
+      HttpRequest.post(new URL(baseURL, "workspaces/" + workspace +"/upload"))
+        .withBody(Joiner.on(URLEncoder.encode("\n", "UTF-8")).join(lines))
+        .addHeader("recorddelimiter", URLEncoder.encode("\n", "UTF-8"))
+        .build());
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  protected ExecuteResponse execute(URL baseURL, String workspace, String[] directives) throws Exception {
+    List<Map.Entry<String, String>> queryParams = new ArrayList<>();
+    for (String directive : directives) {
+      queryParams.add(new AbstractMap.SimpleEntry<>("directive", URLEncoder.encode(directive, "UTF-8")));
+    }
+    queryParams.add(new AbstractMap.SimpleEntry<>("limit", "100"));
+
+    URL url = new URL(baseURL, "workspaces/" + workspace + "/execute" + createQueryParams(queryParams));
+    HttpResponse response = HttpRequests.execute(HttpRequest.get(url).build());
+    Assert.assertEquals(200, response.getResponseCode());
+    return new Gson().fromJson(response.getResponseBodyAsString(), ExecuteResponse.class);
+  }
+
+  // returns the query params string, including any leading '?'
+  protected String createQueryParams(List<Map.Entry<String, String>> queryParams) {
+    if (queryParams.isEmpty()) {
+      return "";
+    }
+    String params = "?" + queryParams.get(0).getKey() + "=" + queryParams.get(0).getValue();
+    for (int i = 1; i < queryParams.size(); i++) {
+      params += "&" + queryParams.get(i).getKey() + "=" + queryParams.get(i).getValue();
+    }
+    return params;
+  }
+}


### PR DESCRIPTION
Add unit tests for Wrangler's getSchema functionality.
Refactor the functionality to generate schema from a Record, to reuse this code from other places.