### PR TITLE
Update submodules to be the same version as parent.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>co.cask.wrangler</groupId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>co.cask.wrangler</groupId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/transform/pom.xml
+++ b/transform/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>co.cask.wrangler</groupId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Similar to https://github.com/hydrator/wrangler/pull/128, but also update the submodules.
Without this, compilation fails using 3.1.1 (but oddly, passes with 3.3.3).

For an example of the failure, see: https://builds.cask.co/browse/CDAP-BUT872-234/log

```
[ERROR] Failed to execute goal on project wrangler-core: Could not resolve dependencies for project co.cask.wrangler:wrangler-core:jar:1.3.0: The following artifacts could not be resolved: co.cask.cdap:cdap-app-fabric:jar:tests:4.2.0-SNAPSHOT, co.cask.cdap:cdap-watchdog-api:jar:4.2.0-SNAPSHOT, co.cask.cdap:cdap-explore:jar:4.2.0-SNAPSHOT, co.cask.cdap:cdap-hbase-spi:jar:4.2.0-SNAPSHOT, co.cask.cdap:cdap-etl-proto:jar:4.2.0-SNAPSHOT, co.cask.cdap:cdap-spi:jar:4.2.0-SNAPSHOT: Could not find artifact co.cask.cdap:cdap-app-fabric:jar:tests:4.2.0-20170606.135149-92 in sonatype (https://oss.sonatype.org/content/groups/public) -> [Help 1]
```