### PR TITLE
Feature/cdap-11435

### DIFF
--- a/transform/src/main/java/co/cask/wrangler/Wrangler.java
+++ b/transform/src/main/java/co/cask/wrangler/Wrangler.java
@@ -259,7 +259,8 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
       getContext().getMetrics().count("failures", 1);
       errorCounter++;
       // If error threshold is reached, then terminate processing.
-      if (errorCounter > config.threshold) {
+      // If threshold is set to -1, it tolerant unlimited errors.
+      if (config.threshold != -1 && errorCounter > config.threshold) {
         LOG.error("Error threshold reached '{}' : {}", config.threshold, e.getMessage());
         throw new Exception(String.format("Reached error threshold %d, terminating processing.", config.threshold));
       }
@@ -312,7 +313,8 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
 
     @Name("threshold")
     @Description("Max number of event failures in wrangling after which to stop the pipeline of processing." +
-      "Threshold is not aggregate across all instance, but is applied for each running instances")
+      "Threshold is not aggregate across all instance, but is applied for each running instances" +
+      "Set to -1 to specify unlimited number of acceptable errors")
     @Macro
     private final int threshold;
 

--- a/transform/src/main/java/co/cask/wrangler/Wrangler.java
+++ b/transform/src/main/java/co/cask/wrangler/Wrangler.java
@@ -258,8 +258,8 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
     } catch (Exception e) {
       getContext().getMetrics().count("failures", 1);
       errorCounter++;
-      // If error threshold is reached, then terminate processing.
-      // If threshold is set to -1, it tolerant unlimited errors.
+      // If error threshold is reached, then terminate processing
+      // If threshold is set to -1, it tolerant unlimited errors
       if (config.threshold != -1 && errorCounter > config.threshold) {
         LOG.error("Error threshold reached '{}' : {}", config.threshold, e.getMessage());
         throw new Exception(String.format("Reached error threshold %d, terminating processing.", config.threshold));

--- a/transform/src/main/java/co/cask/wrangler/Wrangler.java
+++ b/transform/src/main/java/co/cask/wrangler/Wrangler.java
@@ -258,8 +258,8 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
     } catch (Exception e) {
       getContext().getMetrics().count("failures", 1);
       errorCounter++;
-      // If error threshold is reached, then terminate processing.
-      // If threshold is set to -1, it tolerant unlimited errors.
+      // If error threshold is reached, then terminate processing
+      // If threshold is set to -1, it tolerant unlimited errors
       if (config.threshold != -1 && errorCounter > config.threshold) {
         LOG.error("Error threshold reached '{}' : {}", config.threshold, e.getMessage());
         throw new Exception(String.format("Reached error threshold %d, terminating processing.", config.threshold));
@@ -312,9 +312,9 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
     private final String field;
 
     @Name("threshold")
-    @Description("Max number of event failures in wrangling after which to stop the pipeline of processing." +
-      "Threshold is not aggregate across all instance, but is applied for each running instances" +
-      "Set to -1 to specify unlimited number of acceptable errors")
+    @Description("Max number of event failures in wrangling after which to stop the pipeline of processing. " +
+      "Threshold is not aggregate across all instance, but is applied for each running instances. " +
+      "Set to -1 to specify unlimited number of acceptable errors. ")
     @Macro
     private final int threshold;
 

--- a/transform/src/main/java/co/cask/wrangler/Wrangler.java
+++ b/transform/src/main/java/co/cask/wrangler/Wrangler.java
@@ -314,7 +314,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
     @Name("threshold")
     @Description("Max number of event failures in wrangling after which to stop the pipeline of processing. " +
       "Threshold is not aggregate across all instance, but is applied for each running instances. " +
-      "Set to -1 to specify unlimited number of acceptable errors. ")
+      "Set to -1 to specify unlimited number of acceptable errors.")
     @Macro
     private final int threshold;
 


### PR DESCRIPTION
Allow a user to specify an unlimited number of acceptable errors, by setting error threshold to -1.