### PR TITLE
Fix BigQuery service to use DATETIME type as string

### DIFF
--- a/wrangler-core/src/main/java/co/cask/directives/parser/ParseDate.java
+++ b/wrangler-core/src/main/java/co/cask/directives/parser/ParseDate.java
@@ -35,6 +35,7 @@ import co.cask.wrangler.api.parser.UsageDefinition;
 import com.joestelmach.natty.DateGroup;
 import com.joestelmach.natty.Parser;
 
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -82,6 +83,11 @@ public class ParseDate implements Directive {
       int idx = row.find(column);
       if (idx != -1) {
         Object object = row.getValue(idx);
+        // If the data in the cell is null or is already of date format, then
+        // continue to next row.
+        if (object == null || object instanceof ZonedDateTime) {
+          continue;
+        }
         if (object instanceof String) {
           Parser parser = new Parser(timezone);
           List<DateGroup> groups = parser.parse((String) object);
@@ -96,8 +102,7 @@ public class ParseDate implements Directive {
         } else {
           throw new ErrorRowException(
             String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object != null ? object.getClass().getName() : "null", column), 1
-          );
+                          object.getClass().getName(), column), 1);
         }
       }
     }

--- a/wrangler-core/src/main/java/co/cask/directives/parser/ParseSimpleDate.java
+++ b/wrangler-core/src/main/java/co/cask/directives/parser/ParseSimpleDate.java
@@ -103,8 +103,7 @@ public class ParseSimpleDate implements Directive {
         } else {
           throw new ErrorRowException(
             String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object != null ? object.getClass().getName() : "null", column), 2
-          );
+                          object.getClass().getName(), column), 2);
         }
       }
     }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryService.java
@@ -387,12 +387,12 @@ public class BigQueryService extends AbstractWranglerService {
             row.add(fieldName, LocalDate.parse(fieldValue.getStringValue()));
             break;
 
-          case DATETIME:
           case TIMESTAMP:
             long tsMicroValue = fieldValue.getTimestampValue();
             row.add(fieldName, getZonedDateTime(tsMicroValue));
             break;
 
+          case DATETIME:
           case STRING:
             row.add(fieldName, fieldValue.getStringValue());
             break;
@@ -433,7 +433,6 @@ public class BigQueryService extends AbstractWranglerService {
         case TIME:
           schemaType = Schema.of(Schema.LogicalType.TIME_MICROS);
           break;
-        case DATETIME:
         case TIMESTAMP:
           schemaType = Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
           break;
@@ -443,6 +442,7 @@ public class BigQueryService extends AbstractWranglerService {
         case INT64:
           schemaType = Schema.of(Schema.Type.LONG);
           break;
+        case DATETIME:
         case STRING:
           schemaType = Schema.of(Schema.Type.STRING);
           break;


### PR DESCRIPTION
BigQuery `DATETIME` field type is time without timezone. BigQuery apis returns this value as string in ISO 8601 format. However, Bigquery service assumes it to be timestamp instead of string.
Also fixing Natural Date directive to not throw error when column value is null (similar to Simple Date directive).
