### PR TITLE
bump wrangler version and fix cdap dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>co.cask.wrangler</groupId>
   <artifactId>wrangler</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1-SNAPSHOT</version>
   <name>wrangler</name>
   <packaging>pom</packaging>
   <description>An interactive tool for data cleansing and transformation.</description>
@@ -79,7 +79,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <wrangler.version>${project.version}</wrangler.version>
-    <cdap.version>4.2.0-SNAPSHOT</cdap.version>
+    <cdap.version>4.1.0</cdap.version>
     <commons-jexl.version>3.0</commons-jexl.version>
     <commons-csv.version>1.4</commons-csv.version>
     <commons-lang.version>3.5</commons-lang.version>


### PR DESCRIPTION
1.3.x versions of wrangler are supposed to be compatible with
4.1.x versions of cdap. It should not have 4.2.0-SNAPSHOT as the
cdap dependency.