### PR TITLE
CDAP-14372 make directives nullable

### DIFF
--- a/wrangler-core/src/main/java/co/cask/wrangler/parser/MigrateToV2.java
+++ b/wrangler-core/src/main/java/co/cask/wrangler/parser/MigrateToV2.java
@@ -24,6 +24,7 @@ import edu.emory.mathcs.backport.java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+import javax.annotation.Nullable;
 
 import static org.apache.commons.lang3.StringUtils.trim;
 
@@ -50,7 +51,7 @@ public final class MigrateToV2 implements GrammarMigrator {
     this(Arrays.asList(recipe));
   }
 
-  public MigrateToV2(String recipe, String delimiter) {
+  public MigrateToV2(@Nullable String recipe, String delimiter) {
     this(recipe != null ? recipe.trim().split(delimiter) : new String[]{});
   }
 

--- a/wrangler-transform/src/main/java/co/cask/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/co/cask/wrangler/Wrangler.java
@@ -142,7 +142,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
       }
 
       String directives = config.directives;
-      if(config.udds != null && !config.udds.trim().isEmpty()) {
+      if (config.udds != null && !config.udds.trim().isEmpty()) {
         if (config.containsMacro("directives")) {
           directives = String.format("#pragma load-directives %s;", config.udds);
         } else {
@@ -306,7 +306,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
     );
 
     String directives = config.directives;
-    if(config.udds != null && !config.udds.trim().isEmpty()) {
+    if (config.udds != null && !config.udds.trim().isEmpty()) {
       directives = String.format("#pragma load-directives %s;%s", config.udds, config.directives);
     }
 
@@ -536,6 +536,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
     @Name("directives")
     @Description("Recipe for wrangling the input records")
     @Macro
+    @Nullable
     private String directives;
 
     @Name("udd")


### PR DESCRIPTION
If no directives are given, the transform is a no-op.
The main use case for this is if somebody creates a pipeline from
a connection that doesn't actually transform any data. For example,
if somebody wants to write from one dataset table to another
without transformation.