### PR TITLE
[CDAP-12883] Adds emit-errors and emit-alerts properties to widget json of Wrangler transform

### DIFF
--- a/wrangler-transform/widgets/Wrangler-transform.json
+++ b/wrangler-transform/widgets/Wrangler-transform.json
@@ -1,7 +1,9 @@
 {
   "metadata": {
-    "spec-version": "1.3"
+    "spec-version": "1.6"
   },
+  "emit-alerts": true,
+  "emit-errors": true,
   "configuration-groups": [
     {
       "label" : "Input Selection and Prefilters",


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12883

This lets the UI know that these plugins can emit alerts and errors. On-hold until ~~https://github.com/caskdata/cdap/pull/9817 is merged.~~ we know for sure this is how we want to surface this information.