### PR TITLE
[CDAP-11730] Parse JSON as DataType.Text to fix JSParser

### DIFF
--- a/core/src/main/java/co/cask/wrangler/steps/parser/JsParser.java
+++ b/core/src/main/java/co/cask/wrangler/steps/parser/JsParser.java
@@ -90,7 +90,7 @@ public class JsParser extends AbstractStep {
           JsonElement element = null;
           if(value instanceof String) {
             String document = (String) value;
-            element = parser.parse(document);
+            element = parser.parse(document.trim());
           } else if (value instanceof JsonObject || value instanceof JsonArray) {
             element = (JsonElement) value;
           } else {

--- a/core/src/test/java/co/cask/wrangler/steps/parser/JsParserTest.java
+++ b/core/src/test/java/co/cask/wrangler/steps/parser/JsParserTest.java
@@ -142,4 +142,18 @@ public class JsParserTest {
     records = PipelineTest.execute(directives, records);
     Assert.assertTrue(records.size() == 1);
   }
+
+  @Test
+  public void testParsingExtraCharacters() throws Exception {
+    String[] directives = new String[] {
+      "parse-as-json body"
+    };
+
+    List<Record> records = Arrays.asList(
+      new Record("body", "[1,2,3,4,5]             ")
+    );
+
+    records = PipelineTest.execute(directives, records);
+    Assert.assertTrue(records.size() == 5);
+  }
 }

--- a/service/src/main/java/co/cask/wrangler/service/explorer/FilesystemExplorer.java
+++ b/service/src/main/java/co/cask/wrangler/service/explorer/FilesystemExplorer.java
@@ -117,10 +117,12 @@ public class FilesystemExplorer extends AbstractHttpServiceHandler {
                    @QueryParam("path") String path, @QueryParam("lines") int lines,
                    @QueryParam("sampler") String sampler, @QueryParam("fraction") double fraction) {
     RequestExtractor extractor = new RequestExtractor(request);
-    if (extractor.isContentType("text/plain") || extractor.isContentType("application/json")) {
+    if (extractor.isContentType("text/plain")) {
       loadSamplableFile(responder, path, lines, fraction, sampler);
     } else if (extractor.isContentType("application/xml")) {
       loadFile(responder, path, DataType.RECORDS);
+    } else if (extractor.isContentType("application/json")) {
+      loadFile(responder, path, DataType.TEXT);
     } else if (extractor.isContentType("application/avro")
       || extractor.isContentType("application/protobuf")
       || extractor.isContentType("application/excel")) {
@@ -208,8 +210,8 @@ public class FilesystemExplorer extends AbstractHttpServiceHandler {
         ObjectSerDe<List<Record>> serDe = new ObjectSerDe<>();
         byte[] data = serDe.toByteArray(records);
         table.writeToWorkspace(id, WorkspaceDataset.DATA_COL, DataType.RECORDS, data);
-      } else if (type == DataType.BINARY) {
-        table.writeToWorkspace(id, WorkspaceDataset.DATA_COL, DataType.BINARY, bytes);
+      } else if (type == DataType.BINARY || type == DataType.TEXT) {
+        table.writeToWorkspace(id, WorkspaceDataset.DATA_COL, type, bytes);
       }
 
       // Preparing return response to include mandatory fields : id and name.


### PR DESCRIPTION
Parses JSON files as a `DataType.TEXT` through the filebrowser so that the `parse-as-json` directive works as expected.