### PR TITLE
Fixing guava conflicts in wrangler

### DIFF
--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -23,13 +23,7 @@
     </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId>
-      <version>${antlr4.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-maven-plugin</artifactId>
+      <artifactId>antlr4</artifactId>
       <version>${antlr4.version}</version>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
The wrangler Integration tests were failing on MapR clusters because of conflicting guava dependencies. This could happen on any cluster. The fix is to exclude conflicting dependency pulled in transitively from `sisu-guava`

Tested it on MapR 5.2 ITN cluster

Build: https://builds.cask.co/browse/HYP-WT126-3