### PR TITLE
Feature/cdap-11868

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ These directives are currently available:
 | [Set Column Names](docs/directives/set-columns.md)                     | Sets the names of columns, in the order they are specified       |
 | [Split to Columns](docs/directives/split-to-columns.md)                | Splits a column based on a separator into multiple columns       |
 | [Swap Columns](docs/directives/swap.md)                                | Swaps column names of two columns                                |
-| [Set Column Data Type](docs/directives/set-type.md)                    | Convert data type of a column (int, double, string, boolean)                                |
+| [Set Column Data Type](docs/directives/set-type.md)                    | Convert data type of a column                                    |
 | **NLP**                                                                |                                                                  |
 | [Stemming Tokenized Words](docs/directives/stemming.md)                | Applies the Porter stemmer algorithm for English words           |
 | **Transient Aggregators & Setters**                                    |                                                                  |

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ These directives are currently available:
 | [Set Column Names](docs/directives/set-columns.md)                     | Sets the names of columns, in the order they are specified       |
 | [Split to Columns](docs/directives/split-to-columns.md)                | Splits a column based on a separator into multiple columns       |
 | [Swap Columns](docs/directives/swap.md)                                | Swaps column names of two columns                                |
+| [Set Column Data Type](docs/directives/set-type.md)                    | Convert data type of a column (int, double, string, boolean)                                |
 | **NLP**                                                                |                                                                  |
 | [Stemming Tokenized Words](docs/directives/stemming.md)                | Applies the Porter stemmer algorithm for English words           |
 | **Transient Aggregators & Setters**                                    |                                                                  |

--- a/core/src/main/java/co/cask/wrangler/executor/TextDirectives.java
+++ b/core/src/main/java/co/cask/wrangler/executor/TextDirectives.java
@@ -30,6 +30,7 @@ import co.cask.wrangler.steps.column.Drop;
 import co.cask.wrangler.steps.column.Keep;
 import co.cask.wrangler.steps.column.Merge;
 import co.cask.wrangler.steps.column.Rename;
+import co.cask.wrangler.steps.column.SetType;
 import co.cask.wrangler.steps.column.SplitToColumns;
 import co.cask.wrangler.steps.column.Swap;
 import co.cask.wrangler.steps.date.DiffDate;
@@ -211,6 +212,14 @@ public class TextDirectives implements Directives {
           String oldcol = getNextToken(tokenizer,  command, "old", lineno);
           String newcol = getNextToken(tokenizer, command, "new", lineno);
           steps.add(new Rename(lineno, directive, oldcol, newcol));
+        }
+        break;
+
+        //set-type <column> <type>
+        case "set-type": {
+          String col = getNextToken(tokenizer,  command, "col", lineno);
+          String type = getNextToken(tokenizer, command, "type", lineno);
+          steps.add(new SetType(lineno, directive, col, type));
         }
         break;
 

--- a/core/src/main/java/co/cask/wrangler/executor/UsageRegistry.java
+++ b/core/src/main/java/co/cask/wrangler/executor/UsageRegistry.java
@@ -29,6 +29,7 @@ import co.cask.wrangler.steps.column.Drop;
 import co.cask.wrangler.steps.column.Keep;
 import co.cask.wrangler.steps.column.Merge;
 import co.cask.wrangler.steps.column.Rename;
+import co.cask.wrangler.steps.column.SetType;
 import co.cask.wrangler.steps.column.SplitToColumns;
 import co.cask.wrangler.steps.column.Swap;
 import co.cask.wrangler.steps.date.DiffDate;
@@ -188,6 +189,7 @@ public final class UsageRegistry implements Serializable {
     SetCharset.class,
     SetColumn.class,
     SetRecordDelimiter.class,
+    SetType.class,
     Split.class,
     SplitEmail.class,
     SplitToColumns.class,

--- a/core/src/main/java/co/cask/wrangler/steps/column/SetType.java
+++ b/core/src/main/java/co/cask/wrangler/steps/column/SetType.java
@@ -27,15 +27,14 @@ import java.util.List;
 
 /**
  * A Wrangler step for converting data type of a column
- * Accepted types are: int, double, string and boolean
+ * Accepted types are: int, short, long, double, float, string, boolean and bytes
  */
 @Usage(
   directive = "set-type",
-  usage = "set-type <column> <int|double|string|boolean>",
+  usage = "set-type <column> <type>",
   description = "Converting data type of a column"
 )
 public class SetType extends AbstractStep {
-  // Columns of the column to be upper-cased
   private String col;
   private String type;
 
@@ -67,7 +66,7 @@ public class SetType extends AbstractStep {
   }
 
   private Object convertType(String toType, Object object) throws Exception {
-    toType = toType.toLowerCase();
+    toType = toType.toUpperCase();
     switch (toType) {
       case "INTEGER":
       case "I64":
@@ -80,17 +79,16 @@ public class SetType extends AbstractStep {
           return ((Float) object).intValue();
         } else if (object instanceof Double) {
           return ((Double) object).intValue();
-        } else if (object instanceof Number) {
-          return ((Double) object).intValue();
         } else if (object instanceof Integer) {
           return object;
         } else if (object instanceof Long) {
           return ((Long) object).intValue();
         } else if (object instanceof byte[]) {
           return Bytes.toInt((byte[]) object);
+        } else {
+          return object;
         }
       }
-      break;
 
       case "I32":
       case "SHORT": {
@@ -102,17 +100,16 @@ public class SetType extends AbstractStep {
           return ((Float) object).shortValue();
         } else if (object instanceof Double) {
           return ((Double) object).shortValue();
-        } else if (object instanceof Number) {
-          return ((Double) object).shortValue();
         } else if (object instanceof Integer) {
           return ((Integer) object).shortValue();
         } else if (object instanceof Long) {
           return ((Long) object).shortValue();
         } else if (object instanceof byte[]) {
           return Bytes.toShort((byte[]) object);
+        } else {
+          return object;
         }
       }
-      break;
 
       case "LONG": {
         if(object instanceof String) {
@@ -123,17 +120,16 @@ public class SetType extends AbstractStep {
           return ((Float) object).longValue();
         } else if (object instanceof Double) {
           return ((Double) object).longValue();
-        } else if (object instanceof Number) {
-          return ((Double) object).longValue();
         } else if (object instanceof Integer) {
           return ((Integer) object).longValue();
         } else if (object instanceof Long) {
           return object;
         } else if (object instanceof byte[]) {
           return Bytes.toLong((byte[]) object);
+        } else {
+          return object;
         }
       }
-      break;
 
       case "BOOL":
       case "BOOLEAN": {
@@ -145,17 +141,16 @@ public class SetType extends AbstractStep {
           return ((Float) object) > 0 ? true : false;
         } else if (object instanceof Double) {
           return ((Double) object)  > 0 ? true : false;
-        } else if (object instanceof Number) {
-          return ((Double) object)  > 0 ? true : false;
         } else if (object instanceof Integer) {
           return ((Integer) object)  > 0 ? true : false;
         } else if (object instanceof Long) {
           return ((Long) object)  > 0 ? true : false;
         } else if (object instanceof byte[]) {
           return Bytes.toBoolean((byte[]) object);
+        } else {
+          return object;
         }
       }
-      break;
 
       case "STRING": {
         if(object instanceof String) {
@@ -172,9 +167,12 @@ public class SetType extends AbstractStep {
           return Long.toString((Long) object);
         } else if (object instanceof byte[]) {
           return Bytes.toString((byte[]) object);
+        } else if (object instanceof Boolean){
+          return Boolean.toString((Boolean) object);
+        } else {
+          return object;
         }
       }
-      break;
 
       case "FLOAT": {
         if(object instanceof String) {
@@ -185,17 +183,16 @@ public class SetType extends AbstractStep {
           return object;
         } else if (object instanceof Double) {
           return ((Double) object).floatValue();
-        } else if (object instanceof Number) {
-          return ((Double) object).floatValue();
         } else if (object instanceof Integer) {
           return ((Integer) object).floatValue();
         } else if (object instanceof Long) {
-          return ((Long) object).longValue();
+          return ((Long) object).floatValue();
         } else if (object instanceof byte[]) {
           return Bytes.toFloat((byte[]) object);
+        } else {
+          return object;
         }
       }
-      break;
 
       case "DOUBLE": {
         if(object instanceof String) {
@@ -206,17 +203,16 @@ public class SetType extends AbstractStep {
           return ((Float) object).doubleValue();
         } else if (object instanceof Double) {
           return object;
-        } else if (object instanceof Number) {
-          return ((Double) object).doubleValue();
         } else if (object instanceof Integer) {
           return ((Integer) object).doubleValue();
         } else if (object instanceof Long) {
           return ((Long) object).doubleValue();
         } else if (object instanceof byte[]) {
           return Bytes.toDouble((byte[]) object);
+        } else {
+          return object;
         }
       }
-      break;
 
       case "BYTES": {
         if(object instanceof String) {
@@ -227,19 +223,22 @@ public class SetType extends AbstractStep {
           return Bytes.toBytes((Float) object);
         } else if (object instanceof Double) {
           return Bytes.toBytes((Double) object);
-        } else if (object instanceof Number) {
-          return Bytes.toBytes((Double) object);
         } else if (object instanceof Integer) {
           return Bytes.toBytes((Integer) object);
         } else if (object instanceof Long) {
           return Bytes.toBytes((Long) object);
         } else if (object instanceof byte[]) {
           return object;
+        } else {
+          return object;
         }
       }
-      break;
 
+      default:
+        throw new StepException(
+          String.format("Unknown data type '%s' found in the directive. " +
+                  "Accepted types are: int, short, long, double, boolean, string, bytes", toType)
+        );
     }
-
   }
 }

--- a/core/src/main/java/co/cask/wrangler/steps/column/SetType.java
+++ b/core/src/main/java/co/cask/wrangler/steps/column/SetType.java
@@ -16,6 +16,7 @@
 
 package co.cask.wrangler.steps.column;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.wrangler.api.AbstractStep;
 import co.cask.wrangler.api.PipelineContext;
 import co.cask.wrangler.api.Record;
@@ -29,9 +30,9 @@ import java.util.List;
  * Accepted types are: int, double, string and boolean
  */
 @Usage(
-        directive = "set-type",
-        usage = "set-type <column> <int|double|string|boolean>",
-        description = "Converting data type of a column"
+  directive = "set-type",
+  usage = "set-type <column> <int|double|string|boolean>",
+  description = "Converting data type of a column"
 )
 public class SetType extends AbstractStep {
   // Columns of the column to be upper-cased
@@ -50,106 +51,195 @@ public class SetType extends AbstractStep {
       int idx = record.find(col);
       if (idx != -1) {
         Object object = record.getValue(idx);
-
-        //convert to int
-        if (type.equals("int")) {
-          if (object instanceof String) {
-            if (object != null) {
-              String value = (String) object;
-              record.setValue(idx, Integer.valueOf(value));
-            }
-          }
-          else if (object instanceof Double) {
-            if (object != null) {
-              Double value = (Double) object;
-              record.setValue(idx, value.intValue());
-            }
-          }
-          else if (object instanceof Boolean) {
-            if (object != null) {
-              Boolean value = (Boolean) object;
-              if (value.equals(true)) {
-                record.setValue(idx, 1);
-              }
-              else {
-                record.setValue(idx, 0);
-              }
-            }
-          }
+        if (object == null) {
+          continue;
         }
-
-        //convert to string
-        if (type.equals("string")) {
-          if (object != null) {
-            record.setValue(idx, object.toString());
-          }
-        }
-
-        //convert to double
-        if (type.equals("double")) {
-          if (object instanceof Integer) {
-            if (object != null) {
-              Integer value = (Integer) object;
-              record.setValue(idx, value.doubleValue());
-            }
-          }
-          if (object instanceof String) {
-            if (object != null) {
-              String value = (String) object;
-              record.setValue(idx, Double.valueOf(value));
-            }
-          }
-          if (object instanceof Boolean) {
-            if (object != null) {
-              Boolean value = (Boolean) object;
-              if (value.equals(true)) {
-                record.setValue(idx, 1.0);
-              }
-              else {
-                record.setValue(idx, 0.0);
-              }
-            }
-          }
-        }
-
-        //convert to boolean
-        if (type.equals("boolean")) {
-          if (object instanceof Integer) {
-            if (object != null) {
-              Integer value = (Integer) object;
-              if (value.equals(0)) {
-                record.setValue(idx, false);
-              }
-              else {
-                record.setValue(idx, true);
-              }
-            }
-          }
-          if (object instanceof Double) {
-            if (object != null) {
-              Double value = (Double) object;
-              if (value.equals(0.0)) {
-                record.setValue(idx, false);
-              }
-              else {
-                record.setValue(idx, true);
-              }
-            }
-          }
-          if (object instanceof String) {
-            if (object != null) {
-              String value = (String) object;
-              if (value.equals("true")) {
-                record.setValue(idx, true);
-              }
-              else if (value.equals("false")) {
-                record.setValue(idx, false);
-              }
-            }
-          }
+        try {
+          record.setValue(idx, convertType(type, object));
+        } catch (Exception e) {
+          throw new StepException(
+            String.format(toString() + ":" + e.getMessage())
+          );
         }
       }
     }
     return records;
+  }
+
+  private Object convertType(String toType, Object object) throws Exception {
+    toType = toType.toLowerCase();
+    switch (toType) {
+      case "INTEGER":
+      case "I64":
+      case "INT": {
+        if(object instanceof String) {
+          return Integer.parseInt((String) object);
+        } else if (object instanceof Short) {
+          return ((Short) object).intValue();
+        } else if (object instanceof Float) {
+          return ((Float) object).intValue();
+        } else if (object instanceof Double) {
+          return ((Double) object).intValue();
+        } else if (object instanceof Number) {
+          return ((Double) object).intValue();
+        } else if (object instanceof Integer) {
+          return object;
+        } else if (object instanceof Long) {
+          return ((Long) object).intValue();
+        } else if (object instanceof byte[]) {
+          return Bytes.toInt((byte[]) object);
+        }
+      }
+      break;
+
+      case "I32":
+      case "SHORT": {
+        if(object instanceof String) {
+          return Short.parseShort((String) object);
+        } else if (object instanceof Short) {
+          return object;
+        } else if (object instanceof Float) {
+          return ((Float) object).shortValue();
+        } else if (object instanceof Double) {
+          return ((Double) object).shortValue();
+        } else if (object instanceof Number) {
+          return ((Double) object).shortValue();
+        } else if (object instanceof Integer) {
+          return ((Integer) object).shortValue();
+        } else if (object instanceof Long) {
+          return ((Long) object).shortValue();
+        } else if (object instanceof byte[]) {
+          return Bytes.toShort((byte[]) object);
+        }
+      }
+      break;
+
+      case "LONG": {
+        if(object instanceof String) {
+          return Long.parseLong((String) object);
+        } else if (object instanceof Short) {
+          return ((Short) object).longValue();
+        } else if (object instanceof Float) {
+          return ((Float) object).longValue();
+        } else if (object instanceof Double) {
+          return ((Double) object).longValue();
+        } else if (object instanceof Number) {
+          return ((Double) object).longValue();
+        } else if (object instanceof Integer) {
+          return ((Integer) object).longValue();
+        } else if (object instanceof Long) {
+          return object;
+        } else if (object instanceof byte[]) {
+          return Bytes.toLong((byte[]) object);
+        }
+      }
+      break;
+
+      case "BOOL":
+      case "BOOLEAN": {
+        if(object instanceof String) {
+          return Boolean.parseBoolean((String) object);
+        } else if (object instanceof Short) {
+          return ((Short) object) > 0 ? true : false;
+        } else if (object instanceof Float) {
+          return ((Float) object) > 0 ? true : false;
+        } else if (object instanceof Double) {
+          return ((Double) object)  > 0 ? true : false;
+        } else if (object instanceof Number) {
+          return ((Double) object)  > 0 ? true : false;
+        } else if (object instanceof Integer) {
+          return ((Integer) object)  > 0 ? true : false;
+        } else if (object instanceof Long) {
+          return ((Long) object)  > 0 ? true : false;
+        } else if (object instanceof byte[]) {
+          return Bytes.toBoolean((byte[]) object);
+        }
+      }
+      break;
+
+      case "STRING": {
+        if(object instanceof String) {
+          return object;
+        } else if (object instanceof Short) {
+          return Short.toString((Short) object);
+        } else if (object instanceof Float) {
+          return Float.toString((Float) object);
+        } else if (object instanceof Double) {
+          return Double.toString((Double) object);
+        } else if (object instanceof Integer) {
+          return Integer.toString((Integer) object);
+        } else if (object instanceof Long) {
+          return Long.toString((Long) object);
+        } else if (object instanceof byte[]) {
+          return Bytes.toString((byte[]) object);
+        }
+      }
+      break;
+
+      case "FLOAT": {
+        if(object instanceof String) {
+          return Float.parseFloat((String) object);
+        } else if (object instanceof Short) {
+          return ((Short) object).floatValue();
+        } else if (object instanceof Float) {
+          return object;
+        } else if (object instanceof Double) {
+          return ((Double) object).floatValue();
+        } else if (object instanceof Number) {
+          return ((Double) object).floatValue();
+        } else if (object instanceof Integer) {
+          return ((Integer) object).floatValue();
+        } else if (object instanceof Long) {
+          return ((Long) object).longValue();
+        } else if (object instanceof byte[]) {
+          return Bytes.toFloat((byte[]) object);
+        }
+      }
+      break;
+
+      case "DOUBLE": {
+        if(object instanceof String) {
+          return Double.parseDouble((String) object);
+        } else if (object instanceof Short) {
+          return ((Short) object).doubleValue();
+        } else if (object instanceof Float) {
+          return ((Float) object).doubleValue();
+        } else if (object instanceof Double) {
+          return object;
+        } else if (object instanceof Number) {
+          return ((Double) object).doubleValue();
+        } else if (object instanceof Integer) {
+          return ((Integer) object).doubleValue();
+        } else if (object instanceof Long) {
+          return ((Long) object).doubleValue();
+        } else if (object instanceof byte[]) {
+          return Bytes.toDouble((byte[]) object);
+        }
+      }
+      break;
+
+      case "BYTES": {
+        if(object instanceof String) {
+          return Bytes.toBytes((String) object);
+        } else if (object instanceof Short) {
+          return Bytes.toBytes((Short) object);
+        } else if (object instanceof Float) {
+          return Bytes.toBytes((Float) object);
+        } else if (object instanceof Double) {
+          return Bytes.toBytes((Double) object);
+        } else if (object instanceof Number) {
+          return Bytes.toBytes((Double) object);
+        } else if (object instanceof Integer) {
+          return Bytes.toBytes((Integer) object);
+        } else if (object instanceof Long) {
+          return Bytes.toBytes((Long) object);
+        } else if (object instanceof byte[]) {
+          return object;
+        }
+      }
+      break;
+
+    }
+
   }
 }

--- a/core/src/main/java/co/cask/wrangler/steps/column/SetType.java
+++ b/core/src/main/java/co/cask/wrangler/steps/column/SetType.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.steps.column;
+
+import co.cask.wrangler.api.AbstractStep;
+import co.cask.wrangler.api.PipelineContext;
+import co.cask.wrangler.api.Record;
+import co.cask.wrangler.api.StepException;
+import co.cask.wrangler.api.Usage;
+
+import java.util.List;
+
+/**
+ * A Wrangler step for converting data type of a column
+ * Accepted types are: int, double, string and boolean
+ */
+@Usage(
+        directive = "set-type",
+        usage = "set-type <column> <int|double|string|boolean>",
+        description = "Converting data type of a column"
+)
+public class SetType extends AbstractStep {
+  // Columns of the column to be upper-cased
+  private String col;
+  private String type;
+
+  public SetType(int lineno, String detail, String col, String type) {
+    super(lineno, detail);
+    this.col = col;
+    this.type = type;
+  }
+
+  @Override
+  public List<Record> execute(List<Record> records, PipelineContext context) throws StepException {
+    for (Record record : records) {
+      int idx = record.find(col);
+      if (idx != -1) {
+        Object object = record.getValue(idx);
+
+        //convert to int
+        if (type.equals("int")) {
+          if (object instanceof String) {
+            if (object != null) {
+              String value = (String) object;
+              record.setValue(idx, Integer.valueOf(value));
+            }
+          }
+          else if (object instanceof Double) {
+            if (object != null) {
+              Double value = (Double) object;
+              record.setValue(idx, value.intValue());
+            }
+          }
+          else if (object instanceof Boolean) {
+            if (object != null) {
+              Boolean value = (Boolean) object;
+              if (value.equals(true)) {
+                record.setValue(idx, 1);
+              }
+              else {
+                record.setValue(idx, 0);
+              }
+            }
+          }
+        }
+
+        //convert to string
+        if (type.equals("string")) {
+          if (object != null) {
+            record.setValue(idx, object.toString());
+          }
+        }
+
+        //convert to double
+        if (type.equals("double")) {
+          if (object instanceof Integer) {
+            if (object != null) {
+              Integer value = (Integer) object;
+              record.setValue(idx, value.doubleValue());
+            }
+          }
+          if (object instanceof String) {
+            if (object != null) {
+              String value = (String) object;
+              record.setValue(idx, Double.valueOf(value));
+            }
+          }
+          if (object instanceof Boolean) {
+            if (object != null) {
+              Boolean value = (Boolean) object;
+              if (value.equals(true)) {
+                record.setValue(idx, 1.0);
+              }
+              else {
+                record.setValue(idx, 0.0);
+              }
+            }
+          }
+        }
+
+        //convert to boolean
+        if (type.equals("boolean")) {
+          if (object instanceof Integer) {
+            if (object != null) {
+              Integer value = (Integer) object;
+              if (value.equals(0)) {
+                record.setValue(idx, false);
+              }
+              else {
+                record.setValue(idx, true);
+              }
+            }
+          }
+          if (object instanceof Double) {
+            if (object != null) {
+              Double value = (Double) object;
+              if (value.equals(0.0)) {
+                record.setValue(idx, false);
+              }
+              else {
+                record.setValue(idx, true);
+              }
+            }
+          }
+          if (object instanceof String) {
+            if (object != null) {
+              String value = (String) object;
+              if (value.equals("true")) {
+                record.setValue(idx, true);
+              }
+              else if (value.equals("false")) {
+                record.setValue(idx, false);
+              }
+            }
+          }
+        }
+      }
+    }
+    return records;
+  }
+}

--- a/core/src/test/java/co/cask/wrangler/steps/column/SetTypeTest.java
+++ b/core/src/test/java/co/cask/wrangler/steps/column/SetTypeTest.java
@@ -16,7 +16,7 @@
 
 package co.cask.wrangler.steps.column;
 
-import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.common.Bytes;
 import co.cask.wrangler.api.Pipeline;
 import co.cask.wrangler.api.Record;
 import co.cask.wrangler.executor.PipelineExecutor;
@@ -33,138 +33,229 @@ import java.util.List;
 public class SetTypeTest {
 
   @Test
-  public void testSetToString() throws Exception {
-    String[] directives = new String[] {
-      "set-type str_col string", "set-type int_col string", "set-type double_col string",
-      "set-type true_col string", "set-type false_col string"
-    };
+  public void testToInt() throws Exception {
     List<Record> records = Arrays.asList(
-      new Record("str_col", "100").add("int_col", 1).add("double_col", 1.0).
-        add("true_col", true).add("false_col", false)
+      new Record("str_col", "10000").add("int_col", 10000).add("double_col", new Double(10000.0))
+        .add("short_col", new Short("10000")).add("long_col", new Long(10000)).add("float_col", new Float(10000.0))
+        .add("bytes_col", new byte[]{0, 0, 39, 16})
     );
+    String[] directives = new String[] {
+      "set-type str_col int", "set-type int_col i64", "set-type double_col integer",
+      "set-type short_col INT", "set-type long_col I64", "set-type float_col Integer", "set-type bytes_col INTEGER"
+    };
     TextDirectives d = new TextDirectives(directives);
     Pipeline pipeline = new PipelineExecutor();
     pipeline.configure(d, null);
     List<Record> results = pipeline.execute(records);
     Record record = results.get(0);
 
-    for (KeyValue<String, Object> keyValue : record.getFields()) {
-      Assert.assertTrue(keyValue.getValue() instanceof String);
+    for (int i = 0; i < record.length(); i ++) {
+      Object object = record.getValue(i);
+      Assert.assertTrue(object instanceof Integer);
+      Integer intValue = (Integer) object;
+      Assert.assertTrue(intValue.equals(10000));
     }
-
-    String value1 = (String)record.getValue("str_col");
-    String value2 = (String)record.getValue("int_col");
-    String value3 = (String)record.getValue("double_col");
-    String value4 = (String)record.getValue("true_col");
-    String value5 = (String)record.getValue("false_col");
-
-    Assert.assertEquals(value1, "100");
-    Assert.assertEquals(value2, "1");
-    Assert.assertEquals(value3, "1.0");
-    Assert.assertEquals(value4, "true");
-    Assert.assertEquals(value5, "false");
   }
 
   @Test
-  public void testSetToInt() throws Exception {
-    String[] directives = new String[] {
-      "set-type str_col int", "set-type int_col int", "set-type double_col int",
-      "set-type true_col int", "set-type false_col int"
-    };
+  public void testToShort() throws Exception {
     List<Record> records = Arrays.asList(
-      new Record("str_col", "100").add("int_col", 1).add("double_col", 1.0).
-        add("true_col", true).add("false_col", false)
+      new Record("str_col", "10000").add("int_col", 10000).add("double_col", new Double(10000.0))
+        .add("short_col", new Short("10000")).add("long_col", new Long(10000)).add("float_col", new Float(10000.0))
+        .add("bytes_col", new byte[]{39, 16})
     );
+    String[] directives = new String[] {
+      "set-type str_col short", "set-type int_col i32", "set-type double_col Short",
+      "set-type short_col I32", "set-type long_col SHORT", "set-type float_col short", "set-type bytes_col short"
+    };
     TextDirectives d = new TextDirectives(directives);
     Pipeline pipeline = new PipelineExecutor();
     pipeline.configure(d, null);
     List<Record> results = pipeline.execute(records);
     Record record = results.get(0);
 
-    for (KeyValue<String, Object> keyValue : record.getFields()) {
-      Assert.assertTrue(keyValue.getValue() instanceof Integer);
+    for (int i = 0; i < record.length(); i ++) {
+      Object object = record.getValue(i);
+      Assert.assertTrue(object instanceof Short);
+      Short value = (Short) object;
+      Assert.assertTrue(value.equals(new Short("10000")));
     }
-
-    Integer value1 = (Integer)record.getValue("str_col");
-    Integer value2 = (Integer)record.getValue("int_col");
-    Integer value3 = (Integer)record.getValue("double_col");
-    Integer value4 = (Integer)record.getValue("true_col");
-    Integer value5 = (Integer)record.getValue("false_col");
-
-    Assert.assertTrue(value1.equals(100));
-    Assert.assertTrue(value2.equals(1));
-    Assert.assertTrue(value3.equals(1));
-    Assert.assertTrue(value4.equals(1));
-    Assert.assertTrue(value5.equals(0));
   }
 
   @Test
-  public void testSetToDouble() throws Exception {
-    String[] directives = new String[] {
-      "set-type str_col double", "set-type int_col double", "set-type double_col double",
-      "set-type true_col double", "set-type false_col double"
-    };
+  public void testToLong() throws Exception {
     List<Record> records = Arrays.asList(
-      new Record("str_col", "100").add("int_col", 1).add("double_col", 1.0).
-        add("true_col", true).add("false_col", false)
+      new Record("str_col", "10000").add("int_col", 10000).add("double_col", new Double(10000.0))
+        .add("short_col", new Short("10000")).add("long_col", new Long(10000)).add("float_col", new Float(10000.0))
+        .add("bytes_col", new byte[]{0, 0, 0, 0 , 0, 0, 39, 16})
     );
+    String[] directives = new String[] {
+      "set-type str_col long", "set-type int_col Long", "set-type double_col LONG",
+      "set-type short_col long", "set-type long_col Long", "set-type float_col LONG", "set-type bytes_col long"
+    };
     TextDirectives d = new TextDirectives(directives);
     Pipeline pipeline = new PipelineExecutor();
     pipeline.configure(d, null);
     List<Record> results = pipeline.execute(records);
     Record record = results.get(0);
 
-    for (KeyValue<String, Object> keyValue : record.getFields()) {
-      Assert.assertTrue(keyValue.getValue() instanceof Double);
+    for (int i = 0; i < record.length(); i ++) {
+      Object object = record.getValue(i);
+      Assert.assertTrue(object instanceof Long);
+      Long value = (Long) object;
+      Assert.assertTrue(value.equals(new Long(10000)));
     }
-
-    Double value1 = (Double)record.getValue("str_col");
-    Double value2 = (Double)record.getValue("int_col");
-    Double value3 = (Double)record.getValue("double_col");
-    Double value4 = (Double)record.getValue("true_col");
-    Double value5 = (Double)record.getValue("false_col");
-
-    Assert.assertTrue(value1.equals(100.0));
-    Assert.assertTrue(value2.equals(1.0));
-    Assert.assertTrue(value3.equals(1.0));
-    Assert.assertTrue(value4.equals(1.0));
-    Assert.assertTrue(value5.equals(0.0));
   }
 
   @Test
-  public void testSetToBoolean() throws Exception {
-    String[] directives = new String[] {
-      "set-type str_true boolean", "set-type str_false boolean",
-      "set-type int_col boolean", "set-type double_col boolean",
-      "set-type true_col boolean", "set-type false_col boolean"
-    };
+  public void testToFloat() throws Exception {
     List<Record> records = Arrays.asList(
-      new Record("str_true", "true").add("str_false", "false")
-        .add("int_col", 1).add("double_col", 0.0).
-        add("true_col", true).add("false_col", false)
+      new Record("str_col", "10000.00").add("int_col", 10000).add("double_col", new Double(10000.00))
+        .add("short_col", new Short("10000")).add("long_col", new Long(10000)).add("float_col", new Float(10000.0))
+        .add("bytes_col", new byte[]{70, 28, 64, 0})
     );
+    String[] directives = new String[] {
+      "set-type str_col float", "set-type int_col Float", "set-type double_col FLOAT",
+      "set-type short_col float", "set-type long_col Float", "set-type float_col FLOAT", "set-type bytes_col float"
+    };
     TextDirectives d = new TextDirectives(directives);
     Pipeline pipeline = new PipelineExecutor();
     pipeline.configure(d, null);
     List<Record> results = pipeline.execute(records);
     Record record = results.get(0);
 
-    for (KeyValue<String, Object> keyValue : record.getFields()) {
-      Assert.assertTrue(keyValue.getValue() instanceof Boolean);
+    for (int i = 0; i < record.length(); i ++) {
+      Object object = record.getValue(i);
+      Assert.assertTrue(object instanceof Float);
+      Float value = (Float) object;
+      Assert.assertTrue(value.equals(new Float(10000)));
     }
+  }
 
-    Boolean value1 = (Boolean)record.getValue("str_true");
-    Boolean value2 = (Boolean)record.getValue("str_false");
-    Boolean value3 = (Boolean)record.getValue("int_col");
-    Boolean value4 = (Boolean)record.getValue("double_col");
-    Boolean value5 = (Boolean)record.getValue("true_col");
-    Boolean value6 = (Boolean)record.getValue("false_col");
+  @Test
+  public void testToDouble() throws Exception {
+    List<Record> records = Arrays.asList(
+      new Record("str_col", "10000.00").add("int_col", 10000).add("double_col", new Double(10000.00))
+        .add("short_col", new Short("10000")).add("long_col", new Long(10000)).add("float_col", new Float(10000.0))
+        .add("bytes_col", new byte[]{64, -61, -120, 0, 0, 0, 0, 0})
+    );
+    String[] directives = new String[] {
+      "set-type str_col double", "set-type int_col Double", "set-type double_col DOUBLE",
+      "set-type short_col double", "set-type long_col Double", "set-type float_col DOUBLE", "set-type bytes_col double"
+    };
+    TextDirectives d = new TextDirectives(directives);
+    Pipeline pipeline = new PipelineExecutor();
+    pipeline.configure(d, null);
+    List<Record> results = pipeline.execute(records);
+    Record record = results.get(0);
 
-    Assert.assertTrue(value1.equals(true));
-    Assert.assertTrue(value2.equals(false));
-    Assert.assertTrue(value3.equals(true));
-    Assert.assertTrue(value4.equals(false));
-    Assert.assertTrue(value5.equals(true));
-    Assert.assertTrue(value6.equals(false));
+    for (int i = 0; i < record.length(); i ++) {
+      Object object = record.getValue(i);
+      Assert.assertTrue(object instanceof Double);
+      Double value = (Double) object;
+      Assert.assertTrue(value.equals(new Double(10000)));
+    }
+  }
+
+  @Test
+  public void testToBoolean() throws Exception {
+    List<Record> trueRecords = Arrays.asList(
+      new Record("str_1", "true").add("str_2", "True").add("str_3", "TRUE")
+        .add("int_col", 10000).add("double_col", new Double(10000.00))
+        .add("short_col", new Short("10000")).add("long_col", new Long(10000))
+        .add("float_col", new Float(10000.0)).add("true_col", true)
+    );
+    List<Record> falseRecords = Arrays.asList(
+      new Record("str_1", "false").add("str_2", "False").add("str_3", "FALSE")
+        .add("int_col", -10000).add("double_col", new Double(-10000.00))
+        .add("short_col", new Short("-10000")).add("long_col", new Long(-10000))
+        .add("float_col", new Float(-10000.0)).add("false_col", false)
+    );
+    String[] directives = new String[] {
+      "set-type str_1 bool", "set-type str_2 bool", "set-type str_3 bool", "set-type int_col Bool", "set-type double_col BOOL",
+      "set-type short_col boolean", "set-type long_col Boolean", "set-type float_col BOOLEAN", "set-type bytes_col bool"
+    };
+    TextDirectives d = new TextDirectives(directives);
+    Pipeline pipeline = new PipelineExecutor();
+    pipeline.configure(d, null);
+    List<Record> trueResults = pipeline.execute(trueRecords);
+    List<Record> falseResults = pipeline.execute(falseRecords);
+    Record trueRecord = trueResults.get(0);
+    Record falseRecord = falseResults.get(0);
+
+    for (int i = 0; i < trueRecord.length(); i ++) {
+      Object trueObject = trueRecord.getValue(i);
+      Object falseObject = falseRecord.getValue(i);
+      Assert.assertTrue(trueObject instanceof Boolean);
+      Assert.assertTrue(falseObject instanceof Boolean);
+      Boolean trueValue = (Boolean) trueObject;
+      Boolean falseValue = (Boolean) falseObject;
+      Assert.assertTrue(trueValue);
+      Assert.assertFalse(falseValue);
+    }
+  }
+
+  @Test
+  public void testToString() throws Exception {
+    List<Record> records = Arrays.asList(
+      new Record("str_col", "10000").add("int_col", 10000).add("double_col", new Double(10000))
+        .add("short_col", new Short("10000")).add("long_col", new Long(10000)).add("float_col", new Float(10000))
+        .add("bytes_col", new byte[]{49, 48, 48, 48, 48})
+    );
+    String[] directives = new String[] {
+      "set-type str_col string", "set-type int_col String", "set-type double_col STRING",
+      "set-type short_col string", "set-type long_col String", "set-type float_col STRING", "set-type bytes_col string"
+    };
+    TextDirectives d = new TextDirectives(directives);
+    Pipeline pipeline = new PipelineExecutor();
+    pipeline.configure(d, null);
+    List<Record> results = pipeline.execute(records);
+    Record record = results.get(0);
+
+    for (int i = 0; i < record.length(); i ++) {
+      Object object = record.getValue(i);
+      Assert.assertTrue(object instanceof String);
+      String value = (String) object;
+      if (i == 2 || i == 5) {
+        Assert.assertTrue(value.equals("10000.0"));
+      }
+      else {
+        Assert.assertTrue(value.equals("10000"));
+      }
+    }
+  }
+
+  @Test
+  public void testToBytes() throws Exception {
+    List<Record> records = Arrays.asList(
+      new Record("str_col", "10000").add("int_col", 10000).add("double_col", new Double(10000.00))
+        .add("short_col", new Short("10000")).add("long_col", new Long(10000)).add("float_col", new Float(10000.0))
+        .add("bytes_col", new byte[]{64, -61, -120, 0, 0, 0, 0, 0})
+    );
+    byte[][] bytesResults = new byte[][] {
+      new byte[] {49, 48, 48, 48, 48},
+      new byte[] {0, 0, 39, 16},
+      new byte[] {64, -61, -120, 0, 0, 0, 0, 0},
+      new byte[] {39, 16},
+      new byte[] {0, 0, 0, 0, 0, 0, 39, 16},
+      new byte[] {70, 28, 64, 0},
+      new byte[] {64, -61, -120, 0, 0, 0, 0, 0}
+    };
+    String[] directives = new String[] {
+      "set-type str_col bytes", "set-type int_col Bytes", "set-type double_col BYTES",
+      "set-type short_col bytes", "set-type long_col Bytes", "set-type float_col BYTES", "set-type bytes_col bytes"
+    };
+    TextDirectives d = new TextDirectives(directives);
+    Pipeline pipeline = new PipelineExecutor();
+    pipeline.configure(d, null);
+    List<Record> results = pipeline.execute(records);
+    Record record = results.get(0);
+
+    for (int i = 0; i < record.length(); i ++) {
+      Object object = record.getValue(i);
+      Assert.assertTrue(object instanceof byte[]);
+      byte [] value = (byte[]) object;
+      Assert.assertEquals(0, Bytes.compareTo(value, bytesResults[i]));
+    }
   }
 }

--- a/core/src/test/java/co/cask/wrangler/steps/column/SetTypeTest.java
+++ b/core/src/test/java/co/cask/wrangler/steps/column/SetTypeTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.steps.column;
+
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.wrangler.api.Pipeline;
+import co.cask.wrangler.api.Record;
+import co.cask.wrangler.executor.PipelineExecutor;
+import co.cask.wrangler.executor.TextDirectives;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests {@link SetType}
+ */
+public class SetTypeTest {
+
+  @Test
+  public void testSetToString() throws Exception {
+    String[] directives = new String[] {
+      "set-type str_col string", "set-type int_col string", "set-type double_col string",
+      "set-type true_col string", "set-type false_col string"
+    };
+    List<Record> records = Arrays.asList(
+      new Record("str_col", "100").add("int_col", 1).add("double_col", 1.0).
+        add("true_col", true).add("false_col", false)
+    );
+    TextDirectives d = new TextDirectives(directives);
+    Pipeline pipeline = new PipelineExecutor();
+    pipeline.configure(d, null);
+    List<Record> results = pipeline.execute(records);
+    Record record = results.get(0);
+
+    for (KeyValue<String, Object> keyValue : record.getFields()) {
+      Assert.assertTrue(keyValue.getValue() instanceof String);
+    }
+
+    String value1 = (String)record.getValue("str_col");
+    String value2 = (String)record.getValue("int_col");
+    String value3 = (String)record.getValue("double_col");
+    String value4 = (String)record.getValue("true_col");
+    String value5 = (String)record.getValue("false_col");
+
+    Assert.assertEquals(value1, "100");
+    Assert.assertEquals(value2, "1");
+    Assert.assertEquals(value3, "1.0");
+    Assert.assertEquals(value4, "true");
+    Assert.assertEquals(value5, "false");
+  }
+
+  @Test
+  public void testSetToInt() throws Exception {
+    String[] directives = new String[] {
+      "set-type str_col int", "set-type int_col int", "set-type double_col int",
+      "set-type true_col int", "set-type false_col int"
+    };
+    List<Record> records = Arrays.asList(
+      new Record("str_col", "100").add("int_col", 1).add("double_col", 1.0).
+        add("true_col", true).add("false_col", false)
+    );
+    TextDirectives d = new TextDirectives(directives);
+    Pipeline pipeline = new PipelineExecutor();
+    pipeline.configure(d, null);
+    List<Record> results = pipeline.execute(records);
+    Record record = results.get(0);
+
+    for (KeyValue<String, Object> keyValue : record.getFields()) {
+      Assert.assertTrue(keyValue.getValue() instanceof Integer);
+    }
+
+    Integer value1 = (Integer)record.getValue("str_col");
+    Integer value2 = (Integer)record.getValue("int_col");
+    Integer value3 = (Integer)record.getValue("double_col");
+    Integer value4 = (Integer)record.getValue("true_col");
+    Integer value5 = (Integer)record.getValue("false_col");
+
+    Assert.assertTrue(value1.equals(100));
+    Assert.assertTrue(value2.equals(1));
+    Assert.assertTrue(value3.equals(1));
+    Assert.assertTrue(value4.equals(1));
+    Assert.assertTrue(value5.equals(0));
+  }
+
+  @Test
+  public void testSetToDouble() throws Exception {
+    String[] directives = new String[] {
+      "set-type str_col double", "set-type int_col double", "set-type double_col double",
+      "set-type true_col double", "set-type false_col double"
+    };
+    List<Record> records = Arrays.asList(
+      new Record("str_col", "100").add("int_col", 1).add("double_col", 1.0).
+        add("true_col", true).add("false_col", false)
+    );
+    TextDirectives d = new TextDirectives(directives);
+    Pipeline pipeline = new PipelineExecutor();
+    pipeline.configure(d, null);
+    List<Record> results = pipeline.execute(records);
+    Record record = results.get(0);
+
+    for (KeyValue<String, Object> keyValue : record.getFields()) {
+      Assert.assertTrue(keyValue.getValue() instanceof Double);
+    }
+
+    Double value1 = (Double)record.getValue("str_col");
+    Double value2 = (Double)record.getValue("int_col");
+    Double value3 = (Double)record.getValue("double_col");
+    Double value4 = (Double)record.getValue("true_col");
+    Double value5 = (Double)record.getValue("false_col");
+
+    Assert.assertTrue(value1.equals(100.0));
+    Assert.assertTrue(value2.equals(1.0));
+    Assert.assertTrue(value3.equals(1.0));
+    Assert.assertTrue(value4.equals(1.0));
+    Assert.assertTrue(value5.equals(0.0));
+  }
+
+  @Test
+  public void testSetToBoolean() throws Exception {
+    String[] directives = new String[] {
+      "set-type str_true boolean", "set-type str_false boolean",
+      "set-type int_col boolean", "set-type double_col boolean",
+      "set-type true_col boolean", "set-type false_col boolean"
+    };
+    List<Record> records = Arrays.asList(
+      new Record("str_true", "true").add("str_false", "false")
+        .add("int_col", 1).add("double_col", 0.0).
+        add("true_col", true).add("false_col", false)
+    );
+    TextDirectives d = new TextDirectives(directives);
+    Pipeline pipeline = new PipelineExecutor();
+    pipeline.configure(d, null);
+    List<Record> results = pipeline.execute(records);
+    Record record = results.get(0);
+
+    for (KeyValue<String, Object> keyValue : record.getFields()) {
+      Assert.assertTrue(keyValue.getValue() instanceof Boolean);
+    }
+
+    Boolean value1 = (Boolean)record.getValue("str_true");
+    Boolean value2 = (Boolean)record.getValue("str_false");
+    Boolean value3 = (Boolean)record.getValue("int_col");
+    Boolean value4 = (Boolean)record.getValue("double_col");
+    Boolean value5 = (Boolean)record.getValue("true_col");
+    Boolean value6 = (Boolean)record.getValue("false_col");
+
+    Assert.assertTrue(value1.equals(true));
+    Assert.assertTrue(value2.equals(false));
+    Assert.assertTrue(value3.equals(true));
+    Assert.assertTrue(value4.equals(false));
+    Assert.assertTrue(value5.equals(true));
+    Assert.assertTrue(value6.equals(false));
+  }
+}

--- a/docs/directives/set-type.md
+++ b/docs/directives/set-type.md
@@ -1,18 +1,12 @@
-# Trimming Spaces
+# Set Type
 
-The TRIM, LTRIM, and RTRIM directives trim whitespace from both sides,
-left side or right side of a string values they are applied to.
-
+Convert data type of a column 
 
 ## Syntax
 ```
 set-type <column> <int|double|string|boolean>
 ```
-
-The directive performs an in-place trimming of space in the value specified
-by the `<column>`
-
-## Usage
+The `<column>` is converted to one of the types in `<int|double|string|boolean>`.
 
 
 

--- a/docs/directives/set-type.md
+++ b/docs/directives/set-type.md
@@ -4,6 +4,7 @@ Convert data type of a column
 
 ## Syntax
 ```
-set-type <column> <int|double|string|boolean>
+set-type <column> <type>
 ```
-The `<column>` is converted to one of the types in `<int|double|string|boolean>`.
+The `<column>` is converted to the type in `<typpe>`.
+Acceptable types are: int, short, long, float, double, string, bytes, boolean

--- a/docs/directives/set-type.md
+++ b/docs/directives/set-type.md
@@ -1,0 +1,18 @@
+# Trimming Spaces
+
+The TRIM, LTRIM, and RTRIM directives trim whitespace from both sides,
+left side or right side of a string values they are applied to.
+
+
+## Syntax
+```
+set-type <column> <int|double|string|boolean>
+```
+
+The directive performs an in-place trimming of space in the value specified
+by the `<column>`
+
+## Usage
+
+
+

--- a/docs/directives/set-type.md
+++ b/docs/directives/set-type.md
@@ -7,6 +7,3 @@ Convert data type of a column
 set-type <column> <int|double|string|boolean>
 ```
 The `<column>` is converted to one of the types in `<int|double|string|boolean>`.
-
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>4.2.0-SNAPSHOT</cdap.version>
+    <cdap.version>4.3.0-SNAPSHOT</cdap.version>
     <commons-jexl.version>3.0</commons-jexl.version>
     <commons-csv.version>1.4</commons-csv.version>
     <commons-lang.version>3.5</commons-lang.version>


### PR DESCRIPTION
Added a directive "set-type" to convert data type of a column.
 Accepted types to covert from / convert to are: int, double, string, boolean (https://issues.cask.co/browse/CDAP-11868)