### PR TITLE
CDAP-14506 fix binary file handling

### DIFF
--- a/wrangler-core/src/main/java/co/cask/directives/parser/ParseAvroFile.java
+++ b/wrangler-core/src/main/java/co/cask/directives/parser/ParseAvroFile.java
@@ -35,6 +35,7 @@ import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.SeekableByteArrayInput;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -82,8 +83,7 @@ public class ParseAvroFile implements Directive {
           DataFileReader<GenericRecord> reader = null;
           try {
             reader =
-              new DataFileReader<>(new SeekableByteArrayInput((byte[]) object),
-                                                new GenericDatumReader<GenericRecord>());
+              new DataFileReader<>(new SeekableByteArrayInput((byte[]) object), new GenericDatumReader<>());
             while(reader.hasNext()) {
               Row newRow = new Row();
               add(reader.next(), newRow, null);
@@ -101,7 +101,8 @@ public class ParseAvroFile implements Directive {
             }
           }
         } else {
-          throw new DirectiveExecutionException(toString() + " : column " + column + " should be of type byte array avro file.");
+          throw new DirectiveExecutionException(toString() + " : column " + column +
+                                                  " should be of type byte array avro file.");
         }
       }
     }
@@ -129,6 +130,8 @@ public class ParseAvroFile implements Directive {
         add((GenericRecord) v, row, colname);
       } else if (v instanceof Map || v instanceof List) {
         row.add(colname, gson.toJson(v));
+      } else if (v instanceof Utf8) {
+        row.add(colname, v.toString());
       } else {
         row.add(colname, genericRecord.get(field.name()));
       }

--- a/wrangler-service/src/main/java/co/cask/wrangler/PropertyIds.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/PropertyIds.java
@@ -56,6 +56,8 @@ public final class PropertyIds {
   // Plugin type
   public static final String PLUGIN_TYPE = "plugin-type";
 
+  // File format to use when reading data as a pipeline source
+  public static final String FORMAT = "format";
   public static final String CONNECTION_ID = "connectionid";
   public static final String BROKER = "brokers";
   public static final String KEY_DESERIALIZER = "key.deserializer";

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/common/Format.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/common/Format.java
@@ -19,13 +19,18 @@ package co.cask.wrangler.service.common;
 import co.cask.cdap.api.data.schema.Schema;
 
 /**
- * Utilities around schemas.
+ * Different formats for file based sources.
  */
-public class Schemas {
-  public static final Schema TEXT = Schema.recordOf("text", Schema.Field.of("body", Schema.of(Schema.Type.STRING)));
+public enum Format {
+  TEXT(Schema.recordOf("text", Schema.Field.of("body", Schema.of(Schema.Type.STRING)))),
+  BLOB(Schema.recordOf("blob", Schema.Field.of("body", Schema.of(Schema.Type.BYTES))));
+  private final Schema schema;
 
-  private Schemas() {
-    // private constructor for util class
+  Format(Schema schema) {
+    this.schema = schema;
   }
 
+  public Schema getSchema() {
+    return schema;
+  }
 }


### PR DESCRIPTION
Fixed a bug in parse-as-avro-file that would generate an invalid
schema due to usage of Utf8 instead of String.

Also fixed format logic so that the format is correctly stored
and read and the right schema is used.