### PR TITLE
Fix compilation errors

### DIFF
--- a/wrangler-transform/pom.xml
+++ b/wrangler-transform/pom.xml
@@ -10,6 +10,13 @@
   <artifactId>wrangler-transform</artifactId>
   <name>Wrangler Transform</name>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <dependencies>
     <dependency>
       <groupId>co.cask.wrangler</groupId>
@@ -100,7 +107,7 @@
       <plugin>
         <groupId>co.cask</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <configuration>
           <cdapArtifacts>
             <parent>system:cdap-data-pipeline[4.0.0,6.0.0-SNAPSHOT)</parent>


### PR DESCRIPTION
Fix compilation, by defining pluginRepositories, so maven knows where to pull the SNAPSHOT version of cdap-maven-plugin from. The only other way that compilation can succeed is if the cdap-maven-plugin jars are already available in the local maven repository. Additionally, in the snapshot repo, the version is 1.0.0-SNAPSHOT.

Otherwise, an error like the following is encountered:
![image](https://user-images.githubusercontent.com/2440977/34746036-75c0112e-f547-11e7-85ef-7cddb9767fa3.png)

Also, add an empty 'icons' directory, as required by the cdap-maven-plugin.