### PR TITLE
fixing default connection behavior

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/dataset/AbstractTableStore.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/dataset/AbstractTableStore.java
@@ -165,12 +165,12 @@ public abstract class AbstractTableStore<T> {
   }
 
   /**
-   * Mangles the name.
+   * Get connection id for the given connection name
    *
-   * @param name to be mangled.
-   * @return mangled name.
+   * @param name name of the connection.
+   * @return connection id.
    */
-  protected String mangle(String name) {
+  public String getConnectionId(String name) {
     name = name.trim();
     // Lower case columns
     name = name.toLowerCase();

--- a/wrangler-service/src/main/java/co/cask/wrangler/dataset/connections/ConnectionStore.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/dataset/connections/ConnectionStore.java
@@ -73,7 +73,7 @@ public class ConnectionStore extends AbstractTableStore<Connection> {
         String.format("Connection name '%s' already exists.", name)
       );
     }
-    String mangled = mangle(name);
+    String mangled = getConnectionId(name);
     connection.setId(mangled);
     connection.setCreated(now());
     connection.setUpdated(now());
@@ -89,7 +89,7 @@ public class ConnectionStore extends AbstractTableStore<Connection> {
    */
   @Override
   public void update(String id, Connection connection) {
-    if(!hasKey(id)) {
+    if (!hasKey(id)) {
       throw new IllegalArgumentException(
         String.format("Connection '%s' does not exists. Create connection before updating", id)
       );
@@ -120,7 +120,7 @@ public class ConnectionStore extends AbstractTableStore<Connection> {
    * Returns true if connection identified by connectionName already exists
    */
   public boolean connectionExists(String connectionName) {
-    String mangled = mangle(connectionName);
+    String mangled = getConnectionId(connectionName);
     return hasKey(mangled);
   }
 }


### PR DESCRIPTION
When listing connections, check if the configured default connection for ui landing exists in connection list. 

When deleting a connection, check if its configured as a default connection and disallow deleting a connection if it is a default connection.

Reasoning behind this : 

1) We create default connections during service handler initialize, however the initialize gets called on each handler thread initialization, which can happen quite often, hence even if a default connection is deleted, it gets immediately recreated. Also we don't want to store the state of default connection creation/deletion in a table to workaround that, as the admin can make changes to the config to make certain default connections as non-default and at that time we want (and will) to allow those connections to be deletable. 

2) If there was a lifecycle phase such as prepareRun in service that runs only once, it would have been ideal to create the default connections during that phase. the default connection would gets recreated on DataPrep re-initialization if a user has deleted it would have been ideal. However we don't have that option currently.

This trade-off of disallowing users to delete a default connection isn't too bad as if the users doesn't want a default connection, they can contact the administrators about changing the app config for DataPrep and it can be removed from the config.

JIRA : https://issues.cask.co/browse/CDAP-14270
