### PR TITLE
Change the output format of 'write-to-json-map' directive.

### DIFF
--- a/core/src/main/java/co/cask/wrangler/api/Record.java
+++ b/core/src/main/java/co/cask/wrangler/api/Record.java
@@ -18,6 +18,7 @@ package co.cask.wrangler.api;
 
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -248,6 +249,8 @@ public class Record implements Serializable {
     }
   }
 
+
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(getClass())
@@ -256,5 +259,26 @@ public class Record implements Serializable {
       .add("columns", columns)
       .add("values", values)
       .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Record that = (Record) o;
+
+    return Objects.equal(this.values, that.values) &&
+      Objects.equal(this.columns, that.columns) &&
+      Objects.equal(this.isError, that.isError);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(values, columns, isError);
   }
 }

--- a/core/src/main/java/co/cask/wrangler/steps/writer/WriteAsJsonMap.java
+++ b/core/src/main/java/co/cask/wrangler/steps/writer/WriteAsJsonMap.java
@@ -16,6 +16,7 @@
 
 package co.cask.wrangler.steps.writer;
 
+import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.wrangler.api.AbstractStep;
 import co.cask.wrangler.api.PipelineContext;
 import co.cask.wrangler.api.Record;
@@ -23,7 +24,9 @@ import co.cask.wrangler.api.StepException;
 import co.cask.wrangler.api.Usage;
 import com.google.gson.Gson;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A step to write the record fields as JSON.
@@ -53,7 +56,11 @@ public class WriteAsJsonMap extends AbstractStep {
   @Override
   public List<Record> execute(List<Record> records, PipelineContext context) throws StepException {
     for (Record record : records) {
-      record.addOrSet(column, gson.toJson(record.getFields()));
+      Map<String, Object> toJson = new HashMap<>();
+      for (KeyValue<String, Object> entry : record.getFields()) {
+        toJson.put(entry.getKey(), entry.getValue());
+      }
+      record.addOrSet(column, gson.toJson(toJson));
     }
     return records;
   }

--- a/core/src/test/java/co/cask/wrangler/steps/writer/WriteAsJsonMapTest.java
+++ b/core/src/test/java/co/cask/wrangler/steps/writer/WriteAsJsonMapTest.java
@@ -18,6 +18,7 @@ package co.cask.wrangler.steps.writer;
 
 import co.cask.wrangler.api.Record;
 import co.cask.wrangler.steps.PipelineTest;
+import com.google.gson.Gson;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,23 +31,33 @@ import java.util.List;
  */
 public class WriteAsJsonMapTest {
 
+  private static final Gson GSON = new Gson();
+
   @Test
   public void testWriteToJson() throws Exception {
     String[] directives = new String[] {
       "write-as-json-map test",
+      "keep test"
     };
 
     JSONObject o = new JSONObject();
     o.put("a", 1);
     o.put("b", "2");
+    String url = "http://www.yahoo.com?a=b c&b=ab&xyz=1";
     List<Record> records = Arrays.asList(
-      new Record("url", "http://www.yahoo.com?a=b c&b=ab&xyz=1")
+      new Record().add("int", 1).add("string", "this is string"),
+      new Record("url", url)
       .add("o", o)
-      .add("i1", new Integer(1))
-      .add("i2", new Double(1.8f))
+      .add("i1", 1)
+      .add("i2", (double) 1.8f)
     );
     records = PipelineTest.execute(directives, records);
 
-    Assert.assertTrue(records.size() == 1);
+    Assert.assertTrue(records.size() == 2);
+    Assert.assertEquals(new Record("test", "{\"string\":\"this is string\",\"int\":1}"),
+                        records.get(0));
+    Assert.assertEquals(new Record("test", "{\"i1\":1,\"i2\":1.7999999523162842,\"url\":"
+      + GSON.toJson(url) + ",\"o\":{\"map\":{\"a\":1,\"b\":\"2\"}}}"),
+                        records.get(1));
   }
 }

--- a/docs/directives/write-as-json-map.md
+++ b/docs/directives/write-as-json-map.md
@@ -36,7 +36,7 @@ would generate the following record
 
 ```
 {
-  "body" : "[{"key": "int", "value" : "1"}, {"key" : "string", "value" : "this is string"} ]"
+  "body" : "{"string":"this is string","int":1}"
   "int" : 1,
   "string" : "this is string",
 }


### PR DESCRIPTION
I don't see a reason for the previous formatting of the write-to-json-map directive.
This format is more intuitive and a better complement to the parse-as-json directive.