### PR TITLE
CDAP-14397 Use text content type for files without extension

### DIFF
--- a/wrangler-service/src/main/resources/file.extensions
+++ b/wrangler-service/src/main/resources/file.extensions
@@ -7,12 +7,12 @@ aam	application/x-authorware-map
 aas	application/x-authorware-seg
 abc	text/vndabc
 acgi	text/html
-adoc  text/plain
+adoc	text/plain
 aim	text/plain
 ans	text/plain
 apt	text/plain
 asc	text/plain
-ascii text/plain
+ascii	text/plain
 afl	video/animaflex
 ai	application/postscript
 aif	audio/aiff
@@ -263,9 +263,8 @@ p7m	application/pkcs7-mime
 p7r	application/x-pkcs7-certreqresp
 p7s	application/pkcs7-signature
 part	application/pro_eng
-parquet application/parquet
-pas	text/pascal
 parquet	application/parquet
+pas	text/pascal
 pb	application/protobuf
 pbm	image/x-portable-bitmap
 pcl	application/vndhp-pcl

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/FileTypeDetectorTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/FileTypeDetectorTest.java
@@ -35,7 +35,8 @@ public class FileTypeDetectorTest {
       "syslog.txt.1",
       "titanic.csv",
       "titanic.csv.1",
-      "titanic.csv.1.2"
+      "titanic.csv.1.2",
+      "noextension"
     };
 
     for (String filename : filenames) {


### PR DESCRIPTION
**Summary**
- Uses text content type for files without extension
- Uses tab instead of space in `file.extensions`.

![image](https://user-images.githubusercontent.com/14131070/46320291-7d20d180-c592-11e8-8f15-e6b784d10114.png)


![image](https://user-images.githubusercontent.com/14131070/46320270-6b3f2e80-c592-11e8-99e0-dd41cedec75c.png)

Build: https://builds.cask.co/browse/HYP-WT219-1