### PR TITLE
CDAP-14709 fix read logic for GCS connections

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSService.java
@@ -89,7 +89,7 @@ import static co.cask.wrangler.ServiceUtils.error;
  */
 public class GCSService extends AbstractWranglerService {
   private static final Logger LOG = LoggerFactory.getLogger(GCSService.class);
-  static final int FILE_SIZE = 10 * 1024 * 1024;
+  static final long FILE_SIZE = 10 * 1024 * 1024;
   private FileTypeDetector detector;
 
   @Override
@@ -262,11 +262,11 @@ public class GCSService extends AbstractWranglerService {
   }
 
   private byte[] readGCSFile(Blob blob, int len) throws IOException {
-    try (ReadChannel reader = blob.reader()) {
+    try (ReadChannel reader = blob.reader();
+      ByteArrayOutputStream os = new ByteArrayOutputStream(len)) {
       reader.setChunkSize(len);
-      byte[] bytes = new byte[len];
-      WritableByteChannel writable = Channels.newChannel(new ByteArrayOutputStream(len));
-      ByteBuffer buf = ByteBuffer.wrap(bytes);
+      WritableByteChannel writable = Channels.newChannel(os);
+      ByteBuffer buf = ByteBuffer.wrap(new byte[8192]);
       long total = len;
       while (reader.read(buf) != -1 && total > 0) {
         buf.flip();
@@ -275,7 +275,7 @@ public class GCSService extends AbstractWranglerService {
         }
         buf.clear();
       }
-      return bytes;
+      return os.toByteArray();
     }
   }
 
@@ -327,7 +327,8 @@ public class GCSService extends AbstractWranglerService {
       File file = new File(blobName);
 
       if (!blob.isDirectory()) {
-        byte[] bytes = readGCSFile(blob, Math.min(blob.getSize().intValue(), GCSService.FILE_SIZE));
+        boolean shouldTruncate = blob.getSize() > FILE_SIZE;
+        byte[] bytes = readGCSFile(blob, (int) (shouldTruncate ? FILE_SIZE : blob.getSize()));
         ws.createWorkspaceMeta(id, scope, file.getName());
 
         String encoding = BytesDecoder.guessEncoding(bytes);
@@ -343,8 +344,10 @@ public class GCSService extends AbstractWranglerService {
           }
 
           List<Row> rows = new ArrayList<>();
-          for (String line : lines) {
-            rows.add(new Row("body", line));
+          // if the content was truncated, ignore the last line because it's probably not complete.
+          int numLines = shouldTruncate && lines.length > 1 ? lines.length - 1 : lines.length;
+          for (int i = 0; i < numLines; i++) {
+            rows.add(new Row("body", lines[i]));
           }
 
           ObjectSerDe<List<Row>> serDe = new ObjectSerDe<>();

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/gcs/GCSServiceTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/gcs/GCSServiceTest.java
@@ -57,7 +57,7 @@ public class GCSServiceTest {
       String fileType = detector.detectFileType(blobName);
 
       try (ReadChannel reader = blob.reader()) {
-        int min = Math.min(blob.getSize().intValue(), GCSService.FILE_SIZE);
+        int min = (int) Math.min(blob.getSize(), GCSService.FILE_SIZE);
         reader.setChunkSize(min);
         byte[] bytes = new byte[min];
         WritableByteChannel writable = Channels.newChannel(new ByteArrayOutputStream(min));


### PR DESCRIPTION
Fixed an issue where GCS objects larger than 2gb would cause an
error due to casting that length to an integer and using it to
allocate a byte array, resulting in a byte array of negative size.

Also fixed a bug in reading GCS blob content that caused data to
be jumbled.