### PR TITLE
CDAP-14619 refactor the schema registry

### DIFF
--- a/wrangler-proto/pom.xml
+++ b/wrangler-proto/pom.xml
@@ -27,6 +27,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${cdap.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/schema/SchemaDescriptorType.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/schema/SchemaDescriptorType.java
@@ -14,50 +14,27 @@
  * the License.
  */
 
-package co.cask.wrangler.dataset.schema;
+package co.cask.wrangler.proto.schema;
+
+import com.google.gson.annotations.SerializedName;
 
 /**
  * This class {@link SchemaDescriptorType} defines types of Schema supported by the Schema registry
  */
 public enum SchemaDescriptorType {
+  @SerializedName("avro")
   // Represents an AVRO schema.
-  AVRO("avro"),
+  AVRO,
 
+  @SerializedName("protobuf-desc")
   // Represents a protobuf descriptor schema.
-  PROTOBUF_DESC("protobuf-desc"),
+  PROTOBUF_DESC,
 
+  @SerializedName("protobuf-binary")
   // Represents schema is of type protobuf-binary which is compiled classes on protobuf.
-  PROTOBUF_BINARY("protobuf-binary"),
+  PROTOBUF_BINARY,
 
+  @SerializedName("copybook")
   // Defines copybook for COBOL EBCDIC data.
-  COPYBOOK("copybook");
-
-  // Defines the type of data.
-  String type;
-
-  SchemaDescriptorType(String type) {
-    this.type = type;
-  }
-
-  /**
-   * @return Type of schema definition.
-   */
-  public String getType() {
-    return type;
-  }
-
-  /**
-   * Converts the string representation of type into a {@link SchemaDescriptorType}.
-   *
-   * @param text representation of the type.
-   * @return an instance of {@link SchemaDescriptorType} based on it's string representation, null if not found.
-   */
-  public static SchemaDescriptorType fromString(String text) {
-    for (SchemaDescriptorType b : SchemaDescriptorType.values()) {
-      if (b.type.equalsIgnoreCase(text)) {
-        return b;
-      }
-    }
-    return null;
-  }
+  COPYBOOK;
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/schema/SchemaEntry.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/schema/SchemaEntry.java
@@ -14,14 +14,19 @@
  * the License.
  */
 
-package co.cask.wrangler.dataset.schema;
+package co.cask.wrangler.proto.schema;
 
-import java.util.Arrays;
+import co.cask.cdap.api.common.Bytes;
+
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
- * Schema Entry
+ * Schema Entry.
+ *
+ * TODO: (CDAP-14679) Create another SchemaInfo class for the schema itself
+ *   and remove version list and current field from this class.
  */
 public final class SchemaEntry {
   private final String id;
@@ -29,17 +34,17 @@ public final class SchemaEntry {
   private final String description;
   private final SchemaDescriptorType type;
   private final Set<Long> versions;
-  private final byte[] specification;
-  private final long current;
+  private final String specification;
+  private final Long current;
 
   public SchemaEntry(String id, String name, String description, SchemaDescriptorType type,
-                     Set<Long> versions, byte[] specification, long current) {
+                     Set<Long> versions, @Nullable byte[] specification, @Nullable Long current) {
     this.id = id;
     this.name = name;
     this.description = description;
     this.type = type;
     this.versions = versions;
-    this.specification = specification;
+    this.specification = specification == null ? null : Bytes.toHexString(specification);
     this.current = current;
   }
 
@@ -63,12 +68,14 @@ public final class SchemaEntry {
     return versions;
   }
 
-  public byte[] getSpecification() {
-    return specification;
+  @Nullable
+  public Long getCurrent() {
+    return current;
   }
 
-  public long getCurrent() {
-    return current;
+  @Nullable
+  public byte[] getSpecification() {
+    return specification == null ? null : Bytes.fromHexString(specification);
   }
 
   @Override
@@ -80,19 +87,17 @@ public final class SchemaEntry {
       return false;
     }
     SchemaEntry that = (SchemaEntry) o;
-    return current == that.current &&
-      Objects.equals(id, that.id) &&
+    return Objects.equals(id, that.id) &&
       Objects.equals(name, that.name) &&
       Objects.equals(description, that.description) &&
       type == that.type &&
       Objects.equals(versions, that.versions) &&
-      Arrays.equals(specification, that.specification);
+      Objects.equals(specification, that.specification) &&
+      Objects.equals(current, that.current);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(id, name, description, type, versions, current);
-    result = 31 * result + Arrays.hashCode(specification);
-    return result;
+    return Objects.hash(id, name, description, type, versions, specification, current);
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/schema/SchemaEntryVersion.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/schema/SchemaEntryVersion.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.proto.schema;
+
+/**
+ * A schema ID and entry version.
+ */
+public class SchemaEntryVersion {
+  private final String id;
+  private final long version;
+
+  public SchemaEntryVersion(String id, long version) {
+    this.id = id;
+    this.version = version;
+  }
+}

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/schema/SchemaRegistryService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/schema/SchemaRegistryService.java
@@ -17,22 +17,22 @@
 package co.cask.wrangler.service.schema;
 
 import co.cask.cdap.api.annotation.UseDataSet;
-import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceContext;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.wrangler.DataPrep;
-import co.cask.wrangler.dataset.schema.SchemaDescriptorType;
-import co.cask.wrangler.dataset.schema.SchemaEntry;
+import co.cask.wrangler.dataset.schema.SchemaDescriptor;
+import co.cask.wrangler.dataset.schema.SchemaNotFoundException;
 import co.cask.wrangler.dataset.schema.SchemaRegistry;
 import co.cask.wrangler.dataset.schema.SchemaRegistryException;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import co.cask.wrangler.proto.ServiceResponse;
+import co.cask.wrangler.proto.schema.SchemaDescriptorType;
+import co.cask.wrangler.proto.schema.SchemaEntry;
+import co.cask.wrangler.proto.schema.SchemaEntryVersion;
+import com.google.gson.Gson;
 
-import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
 import java.util.Set;
 import javax.ws.rs.DELETE;
@@ -45,13 +45,13 @@ import javax.ws.rs.QueryParam;
 
 import static co.cask.wrangler.ServiceUtils.error;
 import static co.cask.wrangler.ServiceUtils.notFound;
-import static co.cask.wrangler.ServiceUtils.sendJson;
 import static co.cask.wrangler.ServiceUtils.success;
 
 /**
  * This class {@link SchemaRegistryService} provides schema management service.
  */
 public class SchemaRegistryService extends AbstractHttpServiceHandler {
+  private static final Gson GSON = new Gson();
 
   @UseDataSet(DataPrep.CONNECTIONS_DATASET)
   private Table table;
@@ -90,24 +90,27 @@ public class SchemaRegistryService extends AbstractHttpServiceHandler {
                      @QueryParam("description") String description, @QueryParam("type") String type) {
     try {
       if (id == null || id.isEmpty()) {
-        error(responder, "id field is empty. id cannot be null");
+        error(responder, "Schema id must be specified.");
         return;
       }
       if (name == null || name.isEmpty()) {
-        error(responder, "name field is empty. name cannot be null");
+        error(responder, "Schema name must be specified.");
         return;
       }
-      if (type == null || SchemaDescriptorType.fromString(type) == null) {
-        error(responder, "Not valid schema type specified.");
+      SchemaDescriptorType descriptorType = GSON.fromJson(type, SchemaDescriptorType.class);
+      if (descriptorType == null) {
+        error(responder, String.format("Schema type '%s' is invalid.", type));
         return;
       }
       if (description == null || description.isEmpty()) {
-        error(responder, "Description cannot be empty");
+        error(responder, "Schema description must be specified.");
         return;
       }
-      registry.create(id, name, description, SchemaDescriptorType.fromString(type));
-      success(responder, String.format("Successfully created schema entry with id '%s', name '%s'", id, name));
-    } catch (IllegalArgumentException | SchemaRegistryException e) {
+      SchemaDescriptor descriptor = new SchemaDescriptor(id, name, description, descriptorType);
+      registry.write(descriptor);
+      success(responder, String.format("Successfully created schema entry with id '%s', name '%s'",
+                                       id, name));
+    } catch (SchemaRegistryException e) {
       error(responder, e.getMessage());
     }
   }
@@ -140,7 +143,6 @@ public class SchemaRegistryService extends AbstractHttpServiceHandler {
   @Path("schemas/{id}")
   public void upload(HttpServiceRequest request, HttpServiceResponder responder,
                      @PathParam("id") String id) {
-
     byte[] bytes = null;
     ByteBuffer content = request.getContent();
     if (content != null && content.hasRemaining()) {
@@ -154,20 +156,11 @@ public class SchemaRegistryService extends AbstractHttpServiceHandler {
     }
 
     try {
-      if (bytes != null) {
-        long version = registry.add(id, bytes);
-        JsonObject response = new JsonObject();
-        JsonArray array = new JsonArray();
-        JsonObject object = new JsonObject();
-        object.addProperty("id", id);
-        object.addProperty("version", version);
-        array.add(object);
-        response.addProperty("status", HttpURLConnection.HTTP_OK);
-        response.addProperty("message", "Success");
-        response.addProperty("count", array.size());
-        response.add("values", array);
-        sendJson(responder, HttpURLConnection.HTTP_OK, response.toString());
-      }
+      long version = registry.add(id, bytes);
+      ServiceResponse<SchemaEntryVersion> response = new ServiceResponse<>(new SchemaEntryVersion(id, version));
+      responder.sendJson(response);
+    } catch (SchemaNotFoundException e) {
+      notFound(responder, e.getMessage());
     } catch (SchemaRegistryException e) {
       error(responder, e.getMessage());
     }
@@ -212,12 +205,10 @@ public class SchemaRegistryService extends AbstractHttpServiceHandler {
   public void delete(HttpServiceRequest request, HttpServiceResponder responder,
                      @PathParam("id") String id, @PathParam("version") long version) {
     try {
-      if (registry.hasSchema(id, version)) {
-        notFound(responder, "Id " + id + " version " + version + " not found.");
-        return;
-      }
       registry.remove(id, version);
       success(responder, "Successfully deleted version '" + version + "' of schema " + id);
+    } catch (SchemaNotFoundException e) {
+      notFound(responder, e.getMessage());
     } catch (SchemaRegistryException e) {
       error(responder, e.getMessage());
     }
@@ -236,32 +227,11 @@ public class SchemaRegistryService extends AbstractHttpServiceHandler {
   public void get(HttpServiceRequest request, HttpServiceResponder responder,
                   @PathParam("id") String id, @PathParam("version") long version) {
     try {
-      if (!registry.hasSchema(id, version)) {
-        notFound(responder, "Id " + id + " version " + version + " not found.");
-        return;
-      }
-      SchemaEntry entry = registry.get(id, version);
-      JsonObject response = new JsonObject();
-      JsonArray array = new JsonArray();
-      JsonObject object = new JsonObject();
-      object.addProperty("id", id);
-      object.addProperty("name", entry.getName());
-      object.addProperty("version", version);
-      object.addProperty("description", entry.getDescription());
-      object.addProperty("type", entry.getType().getType());
-      object.addProperty("current", entry.getCurrent());
-      object.addProperty("specification", Bytes.toHexString(entry.getSpecification()));
-      JsonArray versions = new JsonArray();
-      for (Long elementVersion : entry.getVersions()) {
-        versions.add(new JsonPrimitive(elementVersion));
-      }
-      object.add("versions", versions);
-      array.add(object);
-      response.addProperty("status", HttpURLConnection.HTTP_OK);
-      response.addProperty("message", "Success");
-      response.addProperty("count", array.size());
-      response.add("values", array);
-      sendJson(responder, HttpURLConnection.HTTP_OK, response.toString());
+      SchemaEntry entry = registry.getEntry(id, version);
+      ServiceResponse<SchemaEntry> response = new ServiceResponse<>(entry);
+      responder.sendJson(response);
+    } catch (SchemaNotFoundException e) {
+      notFound(responder, e.getMessage());
     } catch (SchemaRegistryException e) {
       error(responder, e.getMessage());
     }
@@ -269,7 +239,7 @@ public class SchemaRegistryService extends AbstractHttpServiceHandler {
 
   /**
    * Returns information of schema, including schema requested along with versions available and other metadata.
-   * This call will automatically detect the currect active version of schema to delete.
+   * This call will automatically detect the currect active version of schema.
    *
    * @param request HTTP request handler.
    * @param responder HTTP response handler.
@@ -280,32 +250,11 @@ public class SchemaRegistryService extends AbstractHttpServiceHandler {
   public void get(HttpServiceRequest request, HttpServiceResponder responder,
                   @PathParam("id") String id) {
     try {
-      if (!registry.hasSchema(id)) {
-        notFound(responder, "Id " + id + " not found.");
-        return;
-      }
-      SchemaEntry entry = registry.get(id);
-      JsonObject response = new JsonObject();
-      JsonArray array = new JsonArray();
-      JsonObject object = new JsonObject();
-      object.addProperty("id", id);
-      object.addProperty("name", entry.getName());
-      object.addProperty("version", entry.getCurrent());
-      object.addProperty("description", entry.getDescription());
-      object.addProperty("type", entry.getType().getType());
-      object.addProperty("current", entry.getCurrent());
-      object.addProperty("specification", Bytes.toHexString(entry.getSpecification()));
-      JsonArray versions = new JsonArray();
-      for (Long elementVersion : entry.getVersions()) {
-        versions.add(new JsonPrimitive(elementVersion));
-      }
-      object.add("versions", versions);
-      array.add(object);
-      response.addProperty("status", HttpURLConnection.HTTP_OK);
-      response.addProperty("message", "Success");
-      response.addProperty("count", array.size());
-      response.add("values", array);
-      sendJson(responder, HttpURLConnection.HTTP_OK, response.toString());
+      SchemaEntry entry = registry.getEntry(id);
+      ServiceResponse<SchemaEntry> response = new ServiceResponse<>(entry);
+      responder.sendJson(response);
+    } catch (SchemaNotFoundException e) {
+      notFound(responder, e.getMessage());
     } catch (SchemaRegistryException e) {
       error(responder, e.getMessage());
     }
@@ -320,20 +269,13 @@ public class SchemaRegistryService extends AbstractHttpServiceHandler {
    */
   @GET
   @Path("schemas/{id}/versions")
-  public void versions(HttpServiceRequest request, HttpServiceResponder responder,
-                  @PathParam("id") String id) {
+  public void versions(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("id") String id) {
     try {
       Set<Long> versions = registry.getVersions(id);
-      JsonObject response = new JsonObject();
-      JsonArray array = new JsonArray();
-      for (Long elementVersion : versions) {
-        array.add(new JsonPrimitive(elementVersion));
-      }
-      response.addProperty("status", HttpURLConnection.HTTP_OK);
-      response.addProperty("message", "Success");
-      response.addProperty("count", array.size());
-      response.add("values", array);
-      sendJson(responder, HttpURLConnection.HTTP_OK, response.toString());
+      ServiceResponse<Long> response = new ServiceResponse<>(versions);
+      responder.sendJson(response);
+    } catch (SchemaNotFoundException e) {
+      notFound(responder, e.getMessage());
     } catch (SchemaRegistryException e) {
       error(responder, e.getMessage());
     }

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaDescriptor.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.dataset.schema;
+
+import co.cask.wrangler.proto.schema.SchemaDescriptorType;
+
+/**
+ * Describes a schema.
+ */
+public class SchemaDescriptor {
+  protected final String id;
+  protected final String name;
+  protected final String description;
+  protected final SchemaDescriptorType type;
+
+  public SchemaDescriptor(String id, String name, String description, SchemaDescriptorType type) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.type = type;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public SchemaDescriptorType getType() {
+    return type;
+  }
+}

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaNotFoundException.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaNotFoundException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.dataset.schema;
+
+/**
+ * Thrown when a schema could not be found.
+ */
+public class SchemaNotFoundException extends SchemaRegistryException {
+  public SchemaNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaRow.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaRow.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.dataset.schema;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.wrangler.proto.schema.SchemaDescriptorType;
+
+import javax.annotation.Nullable;
+
+/**
+ * Contains all the information about a schema that is stored in the same row.
+ */
+public class SchemaRow extends SchemaDescriptor {
+  private static final byte[] NAME_COL = Bytes.toBytes("name");
+  private static final byte[] DESC_COL = Bytes.toBytes("description");
+  private static final byte[] CREATED_COL = Bytes.toBytes("created");
+  private static final byte[] UPDATED_COL = Bytes.toBytes("updated");
+  private static final byte[] TYPE_COL = Bytes.toBytes("type");
+  private static final byte[] AUTO_VERSION_COL = Bytes.toBytes("auto");
+  private static final byte[] CURRENT_VERSION_COL = Bytes.toBytes("current");
+
+  private final long created;
+  private final long updated;
+  private final long autoVersion;
+  private final Long currentVersion;
+
+  private SchemaRow(String id, String name, String description, SchemaDescriptorType type,
+                    long created, long updated, long autoVersion, @Nullable Long currentVersion) {
+    super(id, name, description, type);
+    this.created = created;
+    this.updated = updated;
+    this.autoVersion = autoVersion;
+    this.currentVersion = currentVersion;
+  }
+
+  public long getCreated() {
+    return created;
+  }
+
+  public long getUpdated() {
+    return updated;
+  }
+
+  public long getAutoVersion() {
+    return autoVersion;
+  }
+
+  @Nullable
+  public Long getCurrentVersion() {
+    return currentVersion;
+  }
+
+  Put toPut() {
+    Put put = new Put(id);
+    put.add(NAME_COL, name);
+    put.add(DESC_COL, description);
+    put.add(CREATED_COL, created);
+    put.add(UPDATED_COL, updated);
+    put.add(TYPE_COL, type.name());
+    put.add(AUTO_VERSION_COL, autoVersion);
+    if (currentVersion != null) {
+      put.add(CURRENT_VERSION_COL, currentVersion);
+    }
+    return put;
+  }
+
+  static SchemaRow fromRow(Row row) {
+    String id = Bytes.toString(row.getRow());
+    String name = row.getString(NAME_COL);
+    String description = row.getString(DESC_COL);
+    String typeStr = row.getString(TYPE_COL);
+    SchemaDescriptorType type = SchemaDescriptorType.valueOf(typeStr);
+    long created = row.getLong(CREATED_COL);
+    long updated = row.getLong(UPDATED_COL);
+    long auto = row.getLong(AUTO_VERSION_COL);
+    Long current = row.getLong(CURRENT_VERSION_COL);
+    return new SchemaRow(id, name, description, type, created, updated, auto, current);
+  }
+
+  static Builder builder(SchemaRow existing) {
+    return new Builder(existing.getId())
+      .setName(existing.getName())
+      .setDescription(existing.getDescription())
+      .setType(existing.getType())
+      .setUpdated(existing.getUpdated())
+      .setAutoVersion(existing.getAutoVersion())
+      .setCurrentVersion(existing.getCurrentVersion());
+  }
+
+  static Builder builder(SchemaDescriptor descriptor) {
+    return new Builder(descriptor.getId())
+      .setName(descriptor.getName())
+      .setDescription(descriptor.getDescription())
+      .setType(descriptor.getType());
+  }
+
+  /**
+   * Builds a SchemaRow.
+   */
+  public static class Builder {
+    private final String id;
+    private String name;
+    private String description;
+    private SchemaDescriptorType type;
+    private long created;
+    private long updated;
+    private long autoVersion;
+    private Long currentVersion;
+
+    public Builder(String id) {
+      this.id = id;
+    }
+
+    public Builder setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    public Builder setType(SchemaDescriptorType type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder setCreated(long created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder setUpdated(long updated) {
+      this.updated = updated;
+      return this;
+    }
+
+    public Builder setAutoVersion(long autoVersion) {
+      this.autoVersion = autoVersion;
+      return this;
+    }
+
+    public Builder setCurrentVersion(Long currentVersion) {
+      this.currentVersion = currentVersion;
+      return this;
+    }
+
+    public SchemaRow build() {
+      return new SchemaRow(id, name, description, type, created, updated, autoVersion, currentVersion);
+    }
+  }
+}


### PR DESCRIPTION
Refactor the SchemaRegistry to fix bugs and get ready for storage
changes. The SchemaRegistry was changed to write to its own table
and to properly handle cases where the schema or schema entry
does not exist.

Also cleaned up the SchemaRegistryService to use proper java
classes instead of manually manipulating JsonObjects.