### PR TITLE
surfacing available connection types and creating default connections

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/DataPrep.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/DataPrep.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.wrangler.dataset.workspace.WorkspaceDataset;
 import co.cask.wrangler.service.bigquery.BigQueryService;
 import co.cask.wrangler.service.connections.ConnectionService;
+import co.cask.wrangler.service.connections.ConnectionTypeConfig;
 import co.cask.wrangler.service.database.DatabaseService;
 import co.cask.wrangler.service.directive.DirectivesService;
 import co.cask.wrangler.service.explorer.FilesystemExplorer;
@@ -39,7 +40,7 @@ import org.apache.hadoop.mapred.TextOutputFormat;
 /**
  * Wrangler Application.
  */
-public class DataPrep extends AbstractApplication {
+public class DataPrep extends AbstractApplication<ConnectionTypeConfig> {
   public static final String CONNECTIONS_DATASET = "connections";
 
   /**
@@ -83,7 +84,7 @@ public class DataPrep extends AbstractApplication {
                new DirectivesService(),
                new SchemaRegistryService(),
                new FilesystemExplorer(),
-               new ConnectionService(),
+               new ConnectionService(getConfig()),
                new RecipeService(),
                new KafkaService(),
                new DatabaseService(),

--- a/wrangler-service/src/main/java/co/cask/wrangler/dataset/connections/Connection.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/dataset/connections/Connection.java
@@ -44,7 +44,7 @@ public final class Connection {
   private long updated;
 
   // Collection of properties.
-  private Map<String, Object> properties = new HashMap<>();
+  private Map<String, String> properties = new HashMap<>();
 
   /**
    * @return id of the connection.
@@ -94,7 +94,7 @@ public final class Connection {
    * @param key to be added.
    * @param value to be added.
    */
-  public void putProp(String key, Object value) {
+  public void putProp(String key, String value) {
     properties.put(key, value);
   }
 
@@ -175,7 +175,7 @@ public final class Connection {
   /**
    * @return all the properties associated with the connection.
    */
-  public Map<String, Object> getAllProps() {
+  public Map<String, String> getAllProps() {
     return properties;
   }
 

--- a/wrangler-service/src/main/java/co/cask/wrangler/dataset/connections/ConnectionStore.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/dataset/connections/ConnectionStore.java
@@ -68,13 +68,13 @@ public class ConnectionStore extends AbstractTableStore<Connection> {
         String.format("Name not present for connection.")
       );
     }
-    String mangled = mangle(name);
-    connection.setId(mangled);
-    if (hasKey(mangled)) {
+    if (connectionExists(name)) {
       throw new IllegalArgumentException(
-        String.format("Connection name '%s' already exists.", connection.getName())
+        String.format("Connection name '%s' already exists.", name)
       );
     }
+    String mangled = mangle(name);
+    connection.setId(mangled);
     connection.setCreated(now());
     connection.setUpdated(now());
     putObject(Bytes.toBytes(mangled), connection);
@@ -114,5 +114,13 @@ public class ConnectionStore extends AbstractTableStore<Connection> {
     connection.setCreated(now());
     connection.setUpdated(now());
     return connection;
+  }
+
+  /**
+   * Returns true if connection identified by connectionName already exists
+   */
+  public boolean connectionExists(String connectionName) {
+    String mangled = mangle(connectionName);
+    return hasKey(mangled);
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
@@ -210,10 +210,10 @@ public class BigQueryService extends AbstractWranglerService {
       scope = WorkspaceDataset.DEFAULT_SCOPE;
     }
 
-    Map<String, Object> connectionProperties = connection.getAllProps();
-    String projectId = (String) connectionProperties.get(GCPUtils.PROJECT_ID);
-    String path = (String) connectionProperties.get(GCPUtils.SERVICE_ACCOUNT_KEYFILE);
-    String bucket = (String) connectionProperties.get(BUCKET);
+    Map<String, String> connectionProperties = connection.getAllProps();
+    String projectId = connectionProperties.get(GCPUtils.PROJECT_ID);
+    String path = connectionProperties.get(GCPUtils.SERVICE_ACCOUNT_KEYFILE);
+    String bucket = connectionProperties.get(BUCKET);
 
     TableId tableIdObject = TableId.of(projectId, datasetId, tableId);
 

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionTypeConfig.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionTypeConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.service.connections;
+
+import co.cask.cdap.api.Config;
+import co.cask.wrangler.dataset.connections.Connection;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Default connections to create at startup and connection types that needs to be disabled
+ */
+public class ConnectionTypeConfig extends Config {
+  private final Set<ConnectionType> disabledTypes;
+  private final List<Connection> connections;
+
+  public ConnectionTypeConfig() {
+    this(Collections.EMPTY_SET, Collections.EMPTY_LIST);
+  }
+
+  public ConnectionTypeConfig(Set<ConnectionType> disabledTypes, List<Connection> connections) {
+    this.disabledTypes = disabledTypes;
+    this.connections = connections;
+  }
+
+  /**
+   * Return the set of disabled connection types
+   */
+  public Set<ConnectionType> getDisabledTypes() {
+    return disabledTypes == null ? Collections.emptySet() : disabledTypes;
+  }
+
+  /**
+   * Return the list of default connections to be created
+   */
+  public List<Connection> getConnections() {
+    return connections == null ? Collections.emptyList() : connections;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ConnectionTypeConfig that = (ConnectionTypeConfig) o;
+
+    return Objects.equals(disabledTypes, that.disabledTypes) &&
+      Objects.equals(connections, that.connections);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(disabledTypes, connections);
+  }
+
+}

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionTypeInfo.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionTypeInfo.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.service.connections;
+
+/**
+ * ConnectionTypeInfo - sent as response in listing connection types
+ */
+public class ConnectionTypeInfo {
+  private final ConnectionType type;
+
+  public ConnectionTypeInfo(ConnectionType connectionType) {
+    this.type = connectionType;
+  }
+}

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/database/DatabaseService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/database/DatabaseService.java
@@ -617,14 +617,14 @@ public class DatabaseService extends AbstractHttpServiceHandler {
       JsonObject database = new JsonObject();
 
       Map<String, String> properties = new HashMap<>();
-      properties.put("connectionString", (String) conn.getProp("url"));
+      properties.put("connectionString", conn.getProp("url"));
       properties.put("referenceName", table);
-      properties.put("user", (String) conn.getProp("username"));
-      properties.put("password", (String) conn.getProp("password"));
+      properties.put("user", conn.getProp("username"));
+      properties.put("password", conn.getProp("password"));
       properties.put("importQuery", String.format("SELECT * FROM %s WHERE $CONDITIONS", table));
       properties.put("numSplits", "1");
-      properties.put("jdbcPluginName", (String) conn.getProp("name"));
-      properties.put("jdbcPluginType", (String) conn.getProp("type"));
+      properties.put("jdbcPluginName", conn.getProp("name"));
+      properties.put("jdbcPluginType", conn.getProp("type"));
 
       database.add("properties", gson.toJsonTree(properties));
       database.addProperty("name", String.format("Database - %s", table));

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcp/GCPUtils.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcp/GCPUtils.java
@@ -80,11 +80,11 @@ public final class GCPUtils {
    */
   private static void setProperties(Connection connection, ServiceOptions.Builder serviceOptions) throws Exception {
     if (connection.hasProperty(GCPUtils.SERVICE_ACCOUNT_KEYFILE)) {
-      String path = (String) connection.getAllProps().get(GCPUtils.SERVICE_ACCOUNT_KEYFILE);
+      String path = connection.getAllProps().get(GCPUtils.SERVICE_ACCOUNT_KEYFILE);
       serviceOptions.setCredentials(loadLocalFile(path));
     }
     if (connection.hasProperty(GCPUtils.PROJECT_ID)) {
-      String projectId = (String) connection.getAllProps().get(GCPUtils.PROJECT_ID);
+      String projectId = connection.getAllProps().get(GCPUtils.PROJECT_ID);
       serviceOptions.setProjectId(projectId);
     }
   }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
@@ -461,8 +461,8 @@ public class GCSService extends AbstractWranglerService {
       if (pluginType.equalsIgnoreCase("normal")) {
         JsonObject gcs = new JsonObject();
         properties.put("referenceName", "GCS_Source");
-        properties.put("serviceFilePath", (String) connection.getProp(GCPUtils.SERVICE_ACCOUNT_KEYFILE));
-        properties.put("project", (String) connection.getProp(GCPUtils.PROJECT_ID));
+        properties.put("serviceFilePath", connection.getProp(GCPUtils.SERVICE_ACCOUNT_KEYFILE));
+        properties.put("project", connection.getProp(GCPUtils.PROJECT_ID));
         properties.put("bucket", bucket);
         properties.put("path", uri);
         properties.put("recursive", "false");
@@ -474,8 +474,8 @@ public class GCSService extends AbstractWranglerService {
       } else if (pluginType.equalsIgnoreCase("blob")) {
         JsonObject gcs = new JsonObject();
         properties.put("referenceName", "GCS_Blob");
-        properties.put("serviceFilePath", (String) connection.getProp(GCPUtils.SERVICE_ACCOUNT_KEYFILE));
-        properties.put("project", (String) connection.getProp(GCPUtils.PROJECT_ID));
+        properties.put("serviceFilePath", connection.getProp(GCPUtils.SERVICE_ACCOUNT_KEYFILE));
+        properties.put("project", connection.getProp(GCPUtils.PROJECT_ID));
         properties.put("bucket", bucket);
         properties.put("path", uri);
         gcs.add("properties", new Gson().toJsonTree(properties));

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaConfiguration.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaConfiguration.java
@@ -49,25 +49,25 @@ public final class KafkaConfiguration {
       );
     }
 
-    Map<String, Object> properties = conn.getAllProps();
+    Map<String, String> properties = conn.getAllProps();
     if(properties == null || properties.size() == 0) {
       throw new IllegalArgumentException("Kafka properties are not defined. Check connection setting.");
     }
 
     if (properties.containsKey("brokers")) {
-      connection = (String) properties.get("brokers");
+      connection = properties.get("brokers");
     } else {
       throw new IllegalArgumentException("Kafka Brokers not defined.");
     }
 
     if (properties.containsKey("key.type")) {
-      keyDeserializer = deserialize((String) properties.get("key.type"));
+      keyDeserializer = deserialize(properties.get("key.type"));
     }
 
     if (properties.containsKey("value.type")) {
-      valueDeserializer = deserialize((String) properties.get("value.type"));
+      valueDeserializer = deserialize(properties.get("value.type"));
     }
-    String requestTimeoutMs = (String) properties.get(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+    String requestTimeoutMs = properties.get(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
     // default the request timeout to 15 seconds, to avoid hanging for minutes
     if (requestTimeoutMs == null) {
       requestTimeoutMs = "15000";

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaService.java
@@ -282,9 +282,9 @@ public final class KafkaService extends AbstractHttpServiceHandler {
       Map<String, String> properties = new HashMap<>();
       properties.put("topic", topic);
       properties.put("referenceName", topic);
-      properties.put("brokers", (String) conn.getProp(PropertyIds.BROKER));
-      properties.put("kafkaBrokers", (String) conn.getProp(PropertyIds.BROKER));
-      properties.put("keyField", (String) conn.getProp(PropertyIds.KEY_DESERIALIZER));
+      properties.put("brokers", conn.getProp(PropertyIds.BROKER));
+      properties.put("kafkaBrokers", conn.getProp(PropertyIds.BROKER));
+      properties.put("keyField", conn.getProp(PropertyIds.KEY_DESERIALIZER));
       properties.put("format", "text");
 
       kafka.add("properties", gson.toJsonTree(properties));

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Configuration.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Configuration.java
@@ -33,7 +33,7 @@ public class S3Configuration implements AWSCredentials {
   private final String region;
 
   S3Configuration(Connection connection) {
-    Map<String, Object> properties = connection.getAllProps();
+    Map<String, String> properties = connection.getAllProps();
 
     if(properties == null || properties.size() == 0) {
       throw new IllegalArgumentException("S3 properties are not defined. Check connection setting.");
@@ -44,9 +44,9 @@ public class S3Configuration implements AWSCredentials {
         throw new IllegalArgumentException("Missing configuration in connection for property " + property);
       }
     }
-    accessKeyId = String.valueOf(properties.get("accessKeyId"));
-    accessSecretKey = String.valueOf(properties.get("accessSecretKey"));
-    region = String.valueOf(properties.get("region"));
+    accessKeyId = properties.get("accessKeyId");
+    accessSecretKey = properties.get("accessSecretKey");
+    region = properties.get("region");
   }
 
   @Override

--- a/wrangler-service/src/test/java/co/cask/wrangler/dataset/connections/ConnectionTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/dataset/connections/ConnectionTest.java
@@ -41,7 +41,7 @@ public class ConnectionTest {
     connection.setCreated(System.currentTimeMillis()/1000);
     connection.setUpdated(System.currentTimeMillis()/1000);
     connection.putProp("hostname", "localhost");
-    connection.putProp("port", 3306);
+    connection.putProp("port", "3306");
     String from = gson.toJson(connection);
 
     String to = "{\n" +


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-14017

Adding support in dataprep for disabling certain connection-types and creating default connections.

Updated the properties map from `<String, Object>` to `<String, String>`, Object causes artifact inspection to fail when we are adding an artifact and it didn't really seem necessary.