### PR TITLE
CDAP-14879 namespace test endpoints and namespace jdbc drivers

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryHandler.java
@@ -109,6 +109,13 @@ public class BigQueryHandler extends AbstractWranglerHandler {
   @POST
   @Path("/connections/bigquery/test")
   public void testBiqQueryConnection(HttpServiceRequest request, HttpServiceResponder responder) {
+    testBiqQueryConnection(request, responder, getContext().getNamespace());
+  }
+
+  @POST
+  @Path("/contexts/{context}/connections/bigquery/test")
+  public void testBiqQueryConnection(HttpServiceRequest request, HttpServiceResponder responder,
+                                     @PathParam("context") String namespace) {
     respond(request, responder, () -> {
       // Extract the body of the request and transform it to the Connection object.
       RequestExtractor extractor = new RequestExtractor(request);

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSHandler.java
@@ -107,6 +107,13 @@ public class GCSHandler extends AbstractWranglerHandler {
   @POST
   @Path("/connections/gcs/test")
   public void testGCSConnection(HttpServiceRequest request, HttpServiceResponder responder) {
+    testGCSConnection(request, responder, getContext().getNamespace());
+  }
+
+  @POST
+  @Path("/contexts/{context}/connections/gcs/test")
+  public void testGCSConnection(HttpServiceRequest request, HttpServiceResponder responder,
+                                @PathParam("context") String namespace) {
     respond(request, responder, () -> {
       // Extract the body of the request and transform it to the Connection object.
       RequestExtractor extractor = new RequestExtractor(request);

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaHandler.java
@@ -75,6 +75,13 @@ public final class KafkaHandler extends AbstractWranglerHandler {
   @POST
   @Path("connections/kafka/test")
   public void test(HttpServiceRequest request, HttpServiceResponder responder) {
+    test(request, responder, getContext().getNamespace());
+  }
+
+  @POST
+  @Path("contexts/{context}/connections/kafka/test")
+  public void test(HttpServiceRequest request, HttpServiceResponder responder,
+                   @PathParam("context") String namespace) {
     respond(request, responder, () -> {
       // Extract the body of the request and transform it to the Connection object.
       RequestExtractor extractor = new RequestExtractor(request);

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Handler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Handler.java
@@ -96,6 +96,13 @@ public class S3Handler extends AbstractWranglerHandler {
   @POST
   @Path("/connections/s3/test")
   public void testS3Connection(HttpServiceRequest request, HttpServiceResponder responder) {
+    testS3Connection(request, responder, getContext().getNamespace());
+  }
+
+  @POST
+  @Path("/contexts/{context}/connections/s3/test")
+  public void testS3Connection(HttpServiceRequest request, HttpServiceResponder responder,
+                               @PathParam("context") String namespace) {
     respond(request, responder, () -> {
       // Extract the body of the request and transform it to the Connection object.
       RequestExtractor extractor = new RequestExtractor(request);

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerHandler.java
@@ -96,6 +96,13 @@ public class SpannerHandler extends AbstractWranglerHandler {
   @POST
   @Path("/connections/spanner/test")
   public void testSpannerConnection(HttpServiceRequest request, HttpServiceResponder responder) {
+    testSpannerConnection(request, responder, getContext().getNamespace());
+  }
+
+  @POST
+  @Path("/contexts/{context}/connections/spanner/test")
+  public void testSpannerConnection(HttpServiceRequest request, HttpServiceResponder responder,
+                                    @PathParam("context") String namespace) {
     respond(request, responder, () -> {
       // Extract the body of the request and transform it to the Connection object.
       RequestExtractor extractor = new RequestExtractor(request);
@@ -105,6 +112,7 @@ public class SpannerHandler extends AbstractWranglerHandler {
       return new ServiceResponse<Void>("Success");
     });
   }
+
 
   @GET
   @Path("/connections/{connection-id}/spanner/instances")


### PR DESCRIPTION
Fixed a bug where the namespace was not properly being passed
to artifact calls when dealing with jdbc drivers. This would cause
the service to look for system jdbc drivers instead of looking in
the relevant namespace.