### PR TITLE
CDAP-14794 CDAP-14795 fix loading of UDDs

### DIFF
--- a/wrangler-core/src/main/java/co/cask/wrangler/registry/UserDirectiveRegistry.java
+++ b/wrangler-core/src/main/java/co/cask/wrangler/registry/UserDirectiveRegistry.java
@@ -161,7 +161,7 @@ public final class UserDirectiveRegistry implements DirectiveRegistry {
           for (PluginClass plugin : plugins) {
             if (Directive.TYPE.equalsIgnoreCase(plugin.getType())) {
               CloseableClassLoader closeableClassLoader
-                    = manager.createClassLoader(artifact, getClass().getClassLoader());
+                    = manager.createClassLoader(namespace, artifact, getClass().getClassLoader());
               Class<? extends Directive> directive =
                 (Class<? extends Directive>) closeableClassLoader.loadClass(plugin.getClassName());
               DirectiveInfo classz = new DirectiveInfo(DirectiveInfo.Scope.USER, directive);

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/directive/DirectivesHandler.java
@@ -895,6 +895,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
   public void usage(HttpServiceRequest request, HttpServiceResponder responder,
                     @PathParam("context") String namespace) {
     respond(request, responder, namespace, () -> {
+      composite.reload(namespace);
       DirectiveConfig config = ws.getConfig();
       Map<String, List<String>> aliases = config.getReverseAlias();
       List<DirectiveUsage> values = new ArrayList<>();


### PR DESCRIPTION
Fixed a bug where loading UDDs would generate an artifact not
found error because the namespace was not being passed to the
createClassLoader call.

Also changed the usage endpoint to always load UDDs in that
namespace to mirror the behavior that was there before the
namespace refactoring.