### PR TITLE
Update cdap dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>5.1.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
     <commons-jexl.version>3.0</commons-jexl.version>
     <commons-csv.version>1.4</commons-csv.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
We bumped cdap to 6.0.0-SNAPSHOT [here](https://github.com/caskdata/cdap/pull/10814)

Updating cdap dependency