### PR TITLE
CDAP-14604 add a common layer for errors and namespace check

### DIFF
--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/BadRequestException.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/BadRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,18 +14,21 @@
  * the License.
  */
 
-package co.cask.wrangler.dataset;
+package co.cask.wrangler.proto;
+
+import java.net.HttpURLConnection;
 
 /**
- * This class {@link KeyNotFoundException} is thrown when a key in the dataset cannot be found.
- *
- * If any of the methods are attempting to retrieve a key from the dataset and the key is either
- * empty or null, then this exception is thrown. As this is a checked exception, the methods
- * need to declare it in the definition of the function.
- *
+ * Thrown if user provided input is invalid.
  */
-public class KeyNotFoundException extends Exception {
-  public KeyNotFoundException(String message) {
-    super(message);
+public class BadRequestException extends StatusCodeException {
+
+  public BadRequestException(String message) {
+    super(message, HttpURLConnection.HTTP_BAD_REQUEST);
   }
+
+  public BadRequestException(String message, Throwable cause) {
+    super(message, cause, HttpURLConnection.HTTP_BAD_REQUEST);
+  }
+
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/ConflictException.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/ConflictException.java
@@ -14,16 +14,20 @@
  * the License.
  */
 
-package co.cask.wrangler.dataset.connections;
+package co.cask.wrangler.proto;
 
-import co.cask.wrangler.proto.ConflictException;
+import java.net.HttpURLConnection;
 
 /**
- * Thrown when a connection already exists when none is expected.
+ * Thrown when there is some conflict
  */
-public class ConnectionAlreadyExistsException extends ConflictException {
+public class ConflictException extends StatusCodeException {
 
-  public ConnectionAlreadyExistsException(String message) {
-    super(message);
+  public ConflictException(String message) {
+    super(message, HttpURLConnection.HTTP_CONFLICT);
+  }
+
+  public ConflictException(String message, Throwable cause) {
+    super(message, cause, HttpURLConnection.HTTP_CONFLICT);
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/NotFoundException.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/NotFoundException.java
@@ -14,16 +14,20 @@
  * the License.
  */
 
-package co.cask.wrangler.dataset.connections;
+package co.cask.wrangler.proto;
 
-import co.cask.wrangler.proto.ConflictException;
+import java.net.HttpURLConnection;
 
 /**
- * Thrown when a connection already exists when none is expected.
+ * Thrown when some entity could not be found.
  */
-public class ConnectionAlreadyExistsException extends ConflictException {
+public class NotFoundException extends StatusCodeException {
 
-  public ConnectionAlreadyExistsException(String message) {
-    super(message);
+  public NotFoundException(String message) {
+    super(message, HttpURLConnection.HTTP_NOT_FOUND);
+  }
+
+  public NotFoundException(String message, Throwable cause) {
+    super(message, cause, HttpURLConnection.HTTP_NOT_FOUND);
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/StatusCodeException.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/StatusCodeException.java
@@ -14,16 +14,25 @@
  * the License.
  */
 
-package co.cask.wrangler.dataset.connections;
-
-import co.cask.wrangler.proto.ConflictException;
+package co.cask.wrangler.proto;
 
 /**
- * Thrown when a connection already exists when none is expected.
+ * An exception that has an associated status code.
  */
-public class ConnectionAlreadyExistsException extends ConflictException {
+public class StatusCodeException extends RuntimeException {
+  private final int code;
 
-  public ConnectionAlreadyExistsException(String message) {
-    super(message);
+  public StatusCodeException(String s, int code) {
+    super(s);
+    this.code = code;
+  }
+
+  public StatusCodeException(String s, Throwable throwable, int code) {
+    super(s, throwable);
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/UnauthorizedException.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/UnauthorizedException.java
@@ -14,16 +14,20 @@
  * the License.
  */
 
-package co.cask.wrangler.dataset.connections;
+package co.cask.wrangler.proto;
 
-import co.cask.wrangler.proto.ConflictException;
+import java.net.HttpURLConnection;
 
 /**
- * Thrown when a connection already exists when none is expected.
+ * Thrown when an operation is not authorized.
  */
-public class ConnectionAlreadyExistsException extends ConflictException {
+public class UnauthorizedException extends StatusCodeException {
 
-  public ConnectionAlreadyExistsException(String message) {
-    super(message);
+  public UnauthorizedException(String message) {
+    super(message, HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  public UnauthorizedException(String message, Throwable cause) {
+    super(message, cause, HttpURLConnection.HTTP_UNAUTHORIZED);
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/RequestExtractor.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/RequestExtractor.java
@@ -18,6 +18,7 @@ package co.cask.wrangler;
 
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.wrangler.dataset.workspace.RequestDeserializer;
+import co.cask.wrangler.proto.BadRequestException;
 import co.cask.wrangler.proto.Request;
 import co.cask.wrangler.proto.connection.ConnectionMeta;
 import co.cask.wrangler.proto.connection.ConnectionType;
@@ -102,13 +103,13 @@ public final class RequestExtractor {
   public ConnectionMeta getConnectionMeta() {
     String bodyStr = getContent(StandardCharsets.UTF_8);
     if (bodyStr == null) {
-      throw new IllegalArgumentException("No connection was found in the request body.");
+      throw new BadRequestException("No connection was found in the request body.");
     }
     ConnectionMeta connectionMeta;
     try {
       connectionMeta = GSON.fromJson(bodyStr, ConnectionMeta.class);
     } catch (JsonParseException e) {
-      throw new IllegalArgumentException(e.getMessage(), e);
+      throw new BadRequestException(e.getMessage(), e);
     }
     connectionMeta.validate();
     return connectionMeta;
@@ -123,8 +124,8 @@ public final class RequestExtractor {
   public ConnectionMeta getConnectionMeta(ConnectionType expectedType) {
     ConnectionMeta meta = getConnectionMeta();
     if (expectedType != meta.getType()) {
-      throw new IllegalArgumentException(String.format("Expected connection of type '%s' but found '%s'.",
-                                                       expectedType, meta.getType()));
+      throw new BadRequestException(String.format("Expected connection of type '%s' but found '%s'.",
+                                                  expectedType, meta.getType()));
     }
     return meta;
   }

--- a/wrangler-service/src/main/java/co/cask/wrangler/ServiceUtils.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/ServiceUtils.java
@@ -16,16 +16,9 @@
 
 package co.cask.wrangler;
 
-import co.cask.cdap.api.service.http.HttpServiceResponder;
-import co.cask.wrangler.proto.ServiceResponse;
 import com.google.common.base.Charsets;
 import org.bouncycastle.crypto.digests.MD5Digest;
 import org.bouncycastle.util.encoders.Hex;
-
-import java.net.HttpURLConnection;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 
 /**
  * This class provides utility services to the service in this package.
@@ -51,59 +44,5 @@ public final class ServiceUtils {
     byte[] output = new byte[md5Digest.getDigestSize()];
     md5Digest.doFinal(output, 0);
     return new String(Hex.encode(output));
-  }
-
-  /**
-   * Sends the error response back to client.
-   *
-   * @param responder to respond to the service request.
-   * @param message to be included as part of the error
-   */
-  public static void error(HttpServiceResponder responder, String message) {
-    error(responder, HttpURLConnection.HTTP_INTERNAL_ERROR, message);
-  }
-
-  /**
-   * Sends the error response back to client for not Found.
-   *
-   * @param responder to respond to the service request.
-   * @param message to be included as part of the error
-   */
-  public static void notFound(HttpServiceResponder responder, String message) {
-    error(responder, HttpURLConnection.HTTP_NOT_FOUND, message);
-  }
-
-  /**
-   * Sends the error response back to client with error status.
-   *
-   * @param responder to respond to the service request.
-   * @param message to be included as part of the error
-   */
-  public static void error(HttpServiceResponder responder, int status, String message) {
-    ServiceResponse<Void> response = new ServiceResponse<>(message);
-    responder.sendJson(status, response);
-  }
-
-  /**
-   * Returns a Json response back to client.
-   *
-   * @param responder to respond to the service request.
-   * @param status code to be returned to client.
-   * @param body to be sent back to client.
-   */
-  public static void sendJson(HttpServiceResponder responder, int status, String body) {
-    responder.send(status, ByteBuffer.wrap(body.getBytes(StandardCharsets.UTF_8)),
-                   "application/json", new HashMap<>());
-  }
-
-  /**
-   * Sends the success response back to client.
-   *
-   * @param responder to respond to the service request.
-   * @param message to be included as part of the error
-   */
-  public static void success(HttpServiceResponder responder, String message) {
-    ServiceResponse<Void> response = new ServiceResponse<>(message);
-    responder.sendJson(response);
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/common/AbstractWranglerHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/common/AbstractWranglerHandler.java
@@ -20,30 +20,38 @@ import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceContext;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.wrangler.DataPrep;
-import co.cask.wrangler.ServiceUtils;
 import co.cask.wrangler.dataset.connections.ConnectionNotFoundException;
 import co.cask.wrangler.dataset.connections.ConnectionStore;
 import co.cask.wrangler.dataset.workspace.Workspace;
 import co.cask.wrangler.dataset.workspace.WorkspaceDataset;
 import co.cask.wrangler.dataset.workspace.WorkspaceNotFoundException;
+import co.cask.wrangler.proto.BadRequestException;
 import co.cask.wrangler.proto.Recipe;
 import co.cask.wrangler.proto.Request;
+import co.cask.wrangler.proto.ServiceResponse;
+import co.cask.wrangler.proto.StatusCodeException;
 import co.cask.wrangler.proto.connection.Connection;
 import co.cask.wrangler.proto.connection.ConnectionType;
+import com.google.gson.JsonSyntaxException;
 import org.apache.tephra.TransactionFailureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
-
-import static co.cask.wrangler.ServiceUtils.error;
 
 /**
  * Common functionality for wrangler services.
  */
 public class AbstractWranglerHandler extends AbstractHttpServiceHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractWranglerHandler.class);
   protected ConnectionStore store;
 
   @UseDataSet(DataPrep.CONNECTIONS_DATASET)
@@ -99,23 +107,76 @@ public class AbstractWranglerHandler extends AbstractHttpServiceHandler {
    */
   @Nullable
   protected Connection getValidatedConnection(String connectionId, ConnectionType expectedType,
-                                              HttpServiceResponder responder) {
+                                              HttpServiceResponder responder) throws Exception {
     AtomicReference<Connection> connectionRef = new AtomicReference<>();
     try {
       getContext().execute(datasetContext -> connectionRef.set(store.get(connectionId)));
     } catch (TransactionFailureException e) {
       if (e.getCause() instanceof ConnectionNotFoundException) {
-        ServiceUtils.notFound(responder, e.getCause().getMessage());
-        return null;
+        throw (ConnectionNotFoundException) e.getCause();
       }
-      ServiceUtils.error(responder, e.getMessage());
-      return null;
+      throw e;
     }
     Connection connection = connectionRef.get();
+    if (connection.getType() == null) {
+      throw new BadRequestException("Connection type must be specified.");
+    }
     if (expectedType != connection.getType()) {
-      error(responder, "Invalid connection type set, this endpoint only accepts GCS connection type");
-      return null;
+      throw new BadRequestException(String.format("Expected connection type '%s' but found '%s'.",
+                                                  expectedType, connection.getType()));
     }
     return connection;
+  }
+
+  /**
+   * Utility method for executing an endpoint with common error handling and namespace checks built in.
+   * A response will always be sent after this method is called so the http responder should not be used after this.
+   * The endpoint logic should also not use the responder in any way.
+   *
+   * If the callable throws a {@link StatusCodeException}, the exception's status code and message will be used
+   * to create the response.
+   * If a {@link JsonSyntaxException} is thrown, a 400 response will be sent.
+   * If anything else if thrown, a 500 response will be sent.
+   * If nothing is thrown, the result of the callable will be sent as json.
+   *
+   * @param request the http request
+   * @param responder the http responder
+   * @param namespace the namespace to check for, or null if no check needs to be performed
+   * @param callable the endpoint logic to run
+   */
+  protected <T> void respond(HttpServiceRequest request, HttpServiceResponder responder, @Nullable String namespace,
+                             Callable<T> callable) {
+    if (namespace != null) {
+      try {
+        if (!getContext().getAdmin().namespaceExists(namespace)) {
+          responder.sendJson(HttpURLConnection.HTTP_NOT_FOUND,
+                             new ServiceResponse<Void>(String.format("Namespace '%s' does not exist", namespace)));
+          return;
+        }
+      } catch (IOException e) {
+        responder.sendJson(HttpURLConnection.HTTP_INTERNAL_ERROR, new ServiceResponse<Void>(e.getMessage()));
+        return;
+      }
+    }
+
+    try {
+      T results = callable.call();
+      responder.sendJson(results);
+    } catch (StatusCodeException e) {
+      responder.sendJson(e.getCode(), new ServiceResponse<>(e.getMessage()));
+    } catch (JsonSyntaxException e) {
+      responder.sendJson(HttpURLConnection.HTTP_BAD_REQUEST, new ServiceResponse<Void>(e.getMessage()));
+    } catch (Throwable t) {
+      LOG.warn("Error processing {} {}, resulting in a 500 response.", request.getMethod(), request.getRequestURI(), t);
+      responder.sendJson(HttpURLConnection.HTTP_INTERNAL_ERROR, new ServiceResponse<Void>(t.getMessage()));
+    }
+  }
+
+  /**
+   * The same as calling {@link #respond(HttpServiceRequest, HttpServiceResponder, String, Callable)}
+   * with a null namespace.
+   */
+  protected <T> void respond(HttpServiceRequest request, HttpServiceResponder responder, Callable<T> callable) {
+    respond(request, responder, null, callable);
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/explorer/FilesystemExplorer.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/explorer/FilesystemExplorer.java
@@ -18,12 +18,10 @@ package co.cask.wrangler.service.explorer;
 
 import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.annotation.TransactionPolicy;
-import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.service.http.HttpServiceContext;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
-import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.wrangler.PropertyIds;
 import co.cask.wrangler.SamplingMethod;
 import co.cask.wrangler.ServiceUtils;
@@ -31,6 +29,7 @@ import co.cask.wrangler.api.Row;
 import co.cask.wrangler.dataset.workspace.DataType;
 import co.cask.wrangler.dataset.workspace.WorkspaceDataset;
 import co.cask.wrangler.dataset.workspace.WorkspaceMeta;
+import co.cask.wrangler.proto.BadRequestException;
 import co.cask.wrangler.proto.PluginSpec;
 import co.cask.wrangler.proto.ServiceResponse;
 import co.cask.wrangler.proto.connection.ConnectionType;
@@ -43,13 +42,11 @@ import co.cask.wrangler.service.common.AbstractWranglerHandler;
 import co.cask.wrangler.service.common.Format;
 import co.cask.wrangler.utils.ObjectSerDe;
 import com.google.common.base.Charsets;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.apache.twill.filesystem.Location;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import java.io.BufferedInputStream;
-import java.net.HttpURLConnection;
+import java.io.IOException;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -59,21 +56,26 @@ import java.util.Map;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
-
-import static co.cask.wrangler.ServiceUtils.error;
-import static co.cask.wrangler.ServiceUtils.sendJson;
 
 /**
  * A {@link FilesystemExplorer} is a HTTP Service handler for exploring the filesystem.
  * It provides capabilities for listing file(s) and directories. It also provides metadata.
  */
 public class FilesystemExplorer extends AbstractWranglerHandler {
-  private static final Gson gson =
-    new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
   private Explorer explorer;
   private static final String COLUMN_NAME = "body";
   private static final int FILE_SIZE = 10 * 1024 * 1024;
+
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
+  @Path("explorer/fs")
+  @GET
+  public void list(HttpServiceRequest request, HttpServiceResponder responder,
+                   @QueryParam("path") String path,
+                   @QueryParam("hidden") boolean hidden) {
+    list(request, responder, getContext().getNamespace(), path, hidden);
+  }
 
   /**
    * Lists the content of the path specified using the {@link Location}.
@@ -83,18 +85,22 @@ public class FilesystemExplorer extends AbstractWranglerHandler {
    * @param path to the location in the filesystem
    */
   @TransactionPolicy(value = TransactionControl.EXPLICIT)
-  @Path("explorer/fs")
+  @Path("contexts/{context}/explorer/fs")
   @GET
   public void list(HttpServiceRequest request, HttpServiceResponder responder,
-                   @QueryParam("path") String path,
+                   @PathParam("context") String namespace, @QueryParam("path") String path,
                    @QueryParam("hidden") boolean hidden) {
+    respond(request, responder, namespace, () -> explorer.browse(path, hidden));
+  }
 
-    try {
-      Map<String, Object> listing = explorer.browse(path, hidden);
-      sendJson(responder, HttpURLConnection.HTTP_OK, gson.toJson(listing));
-    } catch (ExplorerException e) {
-      error(responder, e.getMessage());
-    }
+  @Path("explorer/fs/read")
+  @GET
+  public void read(HttpServiceRequest request, HttpServiceResponder responder,
+                   @QueryParam("path") String path, @QueryParam("lines") int lines,
+                   @QueryParam("sampler") String sampler,
+                   @QueryParam("fraction") double fraction,
+                   @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
+    read(request, responder, getContext().getNamespace(), path, lines, sampler, fraction, scope);
   }
 
   /**
@@ -106,34 +112,44 @@ public class FilesystemExplorer extends AbstractWranglerHandler {
    * @param lines number of lines to extracted from file if it's a text/plain.
    * @param sampler sampling method to be used.
    */
-  @Path("explorer/fs/read")
+  @Path("contexts/{context}/explorer/fs/read")
   @GET
-  public void read(HttpServiceRequest request, HttpServiceResponder responder,
+  public void read(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace,
                    @QueryParam("path") String path, @QueryParam("lines") int lines,
                    @QueryParam("sampler") String sampler,
                    @QueryParam("fraction") double fraction,
                    @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    String header = request.getHeader(PropertyIds.CONTENT_TYPE);
+    respond(request, responder, namespace, () -> {
+      String header = request.getHeader(PropertyIds.CONTENT_TYPE);
 
-    if (header == null) {
-      error(responder, "Content-Type header not specified.");
-      return;
-    }
+      if (header == null) {
+        throw new BadRequestException("Content-Type header not specified.");
+      }
 
-    if (header.equalsIgnoreCase("text/plain") || header.contains("text/")) {
-      loadSampleableFile(responder, scope, path, lines, fraction, sampler);
-    } else if (header.equalsIgnoreCase("application/xml")) {
-      loadFile(responder, scope, path, DataType.RECORDS);
-    } else if (header.equalsIgnoreCase("application/json")) {
-      loadFile(responder, scope, path, DataType.TEXT);
-    } else if (header.equalsIgnoreCase("application/avro")
-      || header.equalsIgnoreCase("application/protobuf")
-      || header.equalsIgnoreCase("application/excel")
-      || header.contains("image/")) {
-      loadFile(responder, scope, path, DataType.BINARY);
-    } else {
-      error(responder, "Currently doesn't support wrangling of this type of file.");
-    }
+      FileConnectionSample sample;
+      if (header.equalsIgnoreCase("text/plain") || header.contains("text/")) {
+        sample = loadSampleableFile(scope, path, lines, fraction, sampler);
+      } else if (header.equalsIgnoreCase("application/xml")) {
+        sample = loadFile(scope, path, DataType.RECORDS);
+      } else if (header.equalsIgnoreCase("application/json")) {
+        sample = loadFile(scope, path, DataType.TEXT);
+      } else if (header.equalsIgnoreCase("application/avro")
+        || header.equalsIgnoreCase("application/protobuf")
+        || header.equalsIgnoreCase("application/excel")
+        || header.contains("image/")) {
+        sample = loadFile(scope, path, DataType.BINARY);
+      } else {
+        throw new BadRequestException("Currently doesn't support wrangling of this type of file.");
+      }
+      return new ServiceResponse<>(sample);
+    });
+  }
+
+  @Path("explorer/fs/specification")
+  @GET
+  public void specification(HttpServiceRequest request, HttpServiceResponder responder,
+                            @QueryParam("path") String path, @QueryParam("wid") String workspaceId) {
+    specification(request, responder, getContext().getNamespace(), path, workspaceId);
   }
 
   /**
@@ -143,11 +159,12 @@ public class FilesystemExplorer extends AbstractWranglerHandler {
    * @param responder HTTP response handler.
    * @param path to the location in the filesystem.
    */
-  @Path("explorer/fs/specification")
+  @Path("contexts/{context}/explorer/fs/specification")
   @GET
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
+                            @PathParam("context") String namespace,
                             @QueryParam("path") String path, @QueryParam("wid") String workspaceId) {
-    try {
+    respond(request, responder, namespace, () -> {
       Format format = Format.TEXT;
       if (workspaceId != null) {
         Map<String, String> config = ws.getWorkspace(workspaceId).getProperties();
@@ -166,131 +183,117 @@ public class FilesystemExplorer extends AbstractWranglerHandler {
 
       PluginSpec pluginSpec = new PluginSpec("File", "source", properties);
       FileSpec fileSpec = new FileSpec(pluginSpec);
-      ServiceResponse<FileSpec> response = new ServiceResponse<>(fileSpec);
-      responder.sendJson(response);
-    } catch (Exception e) {
-      error(responder, e.getMessage());
-    }
+      return new ServiceResponse<>(fileSpec);
+    });
   }
 
-  private void loadFile(HttpServiceResponder responder, String scope, String path, DataType type) {
-    try {
-      Location location = explorer.getLocation(path);
-      if (!location.exists()) {
-        error(responder, String.format("%s (No such file)", path));
-        return;
-      }
-
-      if (location.length() > FILE_SIZE) {
-        error(responder, "Files larger than 10MB are currently not supported.");
-        return;
-      }
-
-      // Creates workspace.
-      String name = location.getName();
-      String id = String.format("%s:%s:%s:%d", scope, location.getName(),
-                                location.toURI().getPath(), System.nanoTime());
-      id = ServiceUtils.generateMD5(id);
-      Map<String, String> properties = new HashMap<>();
-      properties.put(PropertyIds.FILE_NAME, location.getName());
-      properties.put(PropertyIds.URI, location.toURI().toString());
-      properties.put(PropertyIds.FILE_PATH, location.toURI().getPath());
-      properties.put(PropertyIds.CONNECTION_TYPE, ConnectionType.FILE.getType());
-      properties.put(PropertyIds.SAMPLER_TYPE, SamplingMethod.NONE.getMethod());
-      Format format = type == DataType.BINARY ? Format.BLOB : Format.TEXT;
-      properties.put(PropertyIds.FORMAT, format.name());
-      WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(id, name)
-        .setScope(scope)
-        .setProperties(properties)
-        .build();
-      ws.writeWorkspaceMeta(workspaceMeta);
-
-      byte[] bytes = new byte[(int) location.length() + 1];
-      try (BufferedInputStream stream = new BufferedInputStream(location.getInputStream())) {
-        stream.read(bytes);
-      }
-
-      // Write records to workspace.
-      if (type == DataType.RECORDS) {
-        List<Row> rows = new ArrayList<>();
-        rows.add(new Row(COLUMN_NAME, new String(bytes, Charsets.UTF_8)));
-        ObjectSerDe<List<Row>> serDe = new ObjectSerDe<>();
-        byte[] data = serDe.toByteArray(rows);
-        ws.updateWorkspaceData(id, DataType.RECORDS, data);
-      } else if (type == DataType.BINARY || type == DataType.TEXT) {
-        ws.updateWorkspaceData(id, type, bytes);
-      }
-
-      FileConnectionSample sample = new FileConnectionSample(id, name, ConnectionType.FILE.getType(),
-                                                             SamplingMethod.NONE.getMethod(), null,
-                                                             location.toURI().toString(), location.toURI().getPath(),
-                                                             location.getName());
-      ServiceResponse<FileConnectionSample> response = new ServiceResponse<>(sample);
-      responder.sendJson(response);
-    } catch (Exception e) {
-      error(responder, e.getMessage());
+  private FileConnectionSample loadFile(String scope, String path,
+                                        DataType type) throws ExplorerException, IOException {
+    Location location = explorer.getLocation(path);
+    if (!location.exists()) {
+      throw new BadRequestException(String.format("%s (No such file)", path));
     }
+
+    if (location.length() > FILE_SIZE) {
+      throw new BadRequestException("Files larger than 10MB are currently not supported.");
+    }
+
+    // Creates workspace.
+    String name = location.getName();
+    String id = String.format("%s:%s:%s:%d", scope, location.getName(),
+                              location.toURI().getPath(), System.nanoTime());
+    id = ServiceUtils.generateMD5(id);
+    Map<String, String> properties = new HashMap<>();
+    properties.put(PropertyIds.FILE_NAME, location.getName());
+    properties.put(PropertyIds.URI, location.toURI().toString());
+    properties.put(PropertyIds.FILE_PATH, location.toURI().getPath());
+    properties.put(PropertyIds.CONNECTION_TYPE, ConnectionType.FILE.getType());
+    properties.put(PropertyIds.SAMPLER_TYPE, SamplingMethod.NONE.getMethod());
+    Format format = type == DataType.BINARY ? Format.BLOB : Format.TEXT;
+    properties.put(PropertyIds.FORMAT, format.name());
+    WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(id, name)
+      .setScope(scope)
+      .setProperties(properties)
+      .build();
+    ws.writeWorkspaceMeta(workspaceMeta);
+
+    byte[] bytes = new byte[(int) location.length() + 1];
+    try (BufferedInputStream stream = new BufferedInputStream(location.getInputStream())) {
+      stream.read(bytes);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    // Write records to workspace.
+    if (type == DataType.RECORDS) {
+      List<Row> rows = new ArrayList<>();
+      rows.add(new Row(COLUMN_NAME, new String(bytes, Charsets.UTF_8)));
+      ObjectSerDe<List<Row>> serDe = new ObjectSerDe<>();
+      byte[] data = serDe.toByteArray(rows);
+      ws.updateWorkspaceData(id, DataType.RECORDS, data);
+    } else if (type == DataType.BINARY || type == DataType.TEXT) {
+      ws.updateWorkspaceData(id, type, bytes);
+    }
+
+    return new FileConnectionSample(id, name, ConnectionType.FILE.getType(),
+                                    SamplingMethod.NONE.getMethod(), null,
+                                    location.toURI().toString(), location.toURI().getPath(),
+                                    location.getName());
   }
 
-  private void loadSampleableFile(HttpServiceResponder responder,
-                                  String scope, String path, int lines, double fraction, String sampler) {
+  private FileConnectionSample loadSampleableFile(String scope, String path, int lines, double fraction,
+                                                  String sampler) throws IOException, ExplorerException {
     SamplingMethod samplingMethod = SamplingMethod.fromString(sampler);
     if (sampler == null || sampler.isEmpty() || SamplingMethod.fromString(sampler) == null) {
       samplingMethod = SamplingMethod.FIRST;
     }
-    try {
-      Location location = explorer.getLocation(path);
-      if (!location.exists()) {
-        error(responder, String.format("%s (No such file)", path));
-        return;
-      }
-      String name = location.getName();
-      String id = String.format("%s:%s:%s:%d", scope, location.getName(),
-                                location.toURI().getPath(), System.nanoTime());
-      id = ServiceUtils.generateMD5(id);
-      // Set all properties and write to workspace.
-      Map<String, String> properties = new HashMap<>();
-      properties.put(PropertyIds.FILE_NAME, location.getName());
-      properties.put(PropertyIds.URI, location.toURI().toString());
-      properties.put(PropertyIds.FILE_PATH, location.toURI().getPath());
-      properties.put(PropertyIds.CONNECTION_TYPE, ConnectionType.FILE.getType());
-      properties.put(PropertyIds.SAMPLER_TYPE, samplingMethod.getMethod());
-      WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(id, name)
-        .setScope(scope)
-        .setProperties(properties)
-        .build();
-      ws.writeWorkspaceMeta(workspaceMeta);
 
-      // Iterate through lines to extract only 'limit' random lines.
-      // Depending on the type, the sampling of the input is performed.
-      List<Row> rows = new ArrayList<>();
-      BoundedLineInputStream blis = BoundedLineInputStream.iterator(location.getInputStream(), Charsets.UTF_8, lines);
-      Iterator<String> it = blis;
-      if (samplingMethod == SamplingMethod.POISSON) {
-        it = new Poisson<String>(fraction).sample(blis);
-      } else if (samplingMethod == SamplingMethod.BERNOULLI) {
-        it = new Bernoulli<String>(fraction).sample(blis);
-      } else if (samplingMethod == SamplingMethod.RESERVOIR) {
-        it = new Reservoir<String>(lines).sample(blis);
-      }
-      while (it.hasNext()) {
-        rows.add(new Row(COLUMN_NAME, it.next()));
-      }
-
-      // Write rows to workspace.
-      ObjectSerDe<List<Row>> serDe = new ObjectSerDe<>();
-      byte[] data = serDe.toByteArray(rows);
-      ws.updateWorkspaceData(id, DataType.RECORDS, data);
-
-      FileConnectionSample sample = new FileConnectionSample(id, name, ConnectionType.FILE.getType(),
-                                                             samplingMethod.getMethod(), null,
-                                                             location.toURI().toString(), location.toURI().getPath(),
-                                                             location.getName());
-      ServiceResponse<FileConnectionSample> response = new ServiceResponse<>(sample);
-      responder.sendJson(response);
-    } catch (Exception e) {
-      error(responder, e.getMessage());
+    Location location = explorer.getLocation(path);
+    if (!location.exists()) {
+      throw new BadRequestException(String.format("%s (No such file)", path));
     }
+    String name = location.getName();
+    String id = String.format("%s:%s:%s:%d", scope, location.getName(),
+                              location.toURI().getPath(), System.nanoTime());
+    id = ServiceUtils.generateMD5(id);
+    // Set all properties and write to workspace.
+    Map<String, String> properties = new HashMap<>();
+    properties.put(PropertyIds.FILE_NAME, location.getName());
+    properties.put(PropertyIds.URI, location.toURI().toString());
+    properties.put(PropertyIds.FILE_PATH, location.toURI().getPath());
+    properties.put(PropertyIds.CONNECTION_TYPE, ConnectionType.FILE.getType());
+    properties.put(PropertyIds.SAMPLER_TYPE, samplingMethod.getMethod());
+    WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(id, name)
+      .setScope(scope)
+      .setProperties(properties)
+      .build();
+    ws.writeWorkspaceMeta(workspaceMeta);
+
+    // Iterate through lines to extract only 'limit' random lines.
+    // Depending on the type, the sampling of the input is performed.
+    List<Row> rows = new ArrayList<>();
+    BoundedLineInputStream blis = BoundedLineInputStream.iterator(location.getInputStream(), Charsets.UTF_8, lines);
+    Iterator<String> it = blis;
+    if (samplingMethod == SamplingMethod.POISSON) {
+      it = new Poisson<String>(fraction).sample(blis);
+    } else if (samplingMethod == SamplingMethod.BERNOULLI) {
+      it = new Bernoulli<String>(fraction).sample(blis);
+    } else if (samplingMethod == SamplingMethod.RESERVOIR) {
+      it = new Reservoir<String>(lines).sample(blis);
+    }
+    while (it.hasNext()) {
+      rows.add(new Row(COLUMN_NAME, it.next()));
+    }
+
+    // Write rows to workspace.
+    ObjectSerDe<List<Row>> serDe = new ObjectSerDe<>();
+    byte[] data = serDe.toByteArray(rows);
+    ws.updateWorkspaceData(id, DataType.RECORDS, data);
+
+    return new FileConnectionSample(id, name, ConnectionType.FILE.getType(),
+                                    samplingMethod.getMethod(), null,
+                                    location.toURI().toString(), location.toURI().getPath(),
+                                    location.getName());
   }
 
   @Override

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcp/GCPUtils.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcp/GCPUtils.java
@@ -16,6 +16,7 @@
 
 package co.cask.wrangler.service.gcp;
 
+import co.cask.wrangler.proto.BadRequestException;
 import co.cask.wrangler.proto.connection.ConnectionMeta;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.auth.oauth2.ServiceAccountCredentials;
@@ -88,8 +89,8 @@ public final class GCPUtils {
     String projectId = connProperties.containsKey(PROJECT_ID) ?
       connProperties.get(PROJECT_ID) : ServiceOptions.getDefaultProjectId();
     if (projectId == null) {
-      throw new IllegalArgumentException("Could not detect Google Cloud project id from the environment. " +
-                                           "Please specify a project id for the connection.");
+      throw new BadRequestException("Could not detect Google Cloud project id from the environment. " +
+                                      "Please specify a project id for the connection.");
     }
     optionsBuilder.setProjectId(projectId);
     Spanner spanner = optionsBuilder.build().getService();
@@ -128,16 +129,16 @@ public final class GCPUtils {
    */
   public static void validateProjectCredentials(ConnectionMeta connection) {
     Map<String, String> connProperties = connection.getProperties();
-    if (connProperties.get(PROJECT_ID) == null && ServiceOptions.getDefaultProjectId() == null) {
-      throw new IllegalArgumentException("Project ID could not be found from the environment. " +
-                                           "Please provide the Project ID.");
+    if (connection.getProperties().get(PROJECT_ID) == null && ServiceOptions.getDefaultProjectId() == null) {
+      throw new BadRequestException("Project ID could not be found from the environment. " +
+                                      "Please provide the Project ID.");
     }
     if (connProperties.get(SERVICE_ACCOUNT_KEYFILE) == null) {
       try {
         GoogleCredential.getApplicationDefault();
       } catch (IOException e) {
-        throw new IllegalArgumentException("Google credentials could not be found from the environment. " +
-                                             "Please provide a service account key.");
+        throw new BadRequestException("Google credentials could not be found from the environment. " +
+                                        "Please provide a service account key.");
       }
     }
   }

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/connections/ConnectionNotFoundException.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/connections/ConnectionNotFoundException.java
@@ -16,10 +16,12 @@
 
 package co.cask.wrangler.dataset.connections;
 
+import co.cask.wrangler.proto.NotFoundException;
+
 /**
  * Thrown when a connection does not exist when one is expected to exist.
  */
-public class ConnectionNotFoundException extends Exception {
+public class ConnectionNotFoundException extends NotFoundException {
 
   public ConnectionNotFoundException(String message) {
     super(message);

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaNotFoundException.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/schema/SchemaNotFoundException.java
@@ -16,10 +16,12 @@
 
 package co.cask.wrangler.dataset.schema;
 
+import co.cask.wrangler.proto.NotFoundException;
+
 /**
  * Thrown when a schema could not be found.
  */
-public class SchemaNotFoundException extends SchemaRegistryException {
+public class SchemaNotFoundException extends NotFoundException {
   public SchemaNotFoundException(String message) {
     super(message);
   }

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/WorkspaceNotFoundException.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/WorkspaceNotFoundException.java
@@ -16,10 +16,12 @@
 
 package co.cask.wrangler.dataset.workspace;
 
+import javax.ws.rs.NotFoundException;
+
 /**
  * Thrown when a workspace is not found when it is expected to exist.
  */
-public class WorkspaceNotFoundException extends Exception {
+public class WorkspaceNotFoundException extends NotFoundException {
 
   public WorkspaceNotFoundException(String message) {
     super(message);


### PR DESCRIPTION
Added a single method that takes care of error handling and
namespace checks. Refactored all service endpoints to use this
method.

Also added namespaced versions of all relevant endpoints.
For the time being, they do the same thing as the un-namespaced
endpoints, but will be changed once namespacing is added to the
storage layer.