### PR TITLE
Add a whitelist property to GCS and BigQuery connections

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
@@ -36,6 +36,7 @@ import com.google.api.gax.paging.Page;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.FieldValue;
@@ -47,11 +48,15 @@ import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryResult;
 import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.HttpURLConnection;
 import java.time.Instant;
@@ -61,9 +66,14 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.GET;
@@ -75,8 +85,11 @@ import javax.ws.rs.QueryParam;
 import static co.cask.wrangler.ServiceUtils.error;
 import static co.cask.wrangler.ServiceUtils.sendJson;
 
-
+/**
+ * Service for testing, browsing, and reading using a BigQuery connection.
+ */
 public class BigQueryService extends AbstractWranglerService {
+  private static final Logger LOG = LoggerFactory.getLogger(BigQueryService.class);
   private static final String DATASET_ID = "datasetId";
   private static final String TABLE_ID = "id";
   private static final String SCHEMA = "schema";
@@ -112,7 +125,7 @@ public class BigQueryService extends AbstractWranglerService {
   }
 
   /**
-   * List all Datasets.
+   * List all datasets.
    *
    * @param request HTTP requets handler.
    * @param responder HTTP response handler.
@@ -126,12 +139,20 @@ public class BigQueryService extends AbstractWranglerService {
     if (!validateConnection(connectionId, connection, responder)) {
       return;
     }
+
     BigQuery bigQuery = GCPUtils.getBigQueryService(connection);
-    Page<Dataset> datasets = bigQuery.listDatasets(BigQuery.DatasetListOption.all());
+    String connectionProject = GCPUtils.getProjectId(connection);
+    Set<DatasetId> datasetWhitelist = getDatasetWhitelist(connection);
     JsonArray values = new JsonArray();
-    for (Dataset dataset : datasets.iterateAll()) {
+    for (Dataset dataset : getDatasets(bigQuery, datasetWhitelist)) {
       JsonObject object =  new JsonObject();
-      object.addProperty("name", dataset.getDatasetId().getDataset());
+      String name = dataset.getDatasetId().getDataset();
+      String datasetProject = dataset.getDatasetId().getProject();
+      // if the dataset is not in the connection's project, add the <project>: to the front of the name
+      if (!connectionProject.equals(datasetProject)) {
+        name = new StringJoiner(":").add(datasetProject).add(name).toString();
+      }
+      object.addProperty("name", name);
       object.addProperty("created", dataset.getCreationTime());
       object.addProperty("description", dataset.getDescription());
       object.addProperty("last-modified", dataset.getLastModified());
@@ -147,27 +168,32 @@ public class BigQueryService extends AbstractWranglerService {
   }
 
   /**
-   * List all Datasets.
+   * List all tables in a dataset.
    *
    * @param request HTTP requets handler.
    * @param responder HTTP response handler.
+   * @param datasetStr the dataset id as a string. It will be of the form [project:]name.
+   *   The project prefix is optional. When not given, the connection project should be used.
    */
   @GET
   @Path("connections/{connection-id}/bigquery/{dataset-id}/tables")
   public void listTables(HttpServiceRequest request, HttpServiceResponder responder,
-                           @PathParam("connection-id") String connectionId,
-                           @PathParam("dataset-id") String datasetId) throws Exception {
+                         @PathParam("connection-id") String connectionId,
+                         @PathParam("dataset-id") String datasetStr) throws Exception {
     Connection connection = store.get(connectionId);
 
     if (!validateConnection(connectionId, connection, responder)) {
       return;
     }
     BigQuery bigQuery = GCPUtils.getBigQueryService(connection);
+
+    DatasetId datasetId = getDatasetId(datasetStr, GCPUtils.getProjectId(connection));
+
     try {
-      Page<com.google.cloud.bigquery.Table> tablePage = bigQuery.listTables(datasetId);
+      Page<Table> tablePage = bigQuery.listTables(datasetId);
       JsonArray values = new JsonArray();
 
-      for (com.google.cloud.bigquery.Table table : tablePage.iterateAll()) {
+      for (Table table : tablePage.iterateAll()) {
         JsonObject object = new JsonObject();
 
         object.addProperty("name", table.getFriendlyName());
@@ -198,22 +224,22 @@ public class BigQueryService extends AbstractWranglerService {
   }
 
   /**
-   * List all Datasets.
+   * Read a table.
    *
    * @param request HTTP requets handler.
    * @param responder HTTP response handler.
    * @param connectionId Connection Id for BigQuery Service.
-   * @param datasetId id of the dataset on BigQuery.
+   * @param datasetStr id of the dataset on BigQuery.
    * @param tableId id of the BigQuery table.
    * @param scope Group the workspace is created in.
    */
   @GET
   @Path("connections/{connection-id}/bigquery/{dataset-id}/tables/{table-id}/read")
   public void readTable(HttpServiceRequest request, HttpServiceResponder responder,
-                           @PathParam("connection-id") String connectionId,
-                           @PathParam("dataset-id") String datasetId,
-                           @PathParam("table-id") String tableId,
-                           @QueryParam("scope") String scope) throws Exception {
+                        @PathParam("connection-id") String connectionId,
+                        @PathParam("dataset-id") String datasetStr,
+                        @PathParam("table-id") String tableId,
+                        @QueryParam("scope") String scope) throws Exception {
     Connection connection = store.get(connectionId);
 
     if (!validateConnection(connectionId, connection, responder)) {
@@ -225,11 +251,10 @@ public class BigQueryService extends AbstractWranglerService {
     }
 
     Map<String, String> connectionProperties = connection.getAllProps();
-    String projectId = connectionProperties.get(GCPUtils.PROJECT_ID);
+    DatasetId datasetId = getDatasetId(datasetStr, GCPUtils.getProjectId(connection));
     String path = connectionProperties.get(GCPUtils.SERVICE_ACCOUNT_KEYFILE);
     String bucket = connectionProperties.get(BUCKET);
-    TableId tableIdObject =
-      projectId == null ? TableId.of(datasetId, tableId) : TableId.of(projectId, datasetId, tableId);
+    TableId tableIdObject = TableId.of(datasetId.getProject(), datasetId.getDataset(), tableId);
     Pair<List<Row>, Schema> tableData = getData(connection, tableIdObject);
 
     String identifier = ServiceUtils.generateMD5(String.format("%s:%s", scope, tableId));
@@ -239,14 +264,13 @@ public class BigQueryService extends AbstractWranglerService {
     ws.writeToWorkspace(identifier, WorkspaceDataset.DATA_COL, DataType.RECORDS, data);
 
     Map<String, String> properties = new HashMap<>();
-    properties.put(PropertyIds.ID, identifier);
     properties.put(PropertyIds.NAME, tableId);
     properties.put(PropertyIds.CONNECTION_TYPE, ConnectionType.BIGQUERY.getType());
     properties.put(PropertyIds.SAMPLER_TYPE, SamplingMethod.NONE.getMethod());
     properties.put(PropertyIds.CONNECTION_ID, connectionId);
     properties.put(TABLE_ID, tableId);
-    properties.put(DATASET_ID, datasetId);
-    properties.put(GCPUtils.PROJECT_ID, projectId);
+    properties.put(DATASET_ID, datasetId.getDataset());
+    properties.put(GCPUtils.PROJECT_ID, datasetId.getProject());
     properties.put(GCPUtils.SERVICE_ACCOUNT_KEYFILE, path);
     properties.put(SCHEMA, tableData.getSecond().toString());
     properties.put(BUCKET, bucket);
@@ -457,5 +481,89 @@ public class BigQueryService extends AbstractWranglerService {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Parses the dataset whitelist in the connection properties into a set of DatasetId.
+   * The whitelist is expected to be a comma separated list of dataset ids, where each dataset id is of the form:
+   *
+   * [project:]name
+   *
+   * The project is optional. If it is not given, it is assumed that the dataset is in the connection project.
+   *
+   * For example, consider the following whitelist:
+   *
+   * abc:articles,123:d10,d11
+   *
+   * If the connection is in project 'abc', this will be parsed into 3 dataset ids --
+   * [abc,articles], [123,d10], and [abc,d11].
+   */
+  @VisibleForTesting
+  static Set<DatasetId> getDatasetWhitelist(Connection connection) {
+    String connectionProject = GCPUtils.getProjectId(connection);
+    String whitelistStr = connection.getAllProps().get("datasetWhitelist");
+    Set<DatasetId> whitelist = new LinkedHashSet<>();
+    if (whitelistStr == null) {
+      return whitelist;
+    }
+    for (String whitelistedDataset : whitelistStr.split(",")) {
+      whitelistedDataset = whitelistedDataset.trim();
+      // whitelistedDataset should be of the form <project>:<dataset>, or just <dataset>
+      // if it ends with ':', the admin provided an invalid entry in the whitelist and it should be ignored.
+      if (whitelistedDataset.endsWith(":")) {
+        continue;
+      }
+      int idx = whitelistedDataset.indexOf(':');
+      if (idx > 0) {
+        String datasetProject = whitelistedDataset.substring(0, idx);
+        String datasetName = whitelistedDataset.substring(idx + 1);
+        whitelist.add(DatasetId.of(datasetProject, datasetName));
+      } else if (idx == 0) {
+        // if the value is :<dataset>, treat it like it's just <dataset>
+        whitelist.add(DatasetId.of(connectionProject, whitelistedDataset.substring(1)));
+      } else {
+        whitelist.add(DatasetId.of(connectionProject, whitelistedDataset));
+      }
+    }
+    return whitelist;
+  }
+
+  private DatasetId getDatasetId(String datasetStr, String connectionProject) {
+    int idx = datasetStr.indexOf(":");
+    if (idx > 0) {
+      String project = datasetStr.substring(0, idx);
+      String name = datasetStr.substring(idx + 1);
+      return DatasetId.of(project, name);
+    }
+    return DatasetId.of(connectionProject, datasetStr);
+  }
+
+  private Collection<Dataset> getDatasets(BigQuery bigQuery, Set<DatasetId> datasetWhitelist) {
+    // this will include datasets that can be listed by the service account, but may not include all datasets
+    // in the whitelist, if the whitelist contains publicly accessible datasets from other projects.
+    // do some post-processing to filter out anything not in the whitelist and also try and lookup datasets
+    // that are in the whitelist but not in the returned list
+    Page<Dataset> datasets = bigQuery.listDatasets(BigQuery.DatasetListOption.all());
+    Set<DatasetId> missingDatasets = new HashSet<>(datasetWhitelist);
+    List<Dataset> output = new ArrayList<>();
+    for (Dataset dataset : datasets.iterateAll()) {
+      missingDatasets.remove(dataset.getDatasetId());
+      if (datasetWhitelist.isEmpty() || datasetWhitelist.contains(dataset.getDatasetId())) {
+        output.add(dataset);
+      }
+    }
+    // this only contains datasets that are in the whitelist but were not returned by the list call
+    for (DatasetId whitelistDataset : missingDatasets) {
+      try {
+        Dataset dataset = bigQuery.getDataset(whitelistDataset);
+        if (dataset != null) {
+          output.add(dataset);
+        }
+      } catch (BigQueryException e) {
+        // ignore and move on
+        LOG.debug("Exception getting dataset {} from the whitelist.", whitelistDataset, e);
+      }
+    }
+    return output;
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcp/GCPUtils.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcp/GCPUtils.java
@@ -25,8 +25,6 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,7 +35,6 @@ import java.io.IOException;
  * Class description here.
  */
 public final class GCPUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(GCPUtils.class);
   public static final String PROJECT_ID = "projectId";
   public static final String SERVICE_ACCOUNT_KEYFILE = "service-account-keyfile";
 
@@ -84,13 +81,13 @@ public final class GCPUtils {
    */
   public static Spanner getSpannerService(Connection connection) throws Exception {
     SpannerOptions.Builder optionsBuilder = SpannerOptions.newBuilder();
-    if (connection.hasProperty(GCPUtils.SERVICE_ACCOUNT_KEYFILE)) {
-      String path = connection.getAllProps().get(GCPUtils.SERVICE_ACCOUNT_KEYFILE);
+    if (connection.hasProperty(SERVICE_ACCOUNT_KEYFILE)) {
+      String path = connection.getAllProps().get(SERVICE_ACCOUNT_KEYFILE);
       optionsBuilder.setCredentials(loadLocalFile(path));
     }
 
-    String projectId = connection.hasProperty(GCPUtils.PROJECT_ID) ?
-      connection.getProp(GCPUtils.PROJECT_ID) : ServiceOptions.getDefaultProjectId();
+    String projectId = connection.hasProperty(PROJECT_ID) ?
+      connection.getProp(PROJECT_ID) : ServiceOptions.getDefaultProjectId();
     if (projectId == null) {
       throw new IllegalArgumentException("Could not detect Google Cloud project id from the environment. " +
                                            "Please specify a project id for the connection.");
@@ -104,14 +101,22 @@ public final class GCPUtils {
    * set credentials and project_id if those are provided in the input connection
    */
   private static void setProperties(Connection connection, ServiceOptions.Builder serviceOptions) throws Exception {
-    if (connection.hasProperty(GCPUtils.SERVICE_ACCOUNT_KEYFILE)) {
-      String path = connection.getAllProps().get(GCPUtils.SERVICE_ACCOUNT_KEYFILE);
+    if (connection.hasProperty(SERVICE_ACCOUNT_KEYFILE)) {
+      String path = connection.getAllProps().get(SERVICE_ACCOUNT_KEYFILE);
       serviceOptions.setCredentials(loadLocalFile(path));
     }
-    if (connection.hasProperty(GCPUtils.PROJECT_ID)) {
-      String projectId = connection.getAllProps().get(GCPUtils.PROJECT_ID);
+    if (connection.hasProperty(PROJECT_ID)) {
+      String projectId = connection.getAllProps().get(PROJECT_ID);
       serviceOptions.setProjectId(projectId);
     }
+  }
+
+  /**
+   * Get the project id for the connection
+   */
+  public static String getProjectId(Connection connection) {
+    String projectId = connection.getAllProps().get(GCPUtils.PROJECT_ID);
+    return projectId == null ? ServiceOptions.getDefaultProjectId() : projectId;
   }
 
   private GCPUtils() {

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/bigquery/BigQueryServiceTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/bigquery/BigQueryServiceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.service.bigquery;
+
+import co.cask.wrangler.dataset.connections.Connection;
+import co.cask.wrangler.service.connections.ConnectionType;
+import co.cask.wrangler.service.gcp.GCPUtils;
+import com.google.cloud.bigquery.DatasetId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tests for {@link BigQueryService}.
+ */
+public class BigQueryServiceTest {
+
+  @Test
+  public void testDatasetWhitelistParsing() {
+    Connection connection = new Connection();
+    connection.setType(ConnectionType.BIGQUERY);
+    connection.setName("test");
+    connection.setId("test");
+    connection.putProp(GCPUtils.PROJECT_ID, "pX");
+    // [p0,d0], [p1,d1], 'p2:' is invalid and should be ignored, [pX,d2], [pX,d3]
+    connection.putProp("datasetWhitelist", "p0:d0 , p1:d1 , p2: , d2 , :d3");
+
+    Set<DatasetId> expected = new HashSet<>();
+    expected.add(DatasetId.of("p0", "d0"));
+    expected.add(DatasetId.of("p1", "d1"));
+    expected.add(DatasetId.of("pX", "d2"));
+    expected.add(DatasetId.of("pX", "d3"));
+    Set<DatasetId> actual = BigQueryService.getDatasetWhitelist(connection);
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/wrangler-transform/pom.xml
+++ b/wrangler-transform/pom.xml
@@ -13,7 +13,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
     </pluginRepository>
   </pluginRepositories>
 
@@ -107,11 +107,11 @@
       <plugin>
         <groupId>co.cask</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[4.0.0,6.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[4.0.0,6.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[5.0.0,6.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[5.0.0,6.0.0-SNAPSHOT)</parent>
             <parent>system:mmds-app[1.0.0-SNAPSHOT,2.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>


### PR DESCRIPTION
The whitelist will ensure that only GCS buckets or BigQuery
datasets contained in the whitelist will be shown when browsing.
The whitelist can also contain public buckets or datasets that
normally would not be shown during browsing.

Also performing some general cleanup. Switched to a release
version of the cdap maven plugin instead of a snapshot version
and updated the minimum pipeline parent versions to 5.0.0, as the
wrangler transform uses field level lineage APIs that were only
introduced with 5.0.0.