### PR TITLE
[CDAP-11711] Rename Postgres driver mapping to postgres65 to avoid na…

### DIFF
--- a/service/src/main/java/co/cask/wrangler/service/database/DatabaseService.java
+++ b/service/src/main/java/co/cask/wrangler/service/database/DatabaseService.java
@@ -318,13 +318,10 @@ public class DatabaseService extends AbstractHttpServiceHandler {
       JsonObject object = new JsonObject();
       object.addProperty("class", driver.getKey());
       object.addProperty("label", driver.getValue().getName());
-      object.addProperty("tag", driver.getValue().getTag());
+      String shortTag = driver.getValue().getTag();
+      object.addProperty("tag", shortTag);
+      object.addProperty("name", shortTag);
       object.addProperty("default.port", driver.getValue().getPort());
-      String name = driver.getValue().getName();
-      name = name.trim();
-      name = name.toLowerCase();
-      name = name.replaceAll("[^a-zA-Z0-9_]", "");
-      object.addProperty("name", name);
       values.add(object);
     }
     response.addProperty("status", HttpURLConnection.HTTP_OK);

--- a/service/src/main/resources/drivers.mapping
+++ b/service/src/main/resources/drivers.mapping
@@ -1,4 +1,4 @@
 Oracle Thin,oracle.jdbc.driver.OracleDriver,jdbc:oracle:thin:@${hostname}:${port}:${database},oracle,1521
 MySQL,com.mysql.jdbc.Driver,jdbc:mysql://${hostname}:${port}/${database},mysql,3306
-PostgreSQL (v6.5 and earlier),postgresql.Driver,jdbc:postgresql://${hostname}:${port}/${database},postgresql,5432
+PostgreSQL (v6.5 and earlier),postgresql.Driver,jdbc:postgresql://${hostname}:${port}/${database},postgresql65,5432
 PostgreSQL (v7.0 and later),org.postgresql.Driver,jdbc:postgresql://${hostname}:${port}/${database},postgresql,5432


### PR DESCRIPTION
Fixes https://issues.cask.co/browse/CDAP-11771

Makes drivers mapping more consistent, so that PostgreSQL v6.5 and earlier and PostgreSQL v7.0 and later map to shorter names.