### PR TITLE
CDAP-14470 remove offset from schema of file based sources

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/common/Schemas.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/common/Schemas.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.service.common;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+/**
+ * Utilities around schemas.
+ */
+public class Schemas {
+  public static final Schema TEXT = Schema.recordOf("text", Schema.Field.of("body", Schema.of(Schema.Type.STRING)));
+
+  private Schemas() {
+    // private constructor for util class
+  }
+
+}

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
@@ -35,6 +35,7 @@ import co.cask.wrangler.dataset.workspace.DataType;
 import co.cask.wrangler.dataset.workspace.WorkspaceDataset;
 import co.cask.wrangler.service.FileTypeDetector;
 import co.cask.wrangler.service.common.AbstractWranglerService;
+import co.cask.wrangler.service.common.Schemas;
 import co.cask.wrangler.service.connections.ConnectionType;
 import co.cask.wrangler.service.gcp.GCPUtils;
 import co.cask.wrangler.utils.ObjectSerDe;
@@ -457,6 +458,10 @@ public class GCSService extends AbstractWranglerService {
                             @PathParam("connection-id") String connectionId,
                             @QueryParam("wid") String workspaceId) {
 
+    if (workspaceId == null) {
+      responder.sendError(400, "Workspace ID must be passed as query parameter 'wid'.");
+      return;
+    }
     JsonObject response = new JsonObject();
     try {
 
@@ -489,6 +494,7 @@ public class GCSService extends AbstractWranglerService {
       properties.put("recursive", "false");
       properties.put("filenameOnly", "false");
       properties.put("copyHeader", String.valueOf(shouldCopyHeader(workspaceId)));
+      properties.put("schema", Schemas.TEXT.toString());
       gcs.add("properties", new Gson().toJsonTree(properties));
       gcs.addProperty("name", "GCSFile");
       gcs.addProperty("type", "source");

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Service.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Service.java
@@ -39,6 +39,7 @@ import co.cask.wrangler.sampling.Poisson;
 import co.cask.wrangler.sampling.Reservoir;
 import co.cask.wrangler.service.FileTypeDetector;
 import co.cask.wrangler.service.common.AbstractWranglerService;
+import co.cask.wrangler.service.common.Schemas;
 import co.cask.wrangler.service.connections.ConnectionType;
 import co.cask.wrangler.service.explorer.BoundedLineInputStream;
 import co.cask.wrangler.utils.ObjectSerDe;
@@ -309,10 +310,13 @@ public class S3Service extends AbstractWranglerService {
                             @QueryParam("wid") String workspaceId) {
     JsonObject response = new JsonObject();
     try {
-      Map<String, String> config = ws.getProperties(workspaceId);
-      String pluginType = config.get(PropertyIds.PLUGIN_TYPE);
+      String pluginType = null;
+      if (workspaceId != null) {
+        Map<String, String> config = ws.getProperties(workspaceId);
+        pluginType = config.get(PropertyIds.PLUGIN_TYPE);
+      }
       Map<String, String> properties = new HashMap<>();
-      if (pluginType.equalsIgnoreCase("blob")) {
+      if ("blob".equalsIgnoreCase(pluginType)) {
         properties.put("format", "blob");
       } else {
         // text, json and xml will have pluginType set text and not blob
@@ -326,6 +330,7 @@ public class S3Service extends AbstractWranglerService {
       properties.put("accessKey", s3Configuration.getAWSSecretKey());
       properties.put("path", String.format("s3a://%s/%s", bucketName, key));
       properties.put("copyHeader", String.valueOf(shouldCopyHeader(workspaceId)));
+      properties.put("schema", Schemas.TEXT.toString());
 
       s3.add("properties", gson.toJsonTree(properties));
       s3.addProperty("name", "S3");


### PR DESCRIPTION
Directives like the set columns directive break if there is more
than a single input field. That's an indication of bad design,
but in the meantime, changing the sources to only emit a single
field to workaround the issue.