### PR TITLE
CDAP-14355 Improve reference name

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
@@ -309,8 +309,10 @@ public class BigQueryService extends AbstractWranglerService {
 
       Map<String, String> properties = new HashMap<>();
       JsonObject value = new JsonObject();
-
+      String externalDatasetName =
+        new StringJoiner(".").add(config.get(DATASET_ID)).add(config.get(TABLE_ID)).toString();
       JsonObject bigQuery = new JsonObject();
+      properties.put("referenceName", externalDatasetName);
       properties.put("serviceFilePath", config.get(GCPUtils.SERVICE_ACCOUNT_KEYFILE));
       properties.put("bucket", config.get(BUCKET));
       properties.put("project", config.get(GCPUtils.PROJECT_ID));

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerService.java
@@ -61,6 +61,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
@@ -203,8 +204,10 @@ public class SpannerService extends AbstractWranglerService {
       String projectId = connectionProperties.get(GCPUtils.PROJECT_ID);
       String path = connectionProperties.get(GCPUtils.SERVICE_ACCOUNT_KEYFILE);
 
+      String externalDsName = new StringJoiner(".").add(instanceId).add(databaseId).add(tableId).toString();
+
       SpannerSpecification specification =
-        new SpannerSpecification(path, projectId, instanceId, databaseId, tableId, schema);
+        new SpannerSpecification(externalDsName, path, projectId, instanceId, databaseId, tableId, schema);
 
       // initialize and store workspace properties
       Map<String, String> workspaceProperties = new HashMap<>();

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerSpecification.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerSpecification.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.data.schema.Schema;
  * Spanner specification properties for spanner source plugin
  */
 public class SpannerSpecification {
+  private final String referenceName;
   // gcp properties
   private final String serviceFilePath;
   private final String project;
@@ -31,8 +32,9 @@ public class SpannerSpecification {
   private final String table;
   private final String schema;
 
-  SpannerSpecification(String serviceFilePath, String project, String instance,
+  SpannerSpecification(String referenceName, String serviceFilePath, String project, String instance,
                        String database, String table, Schema schema) {
+    this.referenceName = referenceName;
     this.serviceFilePath = serviceFilePath;
     this.project = project;
     this.instance = instance;


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-14355

## Summary
- Improve the referenceName which gets filled in by Wrangler. 
- Ideally we will like these to be unique although gurnating uniqueness in all cases is hard. For example in case of GCS the complete path to a file should be used as reference but the path can be long leading to a long reference name which is not user friendly so we try the best. The platform should fail the deployment if same referenceName is used for different sources.
- The referenceNames might consists of special characters which is not supported in DatasetId. Wrangler does not do any filtering for it. CDAP will fail the deployment if the referenceName consists of invalid chars.(This will come in another PR).
