### PR TITLE
Combination of send-to-error-and-continue and send-to-error 

### DIFF
--- a/wrangler-api/src/main/java/co/cask/wrangler/api/TransientStore.java
+++ b/wrangler-api/src/main/java/co/cask/wrangler/api/TransientStore.java
@@ -28,7 +28,7 @@ public interface TransientStore extends Serializable {
   /**
    * Resets the state of this store.
    */
-  void reset();
+  void reset(TransientVariableScope scope);
 
   /**
    * A value associated with the variable in the transient store.
@@ -45,7 +45,7 @@ public interface TransientStore extends Serializable {
    * @param name of the variable for which the value needs to be set.
    * @param value of the variable.
    */
-  void set(String name, Object value);
+  void set(TransientVariableScope scope, String name, Object value);
 
   /**
    * Increments a value of the variable.
@@ -53,7 +53,7 @@ public interface TransientStore extends Serializable {
    * @param name of the variable.
    * @param value associated with the variable.
    */
-  void increment(String name, long value);
+  void increment(TransientVariableScope scope, String name, long value);
 
   /**
    * Set of all the variables.

--- a/wrangler-api/src/main/java/co/cask/wrangler/api/TransientVariableScope.java
+++ b/wrangler-api/src/main/java/co/cask/wrangler/api/TransientVariableScope.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.api;
+
+/**
+ * {@link TransientVariableScope} defines the scope of the transient variable.
+ * The variable can be either LOCAL or GLOBAL.
+ */
+public enum TransientVariableScope {
+  LOCAL,
+  GLOBAL
+}

--- a/wrangler-core/src/main/java/co/cask/directives/aggregates/DefaultTransientStore.java
+++ b/wrangler-core/src/main/java/co/cask/directives/aggregates/DefaultTransientStore.java
@@ -44,7 +44,7 @@ public class DefaultTransientStore implements TransientStore {
    */
   @Override
   public void increment(TransientVariableScope scope, String name, long value) {
-    if(scope == TransientVariableScope.GLOBAL) {
+    if (scope == TransientVariableScope.GLOBAL) {
       increment(global, name, value);
     } else if (scope == TransientVariableScope.LOCAL) {
       increment(local, name, value);
@@ -70,7 +70,7 @@ public class DefaultTransientStore implements TransientStore {
   @Override
   public Set<String> getVariables() {
     Set<String> vars = new HashSet<>();
-    if(global == null && local == null) {
+    if (global == null && local == null) {
       return new HashSet<>();
     }
     if (global != null) {

--- a/wrangler-core/src/main/java/co/cask/directives/aggregates/IncrementTransientVariable.java
+++ b/wrangler-core/src/main/java/co/cask/directives/aggregates/IncrementTransientVariable.java
@@ -26,6 +26,7 @@ import co.cask.wrangler.api.DirectiveParseException;
 import co.cask.wrangler.api.ErrorRowException;
 import co.cask.wrangler.api.ExecutorContext;
 import co.cask.wrangler.api.Row;
+import co.cask.wrangler.api.TransientVariableScope;
 import co.cask.wrangler.api.annotations.Categories;
 import co.cask.wrangler.api.parser.Expression;
 import co.cask.wrangler.api.parser.Identifier;
@@ -37,9 +38,8 @@ import co.cask.wrangler.expression.ELContext;
 import co.cask.wrangler.expression.ELException;
 import co.cask.wrangler.expression.ELResult;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+
 
 /**
  * A directive for incrementing the a transient variable based on conditions.
@@ -99,7 +99,7 @@ public class IncrementTransientVariable implements Directive {
       try {
         ELResult result = el.execute(ctx);
         if (result.getBoolean()) {
-          context.getTransientStore().increment(variable, incrementBy);
+          context.getTransientStore().increment(TransientVariableScope.GLOBAL, variable, incrementBy);
         }
       } catch (ELException e) {
         throw new DirectiveExecutionException(e.getMessage());

--- a/wrangler-core/src/main/java/co/cask/directives/aggregates/SetTransientVariable.java
+++ b/wrangler-core/src/main/java/co/cask/directives/aggregates/SetTransientVariable.java
@@ -26,6 +26,7 @@ import co.cask.wrangler.api.DirectiveParseException;
 import co.cask.wrangler.api.ErrorRowException;
 import co.cask.wrangler.api.ExecutorContext;
 import co.cask.wrangler.api.Row;
+import co.cask.wrangler.api.TransientVariableScope;
 import co.cask.wrangler.api.annotations.Categories;
 import co.cask.wrangler.api.parser.Expression;
 import co.cask.wrangler.api.parser.Identifier;
@@ -36,9 +37,7 @@ import co.cask.wrangler.expression.ELContext;
 import co.cask.wrangler.expression.ELException;
 import co.cask.wrangler.expression.ELResult;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A directive that defines a transient variable who's life-expectancy is only within the record.
@@ -103,7 +102,7 @@ public class SetTransientVariable implements Directive {
       try {
         ELResult result = el.execute(ctx);
         if (context != null) {
-          context.getTransientStore().set(variable, result.getObject());
+          context.getTransientStore().set(TransientVariableScope.GLOBAL, variable, result.getObject());
         }
       } catch (ELException e) {
         throw new DirectiveExecutionException(e.getMessage());

--- a/wrangler-core/src/main/java/co/cask/directives/row/SendToError.java
+++ b/wrangler-core/src/main/java/co/cask/directives/row/SendToError.java
@@ -105,6 +105,13 @@ public class SendToError implements Directive {
         ctx.set(var, row.getValue(var));
       }
 
+      // Transient variables are added.
+      if (context != null) {
+        for (String variable : context.getTransientStore().getVariables()) {
+          ctx.set(variable, context.getTransientStore().get(variable));
+        }
+      }
+
       // Execution of the script / expression based on the row data
       // mapped into context.
       try {

--- a/wrangler-core/src/main/java/co/cask/directives/row/SendToErrorAndContinue.java
+++ b/wrangler-core/src/main/java/co/cask/directives/row/SendToErrorAndContinue.java
@@ -27,6 +27,7 @@ import co.cask.wrangler.api.ExecutorContext;
 import co.cask.wrangler.api.Optional;
 import co.cask.wrangler.api.ReportErrorAndProceed;
 import co.cask.wrangler.api.Row;
+import co.cask.wrangler.api.TransientVariableScope;
 import co.cask.wrangler.api.annotations.Categories;
 import co.cask.wrangler.api.parser.Expression;
 import co.cask.wrangler.api.parser.Identifier;
@@ -97,7 +98,7 @@ public class SendToErrorAndContinue implements Directive {
   public List<Row> execute(List<Row> rows, ExecutorContext context)
     throws DirectiveExecutionException, ReportErrorAndProceed {
     if (context != null) {
-      context.getTransientStore().increment("dq_total", 1);
+      context.getTransientStore().increment(TransientVariableScope.LOCAL, "dq_total", 1);
     }
     List<Row> results = new ArrayList<>();
     for (Row row : rows) {
@@ -127,7 +128,7 @@ public class SendToErrorAndContinue implements Directive {
             message = condition;
           }
           if (context != null) {
-            context.getTransientStore().increment("dq_failure", 1);
+            context.getTransientStore().increment(TransientVariableScope.LOCAL, "dq_failure", 1);
           }
           throw new ReportErrorAndProceed(message, 1);
         }

--- a/wrangler-core/src/main/java/co/cask/directives/transformation/ColumnExpression.java
+++ b/wrangler-core/src/main/java/co/cask/directives/transformation/ColumnExpression.java
@@ -36,10 +36,8 @@ import co.cask.wrangler.expression.ELException;
 import co.cask.wrangler.expression.ELResult;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A directive for apply an expression to store the result in a column.
@@ -99,6 +97,13 @@ public class ColumnExpression implements Directive {
       ctx.set("this", row);
       for(String var : el.variables()) {
         ctx.set(var, row.getValue(var));
+      }
+
+      // Transient variables are added.
+      if (context != null) {
+        for (String variable : context.getTransientStore().getVariables()) {
+          ctx.set(variable, context.getTransientStore().get(variable));
+        }
       }
 
       // Execution of the script / expression based on the row data

--- a/wrangler-core/src/main/java/co/cask/wrangler/executor/RecipePipelineExecutor.java
+++ b/wrangler-core/src/main/java/co/cask/wrangler/executor/RecipePipelineExecutor.java
@@ -37,6 +37,7 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -112,11 +113,13 @@ public final class RecipePipelineExecutor implements RecipePipeline<Row, Structu
    */
   @Override
   public List<Row> execute(List<Row> rows) throws RecipeException {
+    List<String> messages = new ArrayList<>();
     List<Row> results = Lists.newArrayList();
     try {
       int i = 0;
       collector.reset();
       while (i < rows.size()) {
+        messages.clear();
         List<Row> newRows = rows.subList(i, i+1);
         try {
           for (Executor<List<Row>, List<Row>> directive : directives) {
@@ -126,14 +129,16 @@ public final class RecipePipelineExecutor implements RecipePipeline<Row, Structu
                 break;
               }
             } catch (ReportErrorAndProceed e) {
-              collector.add(new ErrorRecord(newRows.get(0), e.getMessage(), e.getCode()));
+              //collector.add(new ErrorRecord(newRows.get(0), e.getMessage(), e.getCode()));
+              messages.add(String.format("%s", e.getMessage()));
             }
           }
           if(newRows.size() > 0) {
             results.addAll(newRows);
           }
         } catch (ErrorRowException e) {
-          collector.add(new ErrorRecord(newRows.get(0), e.getMessage(), e.getCode()));
+          messages.add(String.format("%d:%s", e.getCode(), e.getMessage()));
+          collector.add(new ErrorRecord(newRows.get(0), String.join(",", messages), e.getCode()));
         }
         i++;
       }

--- a/wrangler-core/src/test/java/co/cask/directives/aggregates/SetTransientVariableTest.java
+++ b/wrangler-core/src/test/java/co/cask/directives/aggregates/SetTransientVariableTest.java
@@ -21,6 +21,7 @@ import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.wrangler.TestingRig;
 import co.cask.wrangler.api.ExecutorContext;
 import co.cask.wrangler.api.Row;
+import co.cask.wrangler.api.TransientVariableScope;
 import co.cask.wrangler.api.TransientStore;
 import org.junit.Assert;
 import org.junit.Test;
@@ -78,7 +79,7 @@ public class SetTransientVariableTest {
       public TransientStore getTransientStore() {
         return new TransientStore() {
           @Override
-          public void reset() {
+          public void reset(TransientVariableScope scope) {
 
           }
 
@@ -88,12 +89,12 @@ public class SetTransientVariableTest {
           }
 
           @Override
-          public void set(String name, Object value) {
+          public void set(TransientVariableScope scope, String name, Object value) {
             s.put(name, value);
           }
 
           @Override
-          public void increment(String name, long value) {
+          public void increment(TransientVariableScope scope, String name, long value) {
 
           }
 

--- a/wrangler-core/src/test/java/co/cask/directives/row/SendToErrorAndContinueTest.java
+++ b/wrangler-core/src/test/java/co/cask/directives/row/SendToErrorAndContinueTest.java
@@ -54,4 +54,28 @@ public class SendToErrorAndContinueTest {
     Assert.assertEquals(3, errors.size());
     Assert.assertEquals(2, results.size());
   }
+
+  @Test
+  public void testErrorConditionTrueAndContinueWithTransientVariable() throws Exception {
+    String[] directives = new String[] {
+            "parse-as-csv body , true",
+            "drop body",
+            "send-to-error-and-continue exp:{body_3 == 'xx'} 'invalid value'",
+            "send-to-error-and-continue exp:{body_4=='1'} 'junk' ",
+            "send-to-error exp:{dq_failure > 1.0} "
+    };
+
+    List<Row> rows = Arrays.asList(
+            new Row("body", "1020134.298,,1,2,1"),
+            new Row("body", "1020134.298,,1,2,2 "),
+            new Row("body", "1020134.298,,xx,1,3"),
+            new Row("body", "1020134.298,,4,1,4"),
+            new Row("body", "1020134.298,,4,2,5")
+    );
+
+    RecipePipeline pipeline = TestingRig.execute(directives);
+    List<Row> results = pipeline.execute(rows);
+    List<ErrorRecord> errors = pipeline.errors();
+    Assert.assertTrue(true);
+  }
 }

--- a/wrangler-core/src/test/java/co/cask/directives/row/SendToErrorAndContinueTest.java
+++ b/wrangler-core/src/test/java/co/cask/directives/row/SendToErrorAndContinueTest.java
@@ -51,7 +51,7 @@ public class SendToErrorAndContinueTest {
     List<Row> results = pipeline.execute(rows);
     List<ErrorRecord> errors = pipeline.errors();
 
-    Assert.assertEquals(3, errors.size());
+    Assert.assertEquals(0, errors.size());
     Assert.assertEquals(2, results.size());
   }
 
@@ -62,20 +62,21 @@ public class SendToErrorAndContinueTest {
             "drop body",
             "send-to-error-and-continue exp:{body_3 == 'xx'} 'invalid value'",
             "send-to-error-and-continue exp:{body_4=='1'} 'junk' ",
-            "send-to-error exp:{dq_failure > 1.0} "
+            "send-to-error exp:{dq_failure >= 1} "
     };
 
     List<Row> rows = Arrays.asList(
-            new Row("body", "1020134.298,,1,2,1"),
             new Row("body", "1020134.298,,1,2,2 "),
             new Row("body", "1020134.298,,xx,1,3"),
             new Row("body", "1020134.298,,4,1,4"),
-            new Row("body", "1020134.298,,4,2,5")
+            new Row("body", "1020134.298,,4,2,5"),
+            new Row("body", "1020134.298,,1,2,1")
     );
 
     RecipePipeline pipeline = TestingRig.execute(directives);
     List<Row> results = pipeline.execute(rows);
     List<ErrorRecord> errors = pipeline.errors();
-    Assert.assertTrue(true);
+    Assert.assertEquals(2, errors.size());
+    Assert.assertEquals(3, results.size());
   }
 }

--- a/wrangler-core/src/test/java/co/cask/wrangler/TestingPipelineContext.java
+++ b/wrangler-core/src/test/java/co/cask/wrangler/TestingPipelineContext.java
@@ -55,7 +55,27 @@ class TestingPipelineContext implements ExecutorContext {
    */
   @Override
   public StageMetrics getMetrics() {
-    return null;
+    return new StageMetrics() {
+      @Override
+      public void count(String s, int i) {
+
+      }
+
+      @Override
+      public void gauge(String s, long l) {
+
+      }
+
+      @Override
+      public void pipelineCount(String s, int i) {
+
+      }
+
+      @Override
+      public void pipelineGauge(String s, long l) {
+
+      }
+    };
   }
 
   /**

--- a/wrangler-core/src/test/java/co/cask/wrangler/TestingPipelineContext.java
+++ b/wrangler-core/src/test/java/co/cask/wrangler/TestingPipelineContext.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler;
+
+import co.cask.cdap.etl.api.Lookup;
+import co.cask.cdap.etl.api.StageMetrics;
+import co.cask.directives.aggregates.DefaultTransientStore;
+import co.cask.wrangler.api.Executor;
+import co.cask.wrangler.api.ExecutorContext;
+import co.cask.wrangler.api.TransientStore;
+import org.apache.commons.collections.map.HashedMap;
+
+import java.net.URL;
+import java.util.Map;
+
+/**
+ * This class {@link TestingPipelineContext} is a runtime context that is provided for each
+ * {@link Executor} execution.
+ */
+class TestingPipelineContext implements ExecutorContext {
+  private StageMetrics metrics;
+  private String name;
+  private TransientStore store;
+  private Map<String, String> properties;
+
+  TestingPipelineContext() {
+    properties = new HashedMap();
+    store = new DefaultTransientStore();
+  }
+
+  /**
+   * @return Environment this context is prepared for.
+   */
+  @Override
+  public Environment getEnvironment() {
+    return Environment.TESTING;
+  }
+
+  /**
+   * @return Measurements context.
+   */
+  @Override
+  public StageMetrics getMetrics() {
+    return null;
+  }
+
+  /**
+   * @return Context name.
+   */
+  @Override
+  public String getContextName() {
+    return "testing";
+  }
+
+  /**
+   * @return Properties associated with run and pipeline.
+   */
+  @Override
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  /**
+   * Returns a valid service url.
+   *
+   * @param applicationId id of the application to which a service url.
+   * @param serviceId     id of the service within application.
+   * @return URL if service exists, else null.
+   */
+  @Override
+  public URL getService(String applicationId, String serviceId) {
+    return null;
+  }
+
+  @Override
+  public TransientStore getTransientStore() {
+    return store;
+  }
+
+  /**
+   * Provides a handle to dataset for lookup.
+   *
+   * @param s name of the dataset.
+   * @param map properties associated with dataset.
+   * @return handle to dataset for lookup.
+   */
+  @Override
+  public <T> Lookup<T> provide(String s, Map<String, String> map) {
+    return null;
+  }
+}

--- a/wrangler-core/src/test/java/co/cask/wrangler/TestingRig.java
+++ b/wrangler-core/src/test/java/co/cask/wrangler/TestingRig.java
@@ -16,19 +16,10 @@
 
 package co.cask.wrangler;
 
-import co.cask.wrangler.api.CompileException;
-import co.cask.wrangler.api.CompileStatus;
+import co.cask.cdap.etl.api.Lookup;
+import co.cask.cdap.etl.api.StageMetrics;
+import co.cask.wrangler.api.*;
 import co.cask.wrangler.api.Compiler;
-import co.cask.wrangler.api.DirectiveLoadException;
-import co.cask.wrangler.api.DirectiveNotFoundException;
-import co.cask.wrangler.api.DirectiveParseException;
-import co.cask.wrangler.api.ExecutorContext;
-import co.cask.wrangler.api.GrammarMigrator;
-import co.cask.wrangler.api.Pair;
-import co.cask.wrangler.api.RecipeException;
-import co.cask.wrangler.api.RecipeParser;
-import co.cask.wrangler.api.RecipePipeline;
-import co.cask.wrangler.api.Row;
 import co.cask.wrangler.api.parser.SyntaxError;
 import co.cask.wrangler.executor.RecipePipelineExecutor;
 import co.cask.wrangler.parser.GrammarBasedParser;
@@ -39,8 +30,10 @@ import co.cask.wrangler.registry.CompositeDirectiveRegistry;
 import co.cask.wrangler.registry.SystemDirectiveRegistry;
 import org.junit.Assert;
 
+import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Utilities for testing.
@@ -115,7 +108,7 @@ public final class TestingRig {
     RecipeParser parser = new GrammarBasedParser(migrate, registry);
     parser.initialize(new NoOpDirectiveContext());
     RecipePipeline pipeline = new RecipePipelineExecutor();
-    pipeline.initialize(parser, null);
+    pipeline.initialize(parser, new TestingPipelineContext());
     return pipeline;
   }
 

--- a/wrangler-transform/src/main/java/co/cask/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/co/cask/wrangler/Wrangler.java
@@ -50,6 +50,7 @@ import co.cask.wrangler.api.RecipeSymbol;
 import co.cask.wrangler.api.Row;
 import co.cask.wrangler.api.TokenGroup;
 import co.cask.wrangler.api.TransientStore;
+import co.cask.wrangler.api.TransientVariableScope;
 import co.cask.wrangler.executor.RecipePipelineExecutor;
 import co.cask.wrangler.parser.ConfigDirectiveContext;
 import co.cask.wrangler.parser.GrammarBasedParser;
@@ -417,7 +418,8 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
       }
 
       // Reset record aggregation store.
-      store.reset();
+      store.reset(TransientVariableScope.GLOBAL);
+      store.reset(TransientVariableScope.LOCAL);
 
       start = System.nanoTime();
       records = pipeline.execute(Arrays.asList(row), oSchema);


### PR DESCRIPTION
Now correctly handles the use case of subjecting a record to multiple checks before excluding it from the processing. 

```
send-to-error-and-continue exp:{ x == 1 } 'Bad value of x'
send-to-error-and-continue exp:{ name == 'XYZ'} 'Incorrect name'
send-to-error exp:{ dq_failure >= 1}
```

Would check for conditions before emitting it on error port when at-least one of the send-to-error-and-continue condition is hit. 