### PR TITLE
[CPAP-11786] Ensures that null values are filtered correct

### DIFF
--- a/core/src/main/java/co/cask/wrangler/steps/row/RecordRegexFilter.java
+++ b/core/src/main/java/co/cask/wrangler/steps/row/RecordRegexFilter.java
@@ -72,7 +72,8 @@ public class RecordRegexFilter extends AbstractStep {
       if (idx != -1) {
         Object object = record.getValue(idx);
         if (object == null) {
-          continue;
+          if(!match)
+            continue;
         } else if (object instanceof JSONObject) {
           if (pattern == null && JSONObject.NULL.equals(object)) {
             continue;
@@ -92,8 +93,6 @@ public class RecordRegexFilter extends AbstractStep {
                           toString(), object != null ? object.getClass().getName() : "null", column)
           );
         }
-        results.add(record);
-      } else {
         results.add(record);
       }
     }

--- a/core/src/test/java/co/cask/wrangler/steps/row/RecordRegexFilterTest.java
+++ b/core/src/test/java/co/cask/wrangler/steps/row/RecordRegexFilterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.steps.row;
+
+import co.cask.wrangler.api.Record;
+import co.cask.wrangler.steps.PipelineTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Created by archilshah on 6/2/17.
+ */
+public class RecordRegexFilterTest {
+
+    @Test
+    public void testFilterKeepDoesntKeepNullValues() throws Exception {
+        String[] directives = new String[] {
+                "parse-as-csv body , false",
+                "filter-rows-on regex-not-match body_3 .*pot.*"
+        };
+
+        List<Record> records = Arrays.asList(
+                new Record("body", "1, \"Archil\", , \"SHAH\", 19, \"2017-06-02\""),
+                new Record("body", "2, \"Sameet\", \"andpotatoes\", \"Sapra\", 19, \"2017-06-02\""),
+                new Record("body", "3, \"Bob\", , \"Sagett\", 101, \"1970-01-01\"")
+        );
+
+        records = PipelineTest.execute(directives, records);
+
+        Assert.assertTrue(records.size() == 1);
+    }
+
+
+    @Test
+    public void testFilterRemoveDoesntDropNullValues() throws Exception {
+        String[] directives = new String[] {
+                "parse-as-csv body , false",
+                "filter-rows-on regex-match body_3 .*pot.*"
+        };
+
+        List<Record> records = Arrays.asList(
+            new Record("body", "1, \"Archil\", , \"SHAH\", 19, \"2017-06-02\""),
+            new Record("body", "2, \"Sameet\", \"andpotatoes\", \"Sapra\", 19, \"2017-06-02\""),
+            new Record("body", "3, \"Bob\", , \"Sagett\", 101, \"1970-01-01\"")
+         );
+
+        records = PipelineTest.execute(directives, records);
+
+        Assert.assertTrue(records.size() == 2);
+    }
+}

--- a/core/src/test/java/co/cask/wrangler/steps/row/RecordRegexFilterTest.java
+++ b/core/src/test/java/co/cask/wrangler/steps/row/RecordRegexFilterTest.java
@@ -25,44 +25,41 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Created by archilshah on 6/2/17.
+ * Tests {@link RecordRegexFilter}
  */
 public class RecordRegexFilterTest {
+  @Test
+  public void testFilterKeepDoesntKeepNullValues() throws Exception {
+    String[] directives = new String[] {
+      "parse-as-csv body , false",
+      "filter-rows-on regex-not-match body_3 .*pot.*"
+    };
 
-    @Test
-    public void testFilterKeepDoesntKeepNullValues() throws Exception {
-        String[] directives = new String[] {
-                "parse-as-csv body , false",
-                "filter-rows-on regex-not-match body_3 .*pot.*"
-        };
+    List<Record> records = Arrays.asList(
+      new Record("body", "1, \"Archil\", , \"SHAH\", 19, \"2017-06-02\""),
+      new Record("body", "2, \"Sameet\", \"andpotatoes\", \"Sapra\", 19, \"2017-06-02\""),
+      new Record("body", "3, \"Bob\", , \"Sagett\", 101, \"1970-01-01\"")
+    );
 
-        List<Record> records = Arrays.asList(
-                new Record("body", "1, \"Archil\", , \"SHAH\", 19, \"2017-06-02\""),
-                new Record("body", "2, \"Sameet\", \"andpotatoes\", \"Sapra\", 19, \"2017-06-02\""),
-                new Record("body", "3, \"Bob\", , \"Sagett\", 101, \"1970-01-01\"")
-        );
-
-        records = PipelineTest.execute(directives, records);
-
-        Assert.assertTrue(records.size() == 1);
-    }
+    records = PipelineTest.execute(directives, records);
+    Assert.assertTrue(records.size() == 1);
+  }
 
 
-    @Test
-    public void testFilterRemoveDoesntDropNullValues() throws Exception {
-        String[] directives = new String[] {
-                "parse-as-csv body , false",
-                "filter-rows-on regex-match body_3 .*pot.*"
-        };
+  @Test
+  public void testFilterRemoveDoesntDropNullValues() throws Exception {
+    String[] directives = new String[] {
+      "parse-as-csv body , false",
+      "filter-rows-on regex-match body_3 .*pot.*"
+    };
 
-        List<Record> records = Arrays.asList(
-            new Record("body", "1, \"Archil\", , \"SHAH\", 19, \"2017-06-02\""),
-            new Record("body", "2, \"Sameet\", \"andpotatoes\", \"Sapra\", 19, \"2017-06-02\""),
-            new Record("body", "3, \"Bob\", , \"Sagett\", 101, \"1970-01-01\"")
-         );
+    List<Record> records = Arrays.asList(
+      new Record("body", "1, \"Archil\", , \"SHAH\", 19, \"2017-06-02\""),
+      new Record("body", "2, \"Sameet\", \"andpotatoes\", \"Sapra\", 19, \"2017-06-02\""),
+      new Record("body", "3, \"Bob\", , \"Sagett\", 101, \"1970-01-01\"")
+    );
 
-        records = PipelineTest.execute(directives, records);
-
-        Assert.assertTrue(records.size() == 2);
-    }
+    records = PipelineTest.execute(directives, records);
+    Assert.assertTrue(records.size() == 2);
+  }
 }


### PR DESCRIPTION
I believe this is the correct fix to CDAP-11786. `idx` represents the column number that is being affected by the filtering and the -1 check is checking if the column name is in the table. `object` represents the actual value in the column for the particular entry and this is where we have to ensure whether or not null values are being properly handled. I have also included a test. 

@nitinmotgi does this seem right to you?