### PR TITLE
CDAP-14390 fix gcs json and xml files

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/dataset/workspace/DataType.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/dataset/workspace/DataType.java
@@ -26,12 +26,6 @@ public enum DataType {
   // This defines the text files.
   TEXT("text/plain"),
 
-  // This defines the XML files.
-  XML("application/xml"),
-
-  // This defines the JSON files.
-  JSON("application/json"),
-
   // Special format native to Dataprep, this converts the data into records using the delimiter.
   RECORDS("application/data-prep");
 

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
@@ -379,10 +379,10 @@ public class GCSService extends AbstractWranglerService {
           ws.writeToWorkspace(id, WorkspaceDataset.DATA_COL, DataType.RECORDS, records);
           properties.put(PropertyIds.PLUGIN_TYPE, "normal");
         } else if (contentType.equalsIgnoreCase("application/json")) {
-          ws.writeToWorkspace(id, WorkspaceDataset.DATA_COL, DataType.JSON, bytes);
+          ws.writeToWorkspace(id, WorkspaceDataset.DATA_COL, DataType.TEXT, bytes);
           properties.put(PropertyIds.PLUGIN_TYPE, "normal");
         } else if (contentType.equalsIgnoreCase("application/xml")) {
-          ws.writeToWorkspace(id, WorkspaceDataset.DATA_COL, DataType.XML, bytes);
+          ws.writeToWorkspace(id, WorkspaceDataset.DATA_COL, DataType.TEXT, bytes);
           properties.put(PropertyIds.PLUGIN_TYPE, "blob");
         } else {
           ws.writeToWorkspace(id, WorkspaceDataset.DATA_COL, DataType.BINARY, bytes);


### PR DESCRIPTION
The service is using a really half baked system for file types.
There is an enum for Json and XML types, but not way to read
either of those. So anything tagged with those types result in
blank screens.

Removing those types so nobody tries to use them, and switching
their use to TEXT.