### PR TITLE
configure to make project and credentials optional for GCS and BigQuery

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
@@ -76,16 +76,6 @@ public class BigQueryService extends AbstractWranglerService {
   private static final String SCHEMA = "schema";
   private static final String BUCKET = "bucket";
 
-  private BigQuery getBigQuery(Connection connection) throws Exception {
-    Pair<String, ServiceAccountCredentials> projectIdAndCredentials = GCPUtils.getProjectIdAndCredentials(connection);
-
-    return BigQueryOptions.newBuilder()
-      .setProjectId(projectIdAndCredentials.getFirst())
-      .setCredentials(projectIdAndCredentials.getSecond())
-      .build()
-      .getService();
-  }
-
   /**
    * Tests BigQuery Connection.
    *
@@ -107,7 +97,7 @@ public class BigQueryService extends AbstractWranglerService {
         return;
       }
 
-      BigQuery bigQuery = getBigQuery(connection);
+      BigQuery bigQuery = GCPUtils.getBigQueryService(connection);
       bigQuery.listDatasets(BigQuery.DatasetListOption.pageSize(1));
       ServiceUtils.success(responder, "Success");
     } catch (Exception e) {
@@ -130,7 +120,7 @@ public class BigQueryService extends AbstractWranglerService {
     if (!validateConnection(connectionId, connection, responder)) {
       return;
     }
-    BigQuery bigQuery = getBigQuery(connection);
+    BigQuery bigQuery = GCPUtils.getBigQueryService(connection);
     Page<Dataset> datasets = bigQuery.listDatasets(BigQuery.DatasetListOption.all());
     JsonArray values = new JsonArray();
     for (Dataset dataset : datasets.iterateAll()) {
@@ -166,7 +156,7 @@ public class BigQueryService extends AbstractWranglerService {
     if (!validateConnection(connectionId, connection, responder)) {
       return;
     }
-    BigQuery bigQuery = getBigQuery(connection);
+    BigQuery bigQuery = GCPUtils.getBigQueryService(connection);
     Page<com.google.cloud.bigquery.Table> tablePage = bigQuery.listTables(datasetId);
 
     JsonArray values = new JsonArray();
@@ -309,7 +299,7 @@ public class BigQueryService extends AbstractWranglerService {
 
   private Pair<List<Row>, Schema> getData(Connection connection, TableId tableId) throws Exception {
     List<Row> rows = new ArrayList<>();
-    BigQuery bigQuery = getBigQuery(connection);
+    BigQuery bigQuery = GCPUtils.getBigQueryService(connection);
     String query = String.format("SELECT * FROM `%s.%s.%s` LIMIT 1000", tableId.getProject(), tableId.getDataset(),
                                  tableId.getTable());
     QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query).build();

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
@@ -116,7 +116,7 @@ public class GCSService extends AbstractWranglerService {
         return;
       }
 
-      Storage storage = getStorage(connection);
+      Storage storage = GCPUtils.getStorageService(connection);
       storage.list(Storage.BucketListOption.pageSize(1));
       ServiceUtils.success(responder, "Success");
     } catch (Exception e) {
@@ -124,15 +124,7 @@ public class GCSService extends AbstractWranglerService {
     }
   }
 
-  private Storage getStorage(Connection connection) throws Exception {
-    Pair<String, ServiceAccountCredentials> projectIdAndCredentials = GCPUtils.getProjectIdAndCredentials(connection);
 
-    return StorageOptions.newBuilder()
-      .setProjectId(projectIdAndCredentials.getFirst())
-      .setCredentials(projectIdAndCredentials.getSecond())
-      .build()
-      .getService();
-  }
 
   private boolean validateConnection(String connectionId, Connection connection,
                                      HttpServiceResponder responder) {
@@ -189,7 +181,7 @@ public class GCSService extends AbstractWranglerService {
         }
       }
 
-      Storage storage = getStorage(connection[0]);
+      Storage storage = GCPUtils.getStorageService(connection[0]);
       if (bucketName.isEmpty() && prefix == null) {
         Page<Bucket> list = storage.list();
         Iterator<Bucket> iterator = list.getValues().iterator();
@@ -349,7 +341,7 @@ public class GCSService extends AbstractWranglerService {
       }
 
       Map<String, String> properties = new HashMap<>();
-      Storage storage = getStorage(connection);
+      Storage storage = GCPUtils.getStorageService(connection);
       Blob blob = storage.get(BlobId.of(bucket, blobPath));
       if (blob == null) {
         throw new Exception(String.format(


### PR DESCRIPTION
Making credentials and project informational as optional settings when constructing `Storage` or `BigQuery`. 