### PR TITLE
CDAP-12852 hack to copy headers when parse-as-csv is used

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
@@ -474,6 +474,7 @@ public class GCSService extends AbstractWranglerService {
       properties.put("path", uri);
       properties.put("recursive", "false");
       properties.put("filenameOnly", "false");
+      properties.put("copyHeader", String.valueOf(shouldCopyHeader(workspaceId)));
       gcs.add("properties", new Gson().toJsonTree(properties));
       gcs.addProperty("name", "GCSFile");
       gcs.addProperty("type", "source");


### PR DESCRIPTION
Added a hacky workaround that tells pipeline sources to copy
headers if the parse-as-csv directive is used with that directive.