### PR TITLE
Exclude transitive dependency org.slf4j:slf4j-api:jar:1.6.6 brought i…

### DIFF
--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -56,6 +56,12 @@
       <groupId>org.unix4j</groupId>
       <artifactId>unix4j-command</artifactId>
       <version>${unix4j.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
Wrangler was previously packaging two different versions of `org.slf4j:slf4j-api`.

This PR excludes the transitive dependency `org.slf4j:slf4j-api:jar:1.6.6` brought in by `org.unix4j:unix4j-command`.
This conflicts with the version that we depend on directly in wrangler-service and wrangler-transform.

Previously, the dependency tree showed:
![image](https://user-images.githubusercontent.com/2440977/48875176-1bb7fa80-edac-11e8-914a-23b7db3b8fc0.png)

as well as:
![image](https://user-images.githubusercontent.com/2440977/48875183-24a8cc00-edac-11e8-872b-90ace3de67f9.png)