### PR TITLE
CDAP-13977 change wrangler-core to not be a bundled jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,10 +224,6 @@
         <version>2.14.1</version>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
There is no reason for wrangler-core to be a bundle jar as it is
just a common module for the service and transform. This saves
about 100mb in space, as both the service and transform jars
were bundling all of wrangler-core's dependencies as well as a
fat wrangler-core.