### PR TITLE
CDAP-14619 refactor workspace dataset

### DIFF
--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/Recipe.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/Recipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,19 +17,20 @@
 package co.cask.wrangler.proto;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Defines the recipe object that is part of the {@link Request}
  */
 public class Recipe {
   // RecipeParser specified by the user
-  private List<String> directives;
+  private final List<String> directives;
 
   // Ability to save the directives
-  private Boolean save;
+  private final Boolean save;
 
   // Name of the recipe.
-  private String name;
+  private final String name;
 
   public Recipe(List<String> directives, Boolean save, String name) {
     this.directives = directives;
@@ -70,5 +71,24 @@ public class Recipe {
    */
   public String getName() {
     return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Recipe recipe = (Recipe) o;
+    return Objects.equals(directives, recipe.directives) &&
+      Objects.equals(save, recipe.save) &&
+      Objects.equals(name, recipe.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(directives, save, name);
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/RequestV1.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/RequestV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,28 +18,29 @@ package co.cask.wrangler.proto;
 
 import com.google.gson.JsonObject;
 
+import java.util.Objects;
+
 /**
  * Specifies the V1 version of the {@link Request} object.
  */
 public final class RequestV1 implements Request {
   // Version of request.
-  private int version;
+  private final int version;
 
   // Workspace information associated with request.
-  private Workspace workspace;
+  private final Workspace workspace;
 
   // TestRecipe information associated with request.
-  private Recipe recipe;
+  private final Recipe recipe;
 
   // Sampling information associated with request.
-  private Sampling sampling;
+  private final Sampling sampling;
 
   // Additional properties that is of type json.
-  private JsonObject properties;
+  private final JsonObject properties;
 
-  public RequestV1(int version, Workspace workspace, Recipe recipe, Sampling sampling,
-                   JsonObject properties) {
-    this.version = version;
+  public RequestV1(Workspace workspace, Recipe recipe, Sampling sampling, JsonObject properties) {
+    this.version = 1;
     this.workspace = workspace;
     this.recipe = recipe;
     this.sampling = sampling;
@@ -84,5 +85,26 @@ public final class RequestV1 implements Request {
   @Override
   public JsonObject getProperties() {
     return properties;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RequestV1 requestV1 = (RequestV1) o;
+    return version == requestV1.version &&
+      Objects.equals(workspace, requestV1.workspace) &&
+      Objects.equals(recipe, requestV1.recipe) &&
+      Objects.equals(sampling, requestV1.sampling) &&
+      Objects.equals(properties, requestV1.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, workspace, recipe, sampling, properties);
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/Sampling.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/Sampling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,18 +16,26 @@
 
 package co.cask.wrangler.proto;
 
+import java.util.Objects;
+
 /**
  * Defines the sampling specification of the {@link Request}
  */
 public final class Sampling {
   // Sampling method.
-  private String method;
+  private final String method;
 
   // Seeding capability for sampling.
-  private Integer seed;
+  private final Integer seed;
 
   // Number of records to be read.
-  private Integer limit;
+  private final Integer limit;
+
+  public Sampling(String method, Integer seed, Integer limit) {
+    this.method = method;
+    this.seed = seed;
+    this.limit = limit;
+  }
 
   /**
    * @return Method for sampling data.
@@ -56,5 +64,24 @@ public final class Sampling {
     } else {
       return 100;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Sampling sampling = (Sampling) o;
+    return Objects.equals(method, sampling.method) &&
+      Objects.equals(seed, sampling.seed) &&
+      Objects.equals(limit, sampling.limit);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(method, seed, limit);
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/Workspace.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/Workspace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,15 +16,22 @@
 
 package co.cask.wrangler.proto;
 
+import java.util.Objects;
+
 /**
  * Specification about workspace for the {@link Request}
  */
 public final class Workspace {
   // Name of the workspace.
-  private String name;
+  private final String name;
 
   // Number of results to be returned for the workspace.
-  private Integer results;
+  private final Integer results;
+
+  public Workspace(String name, Integer results) {
+    this.name = name;
+    this.results = results;
+  }
 
   /**
    * @return Name of the workspace.
@@ -38,5 +45,23 @@ public final class Workspace {
    */
   public Integer getResults() {
     return results;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Workspace workspace = (Workspace) o;
+    return Objects.equals(name, workspace.name) &&
+      Objects.equals(results, workspace.results);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, results);
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/WorkspaceIdentifier.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/WorkspaceIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,6 +15,8 @@
  */
 package co.cask.wrangler.proto;
 
+import java.util.Objects;
+
 /**
  * Workspace identifier information sent as response after reading table data into workspace
  */
@@ -25,5 +27,30 @@ public class WorkspaceIdentifier {
   public WorkspaceIdentifier(String id, String name) {
     this.id = id;
     this.name = name;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WorkspaceIdentifier that = (WorkspaceIdentifier) o;
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name);
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/DataPrep.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/DataPrep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,17 +23,17 @@ import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.wrangler.dataset.schema.SchemaRegistry;
 import co.cask.wrangler.dataset.workspace.WorkspaceDataset;
-import co.cask.wrangler.service.bigquery.BigQueryService;
-import co.cask.wrangler.service.connections.ConnectionService;
+import co.cask.wrangler.service.bigquery.BigQueryHandler;
+import co.cask.wrangler.service.connections.ConnectionHandler;
 import co.cask.wrangler.service.connections.ConnectionTypeConfig;
-import co.cask.wrangler.service.database.DatabaseService;
-import co.cask.wrangler.service.directive.DirectivesService;
+import co.cask.wrangler.service.database.DatabaseHandler;
+import co.cask.wrangler.service.directive.DirectivesHandler;
 import co.cask.wrangler.service.explorer.FilesystemExplorer;
-import co.cask.wrangler.service.gcs.GCSService;
-import co.cask.wrangler.service.kafka.KafkaService;
-import co.cask.wrangler.service.s3.S3Service;
-import co.cask.wrangler.service.schema.SchemaRegistryService;
-import co.cask.wrangler.service.spanner.SpannerService;
+import co.cask.wrangler.service.gcs.GCSHandler;
+import co.cask.wrangler.service.kafka.KafkaHandler;
+import co.cask.wrangler.service.s3.S3Handler;
+import co.cask.wrangler.service.schema.SchemaRegistryHandler;
+import co.cask.wrangler.service.spanner.SpannerHandler;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.TextOutputFormat;
 
@@ -51,8 +51,8 @@ public class DataPrep extends AbstractApplication<ConnectionTypeConfig> {
     setName("dataprep");
     setDescription("DataPrep Backend Service");
 
-    createDataset(DirectivesService.WORKSPACE_DATASET, WorkspaceDataset.class,
-                  DatasetProperties.builder().setDescription("DataPrep workspace dataset").build());
+    createDataset(WorkspaceDataset.DATASET_NAME, Table.class,
+                  DatasetProperties.builder().setDescription("DataPrep workspace dataset.").build());
     createDataset(CONNECTIONS_DATASET, Table.class,
                   DatasetProperties.builder().setDescription("DataPrep connections store.").build());
     createDataset(SchemaRegistry.DATASET_NAME, Table.class,
@@ -67,16 +67,16 @@ public class DataPrep extends AbstractApplication<ConnectionTypeConfig> {
       .build());
 
     addService("service",
-               new DirectivesService(),
-               new SchemaRegistryService(),
+               new DirectivesHandler(),
+               new SchemaRegistryHandler(),
                new FilesystemExplorer(),
-               new ConnectionService(getConfig()),
-               new KafkaService(),
-               new DatabaseService(),
-               new S3Service(),
-               new GCSService(),
-               new BigQueryService(),
-               new SpannerService()
+               new ConnectionHandler(getConfig()),
+               new KafkaHandler(),
+               new DatabaseHandler(),
+               new S3Handler(),
+               new GCSHandler(),
+               new BigQueryHandler(),
+               new SpannerHandler()
     );
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/RequestExtractor.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/RequestExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2018 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,8 @@
 package co.cask.wrangler;
 
 import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.wrangler.dataset.workspace.RequestDeserializer;
 import co.cask.wrangler.proto.Request;
-import co.cask.wrangler.service.directive.RequestDeserializer;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/common/AbstractWranglerHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/common/AbstractWranglerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,56 +22,58 @@ import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceContext;
 import co.cask.wrangler.DataPrep;
 import co.cask.wrangler.dataset.connections.ConnectionStore;
-import co.cask.wrangler.dataset.workspace.DataType;
+import co.cask.wrangler.dataset.workspace.Workspace;
 import co.cask.wrangler.dataset.workspace.WorkspaceDataset;
-import co.cask.wrangler.dataset.workspace.WorkspaceException;
+import co.cask.wrangler.dataset.workspace.WorkspaceNotFoundException;
 import co.cask.wrangler.proto.Recipe;
-import co.cask.wrangler.proto.RequestV1;
-import com.google.gson.Gson;
+import co.cask.wrangler.proto.Request;
 
 import java.util.List;
 import javax.annotation.Nullable;
 
-import static co.cask.wrangler.service.directive.DirectivesService.WORKSPACE_DATASET;
-
 /**
  * Common functionality for wrangler services.
  */
-public class AbstractWranglerService extends AbstractHttpServiceHandler {
-  private static final Gson GSON = new Gson();
+public class AbstractWranglerHandler extends AbstractHttpServiceHandler {
   protected ConnectionStore store;
 
   @UseDataSet(DataPrep.CONNECTIONS_DATASET)
   private Table connectionTable;
 
-  @UseDataSet(WORKSPACE_DATASET)
+  @UseDataSet(WorkspaceDataset.DATASET_NAME)
+  private Table workspaceTable;
+
   protected WorkspaceDataset ws;
 
   @Override
   public void initialize(HttpServiceContext context) throws Exception {
     super.initialize(context);
     store = new ConnectionStore(connectionTable);
+    ws = new WorkspaceDataset(workspaceTable);
   }
 
   /**
    * Return whether the header needs to be copied when creating the pipeline source for the specified workspace.
    * This just amounts to checking whether parse-as-csv with the first line as a header is used as a directive.
    */
-  protected boolean shouldCopyHeader(@Nullable String workspaceId) throws WorkspaceException {
+  protected boolean shouldCopyHeader(@Nullable String workspaceId) {
     if (workspaceId == null) {
       return false;
     }
-    String data = ws.getData(workspaceId, WorkspaceDataset.REQUEST_COL, DataType.TEXT);
-    if (data == null) {
+    try {
+      Workspace workspace = ws.getWorkspace(workspaceId);
+      Request request = workspace.getRequest();
+      if (request == null) {
+        return false;
+      }
+      Recipe recipe = request.getRecipe();
+      List<String> directives = recipe.getDirectives();
+      // yes this is really hacky, but there doesn't seem to be a good way to get the actual directive classes
+      return directives.stream()
+        .map(String::trim)
+        .anyMatch(directive -> directive.startsWith("parse-as-csv") && directive.endsWith("true"));
+    } catch (WorkspaceNotFoundException e) {
       return false;
     }
-
-    RequestV1 workspaceReq = GSON.fromJson(data, RequestV1.class);
-    Recipe recipe = workspaceReq.getRecipe();
-    List<String> directives = recipe.getDirectives();
-    // yes this is really hacky, but there doesn't seem to be a good way to get the actual directive classes
-    return directives.stream()
-      .map(String::trim)
-      .anyMatch(directive -> directive.startsWith("parse-as-csv") && directive.endsWith("true"));
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionHandler.java
@@ -16,18 +16,14 @@
 
 package co.cask.wrangler.service.connections;
 
-import co.cask.cdap.api.annotation.UseDataSet;
-import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceContext;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
-import co.cask.wrangler.DataPrep;
 import co.cask.wrangler.RequestExtractor;
 import co.cask.wrangler.dataset.connections.Connection;
-import co.cask.wrangler.dataset.connections.ConnectionStore;
 import co.cask.wrangler.dataset.connections.ConnectionType;
 import co.cask.wrangler.proto.ServiceResponse;
+import co.cask.wrangler.service.common.AbstractWranglerHandler;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import org.slf4j.Logger;
@@ -56,21 +52,16 @@ import static co.cask.wrangler.ServiceUtils.notFound;
 /**
  * This service exposes REST APIs for managing the lifecycle of a connection in the connection store.
  */
-public class ConnectionService extends AbstractHttpServiceHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(ConnectionService.class);
+public class ConnectionHandler extends AbstractWranglerHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectionHandler.class);
   private static final String CONNECTION_TYPE_CONFIG = "connectionTypeConfig";
   private static final Gson GSON = new Gson();
   private static final String ALL_TYPES = "*";
-  // Data Prep store which stores all the information associated with dataprep.
-  @UseDataSet(DataPrep.CONNECTIONS_DATASET)
-  private Table table;
 
-  // Abstraction over the table defined above for managing connections.
-  private ConnectionStore store;
   private ConnectionTypeConfig connectionTypeConfig;
   private List<ConnectionTypeInfo> enabledConnectionTypes;
 
-  public ConnectionService(ConnectionTypeConfig connectionTypeConfig) {
+  public ConnectionHandler(ConnectionTypeConfig connectionTypeConfig) {
     this.connectionTypeConfig = connectionTypeConfig;
   }
 
@@ -88,7 +79,6 @@ public class ConnectionService extends AbstractHttpServiceHandler {
   @Override
   public void initialize(HttpServiceContext context) throws Exception {
     super.initialize(context);
-    store = new ConnectionStore(table);
     // initialize available connections
     this.enabledConnectionTypes = new ArrayList<>();
     String connectionTypeConfigString = context.getSpecification().getProperty(CONNECTION_TYPE_CONFIG);

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/schema/SchemaRegistryHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/schema/SchemaRegistryHandler.java
@@ -47,9 +47,9 @@ import static co.cask.wrangler.ServiceUtils.notFound;
 import static co.cask.wrangler.ServiceUtils.success;
 
 /**
- * This class {@link SchemaRegistryService} provides schema management service.
+ * This class {@link SchemaRegistryHandler} provides schema management service.
  */
-public class SchemaRegistryService extends AbstractHttpServiceHandler {
+public class SchemaRegistryHandler extends AbstractHttpServiceHandler {
   private static final Gson GSON = new Gson();
 
   @UseDataSet(SchemaRegistry.DATASET_NAME)

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/WranglerServiceTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/WranglerServiceTest.java
@@ -26,7 +26,7 @@ import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
 import co.cask.wrangler.DataPrep;
-import co.cask.wrangler.service.directive.DirectivesService;
+import co.cask.wrangler.service.directive.DirectivesHandler;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -43,7 +43,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Tests for {@link DirectivesService}.
+ * Tests for {@link DirectivesHandler}.
  */
 @Ignore
 public class WranglerServiceTest extends WranglerServiceTestBase {

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/WranglerServiceTestBase.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/WranglerServiceTestBase.java
@@ -20,7 +20,7 @@ import co.cask.cdap.test.TestBase;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
-import co.cask.wrangler.service.directive.DirectivesService;
+import co.cask.wrangler.service.directive.DirectivesHandler;
 import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Base class which exposes utility functions for interacting with {@link DirectivesService}.
+ * Base class which exposes utility functions for interacting with {@link DirectivesHandler}.
  */
 @Ignore
 public class WranglerServiceTestBase extends TestBase {

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/bigquery/BigQueryServiceTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/bigquery/BigQueryServiceTest.java
@@ -27,7 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Tests for {@link BigQueryService}.
+ * Tests for {@link BigQueryHandler}.
  */
 public class BigQueryServiceTest {
 
@@ -46,7 +46,7 @@ public class BigQueryServiceTest {
     expected.add(DatasetId.of("p1", "d1"));
     expected.add(DatasetId.of("pX", "d2"));
     expected.add(DatasetId.of("pX", "d3"));
-    Set<DatasetId> actual = BigQueryService.getDatasetWhitelist(connection);
+    Set<DatasetId> actual = BigQueryHandler.getDatasetWhitelist(connection);
     Assert.assertEquals(expected, actual);
   }
 }

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/database/DatabaseHandlerTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/database/DatabaseHandlerTest.java
@@ -52,7 +52,7 @@ import java.util.TimeZone;
 /**
  * Class description here.
  */
-public class DatabaseServiceTest {
+public class DatabaseHandlerTest {
   private static HSQLDBServer hsqlDBServer;
   private static final long CURRENT_TS = System.currentTimeMillis();
 
@@ -114,7 +114,7 @@ public class DatabaseServiceTest {
   @Test
   public void testReadingDriverConfiguration() throws Exception {
     Multimap<String, DriverInfo> drivers = ArrayListMultimap.create();
-    InputStream is = DatabaseService.class.getClassLoader().getResourceAsStream("drivers.mapping");
+    InputStream is = DatabaseHandler.class.getClassLoader().getResourceAsStream("drivers.mapping");
     try {
       BufferedReader br = new BufferedReader(new InputStreamReader(is));
       String line;
@@ -169,7 +169,7 @@ public class DatabaseServiceTest {
          Statement stmt = conn.createStatement()) {
       stmt.execute("SELECT * FROM \"my_table\"");
       try (ResultSet resultSet = stmt.getResultSet()) {
-        List<Row> actual = DatabaseService.getRows(2, resultSet);
+        List<Row> actual = DatabaseHandler.getRows(2, resultSet);
         Assert.assertEquals(expected.get(0).getValue(0), actual.get(0).getValue(0));
         Assert.assertEquals(expected.get(0).getValue(1), actual.get(0).getValue(1));
         Assert.assertEquals(expected.get(0).getValue(2), actual.get(0).getValue(2));

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/directive/RequestTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/directive/RequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,6 +16,7 @@
 
 package co.cask.wrangler.service.directive;
 
+import co.cask.wrangler.dataset.workspace.RequestDeserializer;
 import co.cask.wrangler.proto.Request;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/explorer/GCSServiceTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/explorer/GCSServiceTest.java
@@ -17,7 +17,7 @@
 package co.cask.wrangler.service.explorer;
 
 import co.cask.wrangler.service.gcp.GCPUtils;
-import co.cask.wrangler.service.gcs.GCSService;
+import co.cask.wrangler.service.gcs.GCSHandler;
 import com.google.api.gax.paging.Page;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.storage.Blob;
@@ -34,7 +34,7 @@ import java.net.HttpURLConnection;
 import java.util.Iterator;
 
 /**
- * Tests {@link GCSService}
+ * Tests {@link GCSHandler}
  */
 @Ignore
 public class GCSServiceTest {

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/gcs/GCSServiceTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/gcs/GCSServiceTest.java
@@ -37,7 +37,7 @@ import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
 
 /**
- * Tests parts of {@link GCSService}
+ * Tests parts of {@link GCSHandler}
  */
 @Ignore
 public class GCSServiceTest {
@@ -57,7 +57,7 @@ public class GCSServiceTest {
       String fileType = detector.detectFileType(blobName);
 
       try (ReadChannel reader = blob.reader()) {
-        int min = (int) Math.min(blob.getSize(), GCSService.FILE_SIZE);
+        int min = (int) Math.min(blob.getSize(), GCSHandler.FILE_SIZE);
         reader.setChunkSize(min);
         byte[] bytes = new byte[min];
         WritableByteChannel writable = Channels.newChannel(new ByteArrayOutputStream(min));
@@ -75,7 +75,7 @@ public class GCSServiceTest {
           && (encoding.equalsIgnoreCase("utf-8") || encoding.equalsIgnoreCase("ascii"))) {
           String data = new String(bytes, encoding);
           String[] lines = data.split("\r\n|\r|\n");
-          if (blob.getSize() > GCSService.FILE_SIZE) {
+          if (blob.getSize() > GCSHandler.FILE_SIZE) {
             lines = Arrays.copyOf(lines, lines.length - 1);
           }
           Assert.assertTrue(lines.length == lines.length - 1);

--- a/wrangler-service/src/test/java/co/cask/wrangler/service/schema/SchemaRegistryServiceTest.java
+++ b/wrangler-service/src/test/java/co/cask/wrangler/service/schema/SchemaRegistryServiceTest.java
@@ -17,7 +17,7 @@
 package co.cask.wrangler.service.schema;
 
 /**
- * Tests {@link SchemaRegistryService}
+ * Tests {@link SchemaRegistryHandler}
  */
 public class SchemaRegistryServiceTest {
   // NOTE: Once, we fix the issue with the guava inclusion in TestBase, need to add tests here.

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/DataType.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/DataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,6 +15,8 @@
  */
 
 package co.cask.wrangler.dataset.workspace;
+
+import javax.annotation.Nullable;
 
 /**
  * This class {@link DataType} defines types of data that can be stored in a workspace.
@@ -50,6 +52,7 @@ public enum DataType {
    * @param text representation of the type.
    * @return an instance of {@link DataType} based on it's string representation, null if not found.
    */
+  @Nullable
   public static DataType fromString(String text) {
     for (DataType b : DataType.values()) {
       if (b.type.equalsIgnoreCase(text)) {

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/RequestDeserializer.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/RequestDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.wrangler.service.directive;
+package co.cask.wrangler.dataset.workspace;
 
 import co.cask.wrangler.proto.Recipe;
 import co.cask.wrangler.proto.Request;
@@ -53,7 +53,7 @@ public class RequestDeserializer implements JsonDeserializer<Request> {
       Recipe recipe = context.deserialize(object.get("recipe"), Recipe.class);
       Sampling sampling = context.deserialize(object.get("sampling"), Sampling.class);
       JsonObject properties = context.deserialize(object.get("properties"), JsonObject.class);
-      return new RequestV1(version, workspace, recipe, sampling, properties);
+      return new RequestV1(workspace, recipe, sampling, properties);
     } else {
       throw new JsonParseException (
         String.format("Unsupported request version %d.", version)

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/Workspace.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/Workspace.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.dataset.workspace;
+
+import co.cask.wrangler.proto.Request;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Contains all information about a workspace.
+ */
+public class Workspace extends WorkspaceMeta {
+  private final long created;
+  private final long updated;
+  private final byte[] data;
+  private final Request request;
+
+  private Workspace(String id, String name, String scope, DataType type, Map<String, String> properties,
+                    long created, long updated, @Nullable byte[] data, @Nullable Request request) {
+    super(id, name, scope, type, properties);
+    this.created = created;
+    this.updated = updated;
+    this.data = data == null ? null : Arrays.copyOf(data, data.length);
+    this.request = request;
+  }
+
+  public long getCreated() {
+    return created;
+  }
+
+  public long getUpdated() {
+    return updated;
+  }
+
+  @Nullable
+  public byte[] getData() {
+    return data;
+  }
+
+  @Nullable
+  public Request getRequest() {
+    return request;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    Workspace workspace = (Workspace) o;
+    return created == workspace.created &&
+      updated == workspace.updated &&
+      Arrays.equals(data, workspace.data) &&
+      Objects.equals(request, workspace.request);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(super.hashCode(), created, updated, request);
+    result = 31 * result + Arrays.hashCode(data);
+    return result;
+  }
+
+  public static Builder builder(String id, String name) {
+    return new Builder(id, name);
+  }
+
+  public static Builder builder(Workspace existing) {
+    return new Builder(existing.getId(), existing.getName())
+      .setType(existing.getType())
+      .setScope(existing.getScope())
+      .setCreated(existing.getCreated())
+      .setUpdated(existing.getUpdated())
+      .setProperties(existing.getProperties())
+      .setData(existing.getData())
+      .setRequest(existing.getRequest());
+  }
+
+  /**
+   * Creates Workspace objects.
+   */
+  public static class Builder extends WorkspaceMeta.Builder<Builder> {
+    private long created;
+    private long updated;
+    private byte[] data;
+    private Request request;
+
+    Builder(String id, String name) {
+      super(id, name);
+    }
+
+    public Builder setCreated(long created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder setUpdated(long updated) {
+      this.updated = updated;
+      return this;
+    }
+
+    public Builder setData(byte[] data) {
+      this.data = data;
+      return this;
+    }
+
+    public Builder setRequest(Request request) {
+      this.request = request;
+      return this;
+    }
+
+    public Workspace build() {
+      return new Workspace(id, name, scope, type, properties, created, updated, data, request);
+    }
+  }
+}

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/WorkspaceMeta.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/WorkspaceMeta.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.dataset.workspace;
+
+import co.cask.wrangler.proto.WorkspaceIdentifier;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Metadata about a workspace.
+ */
+public class WorkspaceMeta extends WorkspaceIdentifier {
+  private final String scope;
+  private final DataType type;
+  private final Map<String, String> properties;
+
+  protected WorkspaceMeta(String id, String name, String scope, DataType type, Map<String, String> properties) {
+    super(id, name);
+    this.scope = scope;
+    this.type = type;
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public DataType getType() {
+    return type;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    WorkspaceMeta that = (WorkspaceMeta) o;
+    return Objects.equals(scope, that.scope) &&
+      type == that.type &&
+      Objects.equals(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), scope, type, properties);
+  }
+
+  public static Builder builder(String id, String name) {
+    return new Builder(id, name);
+  }
+
+  /**
+   * Creates a WorkspaceMeta instance.
+   *
+   * @param <T> type of builder
+   */
+  @SuppressWarnings("unchecked")
+  public static class Builder<T extends Builder> {
+    protected final String id;
+    protected final String name;
+    protected String scope;
+    protected DataType type;
+    protected Map<String, String> properties;
+
+    Builder(String id, String name) {
+      this.id = id;
+      this.name = name;
+      this.properties = new HashMap<>();
+      this.scope = WorkspaceDataset.DEFAULT_SCOPE;
+      this.type = DataType.BINARY;
+    }
+
+    public T setScope(String scope) {
+      this.scope = scope;
+      return (T) this;
+    }
+
+    public T setType(DataType type) {
+      this.type = type;
+      return (T) this;
+    }
+
+    public T setProperties(Map<String, String> properties) {
+      this.properties.clear();
+      this.properties.putAll(properties);
+      return (T) this;
+    }
+
+    public WorkspaceMeta build() {
+      return new WorkspaceMeta(id, name, scope, type, properties);
+    }
+  }
+}

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/WorkspaceNotFoundException.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/WorkspaceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,11 +17,11 @@
 package co.cask.wrangler.dataset.workspace;
 
 /**
- * This class {@link WorkspaceException} is thrown when there is any issue with dealing with workspace
- * abnormalities.
+ * Thrown when a workspace is not found when it is expected to exist.
  */
-public class WorkspaceException extends Exception {
-  public WorkspaceException(String message) {
+public class WorkspaceNotFoundException extends Exception {
+
+  public WorkspaceNotFoundException(String message) {
     super(message);
   }
 }

--- a/wrangler-storage/src/test/java/co/cask/wrangler/dataset/WorkspaceDatasetTest.java
+++ b/wrangler-storage/src/test/java/co/cask/wrangler/dataset/WorkspaceDatasetTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.dataset;
+
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
+import co.cask.wrangler.dataset.workspace.DataType;
+import co.cask.wrangler.dataset.workspace.Workspace;
+import co.cask.wrangler.dataset.workspace.WorkspaceDataset;
+import co.cask.wrangler.dataset.workspace.WorkspaceMeta;
+import co.cask.wrangler.dataset.workspace.WorkspaceNotFoundException;
+import co.cask.wrangler.proto.Recipe;
+import co.cask.wrangler.proto.Request;
+import co.cask.wrangler.proto.RequestV1;
+import co.cask.wrangler.proto.Sampling;
+import co.cask.wrangler.proto.WorkspaceIdentifier;
+import com.google.gson.JsonObject;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Tests for the workspace dataset.
+ */
+public class WorkspaceDatasetTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+
+  @Test
+  public void testNotFoundExceptions() throws Exception {
+    addDatasetInstance("table", "notfoundTest");
+    DataSetManager<Table> tableManager = getDataset("notfoundTest");
+    Table table = tableManager.get();
+    WorkspaceDataset workspaceDataset = new WorkspaceDataset(table);
+
+    try {
+      workspaceDataset.updateWorkspaceData("id", DataType.TEXT, new byte[] { 0 });
+      Assert.fail("Updating a non-existing workspace should fail.");
+    } catch (WorkspaceNotFoundException e) {
+      // expected
+    }
+
+    try {
+      workspaceDataset.updateWorkspaceProperties("id", Collections.emptyMap());
+      Assert.fail("Updating a non-existing workspace should fail.");
+    } catch (WorkspaceNotFoundException e) {
+      // expected
+    }
+
+    try {
+      workspaceDataset.updateWorkspaceRequest("id", null);
+      Assert.fail("Updating a non-existing workspace should fail.");
+    } catch (WorkspaceNotFoundException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testScopes() throws Exception {
+    addDatasetInstance("table", "scopeTest");
+    DataSetManager<Table> tableManager = getDataset("scopeTest");
+    Table table = tableManager.get();
+    WorkspaceDataset workspaceDataset = new WorkspaceDataset(table);
+
+    WorkspaceIdentifier id1 = new WorkspaceIdentifier("id1", "name1");
+    WorkspaceIdentifier id2 = new WorkspaceIdentifier("id2", "name2");
+
+    String scope1 = "scope1";
+    String scope2 = "scope2";
+    WorkspaceMeta meta1 = WorkspaceMeta.builder(id1.getId(), id1.getName())
+      .setScope(scope1)
+      .build();
+    WorkspaceMeta meta2 = WorkspaceMeta.builder(id2.getId(), id2.getName())
+      .setScope(scope2)
+      .build();
+
+    workspaceDataset.writeWorkspaceMeta(meta1);
+    workspaceDataset.writeWorkspaceMeta(meta2);
+    tableManager.flush();
+
+    Assert.assertEquals(Collections.singletonList(id1), workspaceDataset.listWorkspaces(scope1));
+    Assert.assertEquals(Collections.singletonList(id2), workspaceDataset.listWorkspaces(scope2));
+
+    workspaceDataset.deleteScope(scope1);
+    tableManager.flush();
+
+    Assert.assertTrue(workspaceDataset.listWorkspaces(scope1).isEmpty());
+    Assert.assertEquals(Collections.singletonList(id2), workspaceDataset.listWorkspaces(scope2));
+
+    workspaceDataset.deleteWorkspace(id2.getId());
+    tableManager.flush();
+    Assert.assertTrue(workspaceDataset.listWorkspaces(scope1).isEmpty());
+    Assert.assertTrue(workspaceDataset.listWorkspaces(scope2).isEmpty());
+  }
+
+  @Test
+  public void testCRUD() throws Exception {
+    addDatasetInstance("table", "crudtest");
+    DataSetManager<Table> tableManager = getDataset("crudtest");
+    Table table = tableManager.get();
+    WorkspaceDataset workspaceDataset = new WorkspaceDataset(table);
+
+    String id = "id0";
+    Assert.assertTrue(workspaceDataset.listWorkspaces("default").isEmpty());
+    Assert.assertFalse(workspaceDataset.hasWorkspace(id));
+    WorkspaceIdentifier workspaceIdentifier = new WorkspaceIdentifier(id, "name");
+
+    // test write and get
+    WorkspaceMeta meta = WorkspaceMeta.builder(workspaceIdentifier.getId(), workspaceIdentifier.getName())
+      .setScope("default")
+      .setType(DataType.BINARY)
+      .setProperties(Collections.singletonMap("k1", "v1"))
+      .build();
+    workspaceDataset.writeWorkspaceMeta(meta);
+    tableManager.flush();
+
+    Workspace actual = workspaceDataset.getWorkspace(id);
+    Workspace expected = Workspace.builder(meta.getId(), meta.getName())
+      .setCreated(actual.getCreated())
+      .setUpdated(actual.getUpdated())
+      .setType(meta.getType())
+      .setScope(meta.getScope())
+      .setProperties(meta.getProperties())
+      .build();
+    Assert.assertEquals(expected, actual);
+    Assert.assertEquals(Collections.singletonList(workspaceIdentifier), workspaceDataset.listWorkspaces("default"));
+
+    // test updating properties
+    Map<String, String> properties = Collections.singletonMap("k2", "v2");
+    workspaceDataset.updateWorkspaceProperties(id, properties);
+    tableManager.flush();
+    actual = workspaceDataset.getWorkspace(id);
+    expected = Workspace.builder(expected)
+      .setUpdated(actual.getUpdated())
+      .setProperties(properties)
+      .build();
+    Assert.assertEquals(expected, actual);
+
+    // test updating request
+    co.cask.wrangler.proto.Workspace requestWorkspace = new co.cask.wrangler.proto.Workspace(meta.getName(), 10);
+    Recipe recipe = new Recipe(Collections.singletonList("parse-as-csv body"), true, "recipeName");
+    Sampling sampling = new Sampling("random", 0, 10);
+    Request request = new RequestV1(requestWorkspace, recipe, sampling, new JsonObject());
+    workspaceDataset.updateWorkspaceRequest(id, request);
+    tableManager.flush();
+    actual = workspaceDataset.getWorkspace(id);
+    expected = Workspace.builder(expected)
+      .setUpdated(actual.getUpdated())
+      .setRequest(request)
+      .build();
+    Assert.assertEquals(expected, actual);
+
+    // test updating data
+    byte[] data = new byte[] { 0, 1, 2 };
+    workspaceDataset.updateWorkspaceData(id, DataType.RECORDS, data);
+    tableManager.flush();
+    actual = workspaceDataset.getWorkspace(id);
+    expected = Workspace.builder(expected)
+      .setType(DataType.RECORDS)
+      .setUpdated(actual.getUpdated())
+      .setData(data)
+      .build();
+    Assert.assertEquals(expected, actual);
+
+    // test updating meta
+    meta = WorkspaceMeta.builder(meta.getId(), meta.getName())
+      .setType(DataType.TEXT)
+      .setProperties(Collections.singletonMap("k3", "v3"))
+      .build();
+    workspaceDataset.writeWorkspaceMeta(meta);
+    tableManager.flush();
+    actual = workspaceDataset.getWorkspace(id);
+    expected = Workspace.builder(expected)
+      .setUpdated(actual.getUpdated())
+      .setProperties(meta.getProperties())
+      .setType(meta.getType())
+      .build();
+    Assert.assertEquals(expected, actual);
+    Assert.assertEquals(Collections.singletonList(workspaceIdentifier), workspaceDataset.listWorkspaces("default"));
+
+    // delete workspace
+    workspaceDataset.deleteWorkspace(id);
+    tableManager.flush();
+    Assert.assertTrue(workspaceDataset.listWorkspaces("default").isEmpty());
+    try {
+      workspaceDataset.getWorkspace(id);
+      Assert.fail("Workspace was not deleted.");
+    } catch (WorkspaceNotFoundException e) {
+      // expected
+    }
+  }
+
+}


### PR DESCRIPTION
Refactored the workspace dataset so that logic is encapsulated
inside the class instead of leaked outside. This mostly amounts
to removing places where the DirectivesService would directly
access the underlying Table instead of having an abstraction layer
for updating and reading various workspace information.

Also removed useless exception wrapping and added better error
handling to avoid a bunch of possible null pointer exceptions
and to correctly check whether the workspace exists.

Also added unit tests for the WorkspaceDataset. This revealed a
bug where the method to delete workspaces within a scope actually
deleted every workspace that was not in that scope. Fixed the bug.