### PR TITLE
CDAP-14619 use a separate table for schema registry

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/DataPrep.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/DataPrep.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.wrangler.dataset.schema.SchemaRegistry;
 import co.cask.wrangler.dataset.workspace.WorkspaceDataset;
 import co.cask.wrangler.service.bigquery.BigQueryService;
 import co.cask.wrangler.service.connections.ConnectionService;
@@ -51,9 +52,11 @@ public class DataPrep extends AbstractApplication<ConnectionTypeConfig> {
     setDescription("DataPrep Backend Service");
 
     createDataset(DirectivesService.WORKSPACE_DATASET, WorkspaceDataset.class,
-                  DatasetProperties.builder().setDescription("Dataprep workspace dataset").build());
+                  DatasetProperties.builder().setDescription("DataPrep workspace dataset").build());
     createDataset(CONNECTIONS_DATASET, Table.class,
                   DatasetProperties.builder().setDescription("DataPrep connections store.").build());
+    createDataset(SchemaRegistry.DATASET_NAME, Table.class,
+                  DatasetProperties.builder().setDescription("DataPrep schema registry.").build());
 
     // Used by the file service.
     createDataset("dataprepfs", FileSet.class, FileSetProperties.builder()

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/schema/SchemaRegistryService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/schema/SchemaRegistryService.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceContext;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
-import co.cask.wrangler.DataPrep;
 import co.cask.wrangler.dataset.schema.SchemaDescriptor;
 import co.cask.wrangler.dataset.schema.SchemaNotFoundException;
 import co.cask.wrangler.dataset.schema.SchemaRegistry;
@@ -53,7 +52,7 @@ import static co.cask.wrangler.ServiceUtils.success;
 public class SchemaRegistryService extends AbstractHttpServiceHandler {
   private static final Gson GSON = new Gson();
 
-  @UseDataSet(DataPrep.CONNECTIONS_DATASET)
+  @UseDataSet(SchemaRegistry.DATASET_NAME)
   private Table table;
 
   private SchemaRegistry registry;

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaRegistry.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaRegistry.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
  * of the latest schema entry.
  */
 public final class SchemaRegistry  {
+  public static final String DATASET_NAME = "schemaRegistry";
   // Table in which all the information of the schema is stored.
   private final Table table;
 


### PR DESCRIPTION
Instead of sharing the same table between the connection store and
schema registry, use separate tables. This is to prepare for the
switch to the system table SPI, where each table has its own
set schema.