### PR TITLE
CDAP-11518 wrangler static catalog lookups should ignore case

### DIFF
--- a/core/src/main/java/co/cask/wrangler/executor/TextDirectives.java
+++ b/core/src/main/java/co/cask/wrangler/executor/TextDirectives.java
@@ -785,7 +785,7 @@ public class TextDirectives implements Directives {
             throw new IllegalArgumentException("Invalid ICD type - should be 9 (ICD-9) or 10 (ICD-10-2016 " +
                                                  "or ICD-10-2017).");
           } else {
-            ICDCatalog catalog = new ICDCatalog(type);
+            ICDCatalog catalog = new ICDCatalog(type.toLowerCase());
             if (!catalog.configure()) {
               throw new DirectiveParseException(
                 String.format("Failed to configure ICD StaticCatalog. Check with your administrator")

--- a/core/src/test/java/co/cask/wrangler/steps/transformation/CatalogLookupTest.java
+++ b/core/src/test/java/co/cask/wrangler/steps/transformation/CatalogLookupTest.java
@@ -33,7 +33,9 @@ public class CatalogLookupTest {
   public void testICDCodeLookup() throws Exception {
     String[] directives = new String[] {
       "catalog-lookup icd-10-2016 code",
+      "catalog-lookup ICD-10-2017 code",
     };
+
 
     List<Record> records = Arrays.asList(
       new Record("code", "A0100"),
@@ -47,8 +49,9 @@ public class CatalogLookupTest {
     records = PipelineTest.execute(directives, records);
     Assert.assertTrue(records.size() == 6);
     Assert.assertEquals("code_icd_10_2016_description", records.get(0).getColumn(1));
+    Assert.assertEquals("code_icd_10_2017_description", records.get(0).getColumn(2));
     for (int i = 0; i < 6; ++i) {
-      Assert.assertEquals(2, records.get(i).length());
+      Assert.assertEquals(3, records.get(i).length());
     }
   }
 


### PR DESCRIPTION
Fixed the issue that wrangler static catalog lookups should ignore case: https://issues.cask.co/browse/CDAP-11518