### PR TITLE
Fix compilation.

### DIFF
--- a/wrangler-core/src/main/java/co/cask/wrangler/expression/EL.java
+++ b/wrangler-core/src/main/java/co/cask/wrangler/expression/EL.java
@@ -13,7 +13,7 @@
  *  License for the specific language governing permissions and limitations under
  *  the License.
  */
-s
+
 package co.cask.wrangler.expression;
 
 import co.cask.cdap.api.common.Bytes;


### PR DESCRIPTION
CDAP autobuild on release/4.3 branch is failing due to compilation error in this repo caused by [this commit](https://github.com/hydrator/wrangler/commit/4a5530a3c90e29949ef1cd22c8a1f6284ebd3b54):

![image](https://user-images.githubusercontent.com/2440977/33959767-6abf2fbc-dffd-11e7-9c33-f5a9609cf56b.png)
