### PR TITLE
CDAP-12538-fix-workspaces-endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <antlr4.version>4.7</antlr4.version>
     <antlr4-maven-plugin.version>4.7</antlr4-maven-plugin.version>
     <junit.version>4.12</junit.version>
-    <reflections.version>0.9.11</reflections.version>
+    <reflections.version>0.9.9</reflections.version>
     <commons.validator.version>1.6</commons.validator.version>
   </properties>
 

--- a/wrangler-core/src/main/java/co/cask/wrangler/registry/SystemDirectiveRegistry.java
+++ b/wrangler-core/src/main/java/co/cask/wrangler/registry/SystemDirectiveRegistry.java
@@ -88,7 +88,7 @@ public final class SystemDirectiveRegistry implements  DirectiveRegistry {
   /**
    * Given the name of the directive, returns the information related to the directive.
    *
-   * @param name of the directive to be retrived from the registry.
+   * @param name of the directive to be retrieved from the registry.
    * @return an instance of {@link DirectiveInfo} if found, else null.
    */
   @Override

--- a/wrangler-core/src/main/java/co/cask/wrangler/registry/UserDirectiveRegistry.java
+++ b/wrangler-core/src/main/java/co/cask/wrangler/registry/UserDirectiveRegistry.java
@@ -56,7 +56,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
  * extract all the <tt>DirectiveInfo</tt> from the instance of directive created.</p>
  *
  * <p>Second context is the <tt>Transform</tt> plugin, were the second constructor
- * of this class in used to intialize. Initializing this class using <tt>StageContext</tt>
+ * of this class in used to initialize. Initializing this class using <tt>StageContext</tt>
  * provides a way to create an instance of the plugin. The name of the directive is
  * used as the <tt>id</tt> for the plugin.</p>
  *


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-12538

The issue was the dependency for Reflections used in the code had a bug: https://github.com/ronmamo/reflections/issues/81 which was causing following exception:

```java.lang.IllegalStateException: zip file closed
        at java.util.zip.ZipFile.ensureOpen(ZipFile.java:634)
        at java.util.zip.ZipFile.access$200(ZipFile.java:56)
        at java.util.zip.ZipFile$1.hasMoreElements(ZipFile.java:487)
        at java.util.jar.JarFile$1.hasMoreElements(JarFile.java:241)
        at org.reflections.vfs.ZipDir$1$1.computeNext(ZipDir.java:30)
        at org.reflections.vfs.ZipDir$1$1.computeNext(ZipDir.java:26)
        at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:145)
        at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:140)
        at org.reflections.Reflections.scan(Reflections.java:243)
        at org.reflections.Reflections.scan(Reflections.java:202)
        at org.reflections.Reflections.<init>(Reflections.java:123)
        at org.reflections.Reflections.<init>(Reflections.java:168)
        at org.reflections.Reflections.<init>(Reflections.java:141)
        at co.cask.wrangler.registry.SystemDirectiveRegistry.<init>(SystemDirectiveRegistry.java:76)
        at co.cask.wrangler.registry.SystemDirectiveRegistry.<init>(SystemDirectiveRegistry.java:60)
        at co.cask.wrangler.service.directive.DirectivesService.initialize(DirectivesService.java:140)
        at co.cask.wrangler.service.directive.DirectivesService.initialize(DirectivesService.java:114)

Reducing the version from 0.9.11 to 0.9.9 fixes the issue as suggested in the issue 81.

Tested on cluster