### PR TITLE
CDAP-14709 fix read logic for GCS connections

### DIFF
--- a/wrangler-service/src/test/java/co/cask/wrangler/service/gcs/GCSServiceTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/gcs/GCSServiceTest.java
@@ -57,7 +57,7 @@ public class GCSServiceTest {
       String fileType = detector.detectFileType(blobName);
 
       try (ReadChannel reader = blob.reader()) {
-        int min = Math.min(blob.getSize().intValue(), GCSService.FILE_SIZE);
+        int min = (int) Math.min(blob.getSize(), GCSService.FILE_SIZE);
         reader.setChunkSize(min);
         byte[] bytes = new byte[min];
         WritableByteChannel writable = Channels.newChannel(new ByteArrayOutputStream(min));


### PR DESCRIPTION
Fixed an issue where GCS objects larger than 2gb would cause an
error due to casting that length to an integer and using it to
allocate a byte array, resulting in a byte array of negative size.

Also fixed a bug in reading GCS blob content that caused data to
be jumbled.