### PR TITLE
Convert String to Integer using Integer.parseInt wrapper method.

### DIFF
--- a/wrangler-service/src/test/java/co/cask/wrangler/dataset/connections/ConnectionTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/dataset/connections/ConnectionTest.java
@@ -56,8 +56,7 @@ public class ConnectionTest {
       "\t}\n" +
       "}";
     Connection newConnection = gson.fromJson(to, Connection.class);
-    Number port = newConnection.getProp("port");
-    int p = port.intValue();
+    int p = Integer.parseInt(newConnection.getProp("port"));
     Assert.assertEquals(3306, p);
     Assert.assertTrue(true);
   }


### PR DESCRIPTION
Converting String to Number fails because they are not part of same inheritance hierarchy. Using `Integer.parseInt` instead.