### PR TITLE
Fix/expression test

### DIFF
--- a/wrangler-api/src/main/java/co/cask/wrangler/api/parser/Identifier.java
+++ b/wrangler-api/src/main/java/co/cask/wrangler/api/parser/Identifier.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright © 2017 Cask Data, Inc.
+ *  Copyright © 2017-2018 Cask Data, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
  *  use this file except in compliance with the License. You may obtain a copy of
@@ -21,7 +21,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
- * The <code>Identifirt</code> class wraps the primitive type {@code String} in a object.
+ * The <code>Identifier</code> class wraps the primitive type {@code String} in a object.
  * An object of type {@code Identifier} contains the value in primitive type
  * as well as the type of the token this class represents.
  *

--- a/wrangler-core/src/main/java/co/cask/directives/parser/ParseTimestamp.java
+++ b/wrangler-core/src/main/java/co/cask/directives/parser/ParseTimestamp.java
@@ -1,0 +1,148 @@
+/*
+ *  Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.directives.parser;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.wrangler.api.Arguments;
+import co.cask.wrangler.api.Directive;
+import co.cask.wrangler.api.DirectiveExecutionException;
+import co.cask.wrangler.api.DirectiveParseException;
+import co.cask.wrangler.api.ErrorRowException;
+import co.cask.wrangler.api.ExecutorContext;
+import co.cask.wrangler.api.Optional;
+import co.cask.wrangler.api.Row;
+import co.cask.wrangler.api.annotations.Categories;
+import co.cask.wrangler.api.parser.ColumnName;
+import co.cask.wrangler.api.parser.Text;
+import co.cask.wrangler.api.parser.TokenType;
+import co.cask.wrangler.api.parser.UsageDefinition;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A Executor to parse timestamp as date.
+ */
+@Plugin(type = Directive.Type)
+@Name("parse-timestamp")
+@Categories(categories = {"parser", "date"})
+@Description("Parses column values representing unix timestamp as date.")
+public class ParseTimestamp implements Directive {
+  public static final String NAME = "parse-timestamp";
+  private static final Set<TimeUnit> SUPPORTED_TIME_UNITS = EnumSet.of(TimeUnit.SECONDS, TimeUnit.MILLISECONDS,
+                                                                       TimeUnit.MICROSECONDS);
+  private String column;
+  private TimeUnit timeUnit;
+
+  @Override
+  public UsageDefinition define() {
+    UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+    builder.define("column", TokenType.COLUMN_NAME);
+    builder.define("timeunit", TokenType.TEXT, Optional.TRUE);
+    return builder.build();
+  }
+
+  @Override
+  public void initialize(Arguments args) throws DirectiveParseException {
+    this.column = ((ColumnName) args.value("column")).value();
+    this.timeUnit = TimeUnit.MILLISECONDS;
+
+    if (args.contains("timeunit")) {
+      String unitValue = ((Text) args.value("timeunit")).value();
+      this.timeUnit = getTimeUnit(unitValue);
+    }
+  }
+
+  @Override
+  public void destroy() {
+    // no-op
+  }
+
+  @Override
+  public List<Row> execute(List<Row> rows, ExecutorContext context)
+    throws DirectiveExecutionException, ErrorRowException {
+    for (Row row : rows) {
+      int idx = row.find(column);
+      if (idx != -1) {
+        Object object = row.getValue(idx);
+        // If the data in the cell is null or is already of date format, then
+        // continue to next row.
+        if (object == null || object instanceof ZonedDateTime) {
+          continue;
+        }
+
+        long longValue = getLongValue(object);
+        ZonedDateTime zonedDateTime = getZonedDateTime(longValue, timeUnit, ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+        row.setValue(idx, zonedDateTime);
+      }
+    }
+    return rows;
+  }
+
+  private static TimeUnit getTimeUnit(String unitValue) throws DirectiveParseException {
+    TimeUnit unit;
+
+    try {
+      unit = TimeUnit.valueOf(unitValue.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new DirectiveParseException(String.format("'%s' is not a supported time unit. Supported time " +
+                                                        "units are %s", unitValue, SUPPORTED_TIME_UNITS));
+    }
+
+    if (!SUPPORTED_TIME_UNITS.contains(unit)) {
+      throw new DirectiveParseException(String.format("'%s' is not a supported time unit. Supported time " +
+                                                        "units are %s", unitValue, SUPPORTED_TIME_UNITS));
+    }
+
+    return unit;
+  }
+
+  private long getLongValue(Object object) throws ErrorRowException {
+    String errorMsg = String.format("%s : Invalid type '%s' of column '%s'. Must be of type Long or String.",
+                                    toString(), object.getClass().getName(), column);
+    try {
+      if (object instanceof Long) {
+        return  (long) object;
+      } else if (object instanceof String) {
+        return Long.parseLong((String) object);
+      }
+    } catch (Exception e) {
+      // Exception while casting the object, do not handle it here, so that ErrorRowException is thrown.
+      errorMsg = String.format("%s : Invalid value for column '%s'. Must be of type Long or String representing long.",
+                               toString(), column);
+    }
+
+    throw new ErrorRowException(errorMsg, 2);
+  }
+
+  private ZonedDateTime getZonedDateTime(long ts, TimeUnit unit, ZoneId zoneId) {
+    long mod = unit.convert(1, TimeUnit.SECONDS);
+    int fraction = (int) (ts % mod);
+    long tsInSeconds = unit.toSeconds(ts);
+    // create an Instant with time in seconds and fraction which will be stored as nano seconds.
+    Instant instant = Instant.ofEpochSecond(tsInSeconds, unit.toNanos(fraction));
+    return ZonedDateTime.ofInstant(instant, zoneId);
+  }
+}

--- a/wrangler-core/src/main/java/co/cask/functions/Dates.java
+++ b/wrangler-core/src/main/java/co/cask/functions/Dates.java
@@ -18,11 +18,17 @@ package co.cask.functions;
 
 import co.cask.wrangler.dq.TypeInference;
 import org.joda.time.DateTime;
-import org.joda.time.Days;
+import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.joda.time.Seconds;
 
-import java.util.Date;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.TimeZone;
+
+import static java.time.temporal.ChronoField.ERA;
+import static java.time.temporal.ChronoUnit.DAYS;
 
 /**
  * Collection of useful expression functions made available in the context
@@ -37,8 +43,9 @@ public final class Dates {
    * @param date to be converted to unix timestamp.
    * @return unixtimestamp of the date.
    */
-  public static long UNIXTIMESTAMP_MILLIS(Date date) {
-    return date.getTime();
+  public static long UNIXTIMESTAMP_MILLIS(ZonedDateTime date) {
+    validate(date, "UNIXTIMESTAMP_MILLIS");
+    return date.toInstant().toEpochMilli();
   }
 
   /**
@@ -47,22 +54,22 @@ public final class Dates {
    * @param date to be converted to unix timestamp.
    * @return unixtimestamp of the date.
    */
-  public static long UNIXTIMESTAMP_SECONDS(Date date) {
-    return date.getTime() / 1000;
+  public static long UNIXTIMESTAMP_SECONDS(ZonedDateTime date) {
+    validate(date, "UNIXTIMESTAMP_SECONDS");
+    return date.toEpochSecond();
   }
 
   /**
-   * Converts a {@link Date} to Month in year.
+   * Converts a {@link ZonedDateTime} to Month in year.
    * <p>
    *   January is 1, February is 2, and so on.
    * </p>
    * @param date to extract month.
    * @return month.
    */
-  public static int MONTH(Date date) {
-    DateTime dt = new DateTime(date);
-    DateTime.Property pMoY = dt.monthOfYear();
-    return pMoY.get();
+  public static int MONTH(ZonedDateTime date) {
+    validate(date, "MONTH");
+    return date.getMonthValue();
   }
 
   /**
@@ -71,8 +78,9 @@ public final class Dates {
    * @param date to extract short month description.
    * @return short month description.
    */
-  public static String MONTH_SHORT(Date date) {
-    DateTime dt = new DateTime(date);
+  public static String MONTH_SHORT(ZonedDateTime date) {
+    validate(date, "MONTH_SHORT");
+    DateTime dt = getDateTime(date);
     DateTime.Property pMoY = dt.monthOfYear();
     return pMoY.getAsShortText();
   }
@@ -83,8 +91,9 @@ public final class Dates {
    * @param date to extract long month description.
    * @return long month description.
    */
-  public static String MONTH_LONG(Date date) {
-    DateTime dt = new DateTime(date);
+  public static String MONTH_LONG(ZonedDateTime date) {
+    validate(date, "MONTH_LONG");
+    DateTime dt = getDateTime(date);
     DateTime.Property pMoY = dt.monthOfYear();
     return pMoY.getAsText();
   }
@@ -95,9 +104,9 @@ public final class Dates {
    * @param date to extract year from.
    * @return year as integer.
    */
-  public static int YEAR(Date date) {
-    DateTime dt = new DateTime(date);
-    return dt.getYear();
+  public static int YEAR(ZonedDateTime date) {
+    validate(date, "YEAR");
+    return date.getYear();
   }
 
   /**
@@ -106,10 +115,9 @@ public final class Dates {
    * @param date to extract date of the week.
    * @return day of the week.
    */
-  public static int DAY_OF_WEEK(Date date) {
-    DateTime dt = new DateTime(date);
-    DateTime.Property value = dt.dayOfWeek();
-    return value.get();
+  public static int DAY_OF_WEEK(ZonedDateTime date) {
+    validate(date, "DAY_OF_WEEK");
+    return date.getDayOfWeek().getValue();
   }
 
   /**
@@ -118,8 +126,9 @@ public final class Dates {
    * @param date to extract date of the week.
    * @return day of the week.
    */
-  public static String DAY_OF_WEEK_SHORT(Date date) {
-    DateTime dt = new DateTime(date);
+  public static String DAY_OF_WEEK_SHORT(ZonedDateTime date) {
+    validate(date, "DAY_OF_WEEK_SHORT");
+    DateTime dt = getDateTime(date);
     DateTime.Property value = dt.dayOfWeek();
     return value.getAsShortText();
   }
@@ -130,8 +139,9 @@ public final class Dates {
    * @param date to extract date of the week.
    * @return day of the week.
    */
-  public static String DAY_OF_WEEK_LONG(Date date) {
-    DateTime dt = new DateTime(date);
+  public static String DAY_OF_WEEK_LONG(ZonedDateTime date) {
+    validate(date, "DAY_OF_WEEK_LONG");
+    DateTime dt = getDateTime(date);
     DateTime.Property value = dt.dayOfWeek();
     return value.getAsText();
   }
@@ -142,10 +152,9 @@ public final class Dates {
    * @param date to extract date of the year.
    * @return date of the year.
    */
-  public static int DAY_OF_YEAR(Date date) {
-    DateTime dt = new DateTime(date);
-    DateTime.Property value = dt.dayOfYear();
-    return value.get();
+  public static int DAY_OF_YEAR(ZonedDateTime date) {
+    validate(date, "DAY_OF_YEAR");
+    return date.getDayOfYear();
   }
 
   /**
@@ -154,10 +163,9 @@ public final class Dates {
    * @param date to extract era.
    * @return era.
    */
-  public static int ERA(Date date) {
-    DateTime dt = new DateTime(date);
-    DateTime.Property value = dt.era();
-    return value.get();
+  public static int ERA(ZonedDateTime date) {
+    validate(date, "ERA");
+    return date.get(ERA);
   }
 
   /**
@@ -166,8 +174,9 @@ public final class Dates {
    * @param date to extract era.
    * @return era.
    */
-  public static String ERA_SHORT(Date date) {
-    DateTime dt = new DateTime(date);
+  public static String ERA_SHORT(ZonedDateTime date) {
+    validate(date, "ERA_SHORT");
+    DateTime dt = getDateTime(date);
     DateTime.Property value = dt.era();
     return value.getAsShortText();
   }
@@ -178,8 +187,9 @@ public final class Dates {
    * @param date to extract era.
    * @return era.
    */
-  public static String ERA_LONG(Date date) {
-    DateTime dt = new DateTime(date);
+  public static String ERA_LONG(ZonedDateTime date) {
+    validate(date, "ERA_LONG");
+    DateTime dt = getDateTime(date);
     DateTime.Property value = dt.era();
     return value.getAsText();
   }
@@ -191,10 +201,10 @@ public final class Dates {
    * @param date2 Second date.
    * @return Number of days.
    */
-  public static int DAYS_BETWEEN(Date date1, Date date2) {
-    DateTime dt1 = new DateTime(date1);
-    DateTime dt2 = new DateTime(date2);
-    return Days.daysBetween(dt1, dt2).getDays();
+  public static int DAYS_BETWEEN(ZonedDateTime date1, ZonedDateTime date2) {
+    validate(date1, "ERA_LONG");
+    validate(date2, "ERA_LONG");
+    return (int) DAYS.between(date1, date2);
   }
 
   /**
@@ -203,10 +213,11 @@ public final class Dates {
    * @param date Now - this date.
    * @return Number of days.
    */
-  public static int DAYS_BETWEEN_NOW(Date date) {
-    DateTime dt1 = new DateTime();
-    DateTime dt2 = new DateTime(date);
-    return Days.daysBetween(dt1, dt2).getDays();
+  public static int DAYS_BETWEEN_NOW(ZonedDateTime date) {
+    validate(date, "DAYS_BETWEEN_NOW");
+    ZonedDateTime now = ZonedDateTime.now(ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+    // returns number of days between date and now, date being lower.
+    return (int) DAYS.between(date, now);
   }
 
   /**
@@ -271,5 +282,17 @@ public final class Dates {
    */
   public static boolean isTime(String value) {
     return TypeInference.isTime(value);
+  }
+
+  private static DateTime getDateTime(ZonedDateTime zonedDateTime) {
+    return new DateTime(
+      zonedDateTime.toInstant().toEpochMilli(),
+      DateTimeZone.forTimeZone(TimeZone.getTimeZone(zonedDateTime.getZone())));
+  }
+
+  private static void validate(ZonedDateTime date, String method) {
+    if (date == null) {
+      throw new IllegalArgumentException(String.format("Date can not be null for %s", method));
+    }
   }
 }

--- a/wrangler-core/src/test/java/co/cask/directives/transformation/ParseTimestampTest.java
+++ b/wrangler-core/src/test/java/co/cask/directives/transformation/ParseTimestampTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.directives.transformation;
+
+import co.cask.wrangler.TestingRig;
+import co.cask.wrangler.api.RecipeException;
+import co.cask.wrangler.api.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class ParseTimestampTest {
+  @Test
+  public void testParseTimestamp() throws Exception {
+    String[] directives = new String[] {
+      "parse-timestamp :date1",
+      "parse-timestamp :date2",
+      "parse-timestamp :date3",
+      "parse-timestamp :date4 'seconds'",
+      "parse-timestamp :date5 'milliseconds'",
+      "parse-timestamp :date6 'microseconds'"
+    };
+
+    Row row1 = new Row();
+    row1.add("date1", 1536332271894L);
+    row1.add("date2", null);
+    row1.add("date3", "1536332271894");
+    row1.add("date4", "1536332271");
+    row1.add("date5", "1536332271894");
+    row1.add("date6", "1536332271894123");
+
+    List<Row> rows = TestingRig.execute(directives, Arrays.asList(row1));
+    ZonedDateTime dateTime = ZonedDateTime.of(2018, 9, 7, 14, 57, 51,
+                                              Math.toIntExact(TimeUnit.MILLISECONDS.toNanos(894)),
+                                              ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+    Assert.assertEquals(dateTime, rows.get(0).getValue("date1"));
+    Assert.assertNull(rows.get(0).getValue("date2"));
+    Assert.assertEquals(dateTime, rows.get(0).getValue("date3"));
+    Assert.assertEquals(dateTime.minusNanos(TimeUnit.MILLISECONDS.toNanos(894)), rows.get(0).getValue("date4"));
+    Assert.assertEquals(dateTime, rows.get(0).getValue("date5"));
+    Assert.assertEquals(dateTime.plusNanos(TimeUnit.MILLISECONDS.toMicros(123)), rows.get(0).getValue("date6"));
+  }
+
+  @Test(expected = RecipeException.class)
+  public void testInvalidTimestamp() throws Exception {
+    String[] directives = new String[] {
+      "parse-timestamp :date1 'nanoseconds'"
+    };
+
+    Row row1 = new Row();
+    row1.add("date1", 1536332271894L);
+
+    List<Row> rows = TestingRig.execute(directives, Arrays.asList(row1));
+  }
+}

--- a/wrangler-core/src/test/java/co/cask/functions/ExpressionTest.java
+++ b/wrangler-core/src/test/java/co/cask/functions/ExpressionTest.java
@@ -25,6 +25,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -154,6 +157,47 @@ public class ExpressionTest {
     rows = TestingRig.execute(directives, rows);
 
     Assert.assertTrue(rows.size() == 1);
+
+    ZonedDateTime date = ZonedDateTime.of(2017, 2, 2, 21, 6, 44, 0, ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+    ZonedDateTime other = ZonedDateTime.of(2017, 2, 3, 21, 6, 44, 0, ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+    Assert.assertEquals(date, rows.get(0).getValue("date"));
+    Assert.assertEquals(other, rows.get(0).getValue("other"));
+    Assert.assertEquals(1486069604000L, rows.get(0).getValue("unixtimestamp"));
+    Assert.assertEquals(2, rows.get(0).getValue("month_no"));
+    Assert.assertEquals("Feb", rows.get(0).getValue("month_short"));
+    Assert.assertEquals("February", rows.get(0).getValue("month_long"));
+    Assert.assertEquals(2017, rows.get(0).getValue("year"));
+    Assert.assertEquals(33, rows.get(0).getValue("day_of_year"));
+    Assert.assertEquals("AD", rows.get(0).getValue("era_long"));
+    Assert.assertEquals(1, rows.get(0).getValue("days"));
+    Assert.assertEquals(24, rows.get(0).getValue("hours"));
+    Assert.assertEquals(1, rows.get(0).getValue("diff"));
+  }
+
+  @Test(expected = RecipeException.class)
+  public void testInvalidDateFunction() throws Exception {
+    String[] directives = new String[] {
+      "parse-as-simple-date date yyyy-MM-dd'T'HH:mm:ss",
+      "parse-as-simple-date other yyyy-MM-dd'T'HH:mm:ss",
+      "set-column unixtimestamp date:UNIXTIMESTAMP_MILLIS(date)",
+      "set-column month_no date:MONTH(date)",
+      "set-column month_short date:MONTH_SHORT(date)",
+      "set-column month_long date:MONTH_LONG(date)",
+      "set-column year date:YEAR(date)",
+      "set-column day_of_year date:DAY_OF_YEAR(date)",
+      "set-column era_long date:ERA_LONG(date)",
+      "set-column days date:SECONDS_TO_DAYS(seconds)",
+      "set-column hours date:SECONDS_TO_HOURS(seconds)",
+      "set-column diff_days date:DAYS_BETWEEN_NOW(date)",
+      "set-column diff date:DAYS_BETWEEN(date, other)"
+    };
+
+    //2017-02-02T21:06:44Z
+    List<Row> rows = Arrays.asList(
+      new Row("date", null).add("seconds", 86401).add("other", "2017-02-03T21:06:44Z")
+    );
+
+    rows = TestingRig.execute(directives, rows);
   }
 
   @Test

--- a/wrangler-core/src/test/java/co/cask/wrangler/registry/CompositeDirectiveRegistryTest.java
+++ b/wrangler-core/src/test/java/co/cask/wrangler/registry/CompositeDirectiveRegistryTest.java
@@ -130,7 +130,7 @@ public class CompositeDirectiveRegistryTest {
       iterator.next();
       count++;
     }
-    Assert.assertEquals(78, count);
+    Assert.assertEquals(79, count);
 
     registry.reload();
 
@@ -140,7 +140,7 @@ public class CompositeDirectiveRegistryTest {
       iterator.next();
       count++;
     }
-    Assert.assertEquals(78, count);
+    Assert.assertEquals(79, count);
 
   }
 }

--- a/wrangler-docs/directives/parse-timestamp.md
+++ b/wrangler-docs/directives/parse-timestamp.md
@@ -1,0 +1,22 @@
+# Parse Timestamp
+
+The PARSE-TIMESTAMP directive parses column values representing unix timestamp as date.
+
+
+## Syntax
+```
+parse-timestamp :<column> '<timeunit>'
+```
+
+
+## Usage Notes
+
+The PARSE-TIMESTAMP directive will parse a column representing Unix timestamp. The column type can be string or long.
+ long or string as date objects. The directive also has optional parameter timeunit which can be seconds, milliseconds
+ or microseconds. The default timeunit is milliseconds. If the column is `null` or has already been parsed as a date,
+ applying this directive is a no-op. The column to be parsed as a date should be of type string.
+
+
+## Examples
+if the column has unix timestamp 1536332271894 or "1536332271894", then after applying this directive,
+the column value represents date equivalent of UTC: Friday, September 7, 2018 2:57:51.894 PM.


### PR DESCRIPTION
**Summary**

- Changes to support date/time in expressions
- Added actual test to test values in `ExpressionTest`
- Added a directive `parse-timestamp-as-date` to convert unix timestamp in millis to ZonedDateTime.
- Added corresponding test for `parse-timestamp-as-date`

https://builds.cask.co/browse/HYP-WT205-9