### PR TITLE
Handle oracle's ROWID datatype

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/database/DatabaseService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/database/DatabaseService.java
@@ -529,12 +529,15 @@ public class DatabaseService extends AbstractHttpServiceHandler {
                 if (object instanceof java.sql.Date) {
                   java.sql.Date dt = (java.sql.Date) object;
                   object = dt.toString();
-                } else if (object instanceof java.sql.Time) {
+                } else if (object instanceof java.sql.Timestamp) {
                   java.sql.Timestamp dt = (java.sql.Timestamp) object;
                   object = dt.toString();
                 } else if (object instanceof java.sql.Time) {
                   java.sql.Time dt = (java.sql.Time) object;
                   object = dt.toString();
+                } else if (object.getClass().getName().equals("oracle.sql.ROWID")) {
+                  // If the object is Oracle ROWID, then convert it into a string.
+                  object = object.toString();
                 }
                 row.add(meta.getColumnName(i), object);
               }


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-12639

![image](https://user-images.githubusercontent.com/14131070/30666097-174513ec-9e08-11e7-9cc0-1bc81d203314.png)

Tested the fix. Here RID is a `RowId` type.