### PR TITLE
CDAP-14827 add namespace generation to entity keys

### DIFF
--- a/wrangler-core/src/main/java/co/cask/directives/parser/ParseAvro.java
+++ b/wrangler-core/src/main/java/co/cask/directives/parser/ParseAvro.java
@@ -40,7 +40,6 @@ import co.cask.wrangler.codec.BinaryAvroDecoder;
 import co.cask.wrangler.codec.Decoder;
 import co.cask.wrangler.codec.DecoderException;
 import co.cask.wrangler.codec.JsonAvroDecoder;
-import co.cask.wrangler.proto.NamespacedId;
 import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
@@ -115,9 +114,9 @@ public class ParseAvro implements Directive {
         client = SchemaRegistryClient.getInstance(context);
         byte[] bytes;
         if (version != -1) {
-          bytes = client.getSchema(new NamespacedId(context.getNamespace(), schemaId), version);
+          bytes = client.getSchema(context.getNamespace(), schemaId, version);
         } else {
-          bytes = client.getSchema(new NamespacedId(context.getNamespace(), schemaId));
+          bytes = client.getSchema(context.getNamespace(), schemaId);
         }
         Schema.Parser parser = new Schema.Parser();
         Schema schema = parser.parse(Bytes.toString(bytes));

--- a/wrangler-core/src/main/java/co/cask/directives/parser/ParseProtobuf.java
+++ b/wrangler-core/src/main/java/co/cask/directives/parser/ParseProtobuf.java
@@ -39,7 +39,6 @@ import co.cask.wrangler.clients.SchemaRegistryClient;
 import co.cask.wrangler.codec.Decoder;
 import co.cask.wrangler.codec.DecoderException;
 import co.cask.wrangler.codec.ProtobufDecoderUsingDescriptor;
-import co.cask.wrangler.proto.NamespacedId;
 import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
@@ -114,9 +113,9 @@ public class ParseProtobuf implements Directive {
           client = SchemaRegistryClient.getInstance(context);
           byte[] bytes;
           if (version != -1) {
-            bytes = client.getSchema(new NamespacedId(context.getNamespace(), schemaId), version);
+            bytes = client.getSchema(context.getNamespace(), schemaId, version);
           } else {
-            bytes = client.getSchema(new NamespacedId(context.getNamespace(), schemaId));
+            bytes = client.getSchema(context.getNamespace(), schemaId);
           }
 
           return new ProtobufDecoderUsingDescriptor(bytes, recordName);

--- a/wrangler-core/src/main/java/co/cask/wrangler/clients/SchemaRegistryClient.java
+++ b/wrangler-core/src/main/java/co/cask/wrangler/clients/SchemaRegistryClient.java
@@ -99,6 +99,7 @@ public final class SchemaRegistryClient {
   /**
    * Retrieves schema provided a schema id and version of the schema.
    *
+   * @param namespace the schema namespace
    * @param id the schema id
    * @param version the schema version
    * @return {@link Response} of the schema.
@@ -106,11 +107,10 @@ public final class SchemaRegistryClient {
    * @throws IOException throw when there are issues connecting to the service.
    * @throws RestClientException thrown when there are issues with request or response returned.
    */
-  public byte[] getSchema(NamespacedId id, long version)
+  public byte[] getSchema(String namespace, String id, long version)
     throws URISyntaxException, IOException, RestClientException {
     URL url = concat(new URI(baseUrl),
-                     String.format("contexts/%s/schemas/%s/versions/%d",
-                                   id.getNamespace(), id.getId(), version)).toURL();
+                     String.format("contexts/%s/schemas/%s/versions/%d", namespace, id, version)).toURL();
     Response<SchemaInfo> response = request(url, "GET", new TypeToken<Response<SchemaInfo>>() { }.getType());
     if (response.getCount() == 1) {
       return Bytes.fromHexString(response.getValues().get(0).getSpecification());
@@ -121,15 +121,16 @@ public final class SchemaRegistryClient {
   /**
    * Retrieves schema provided a schema id. It provides the latest, current version of schema.
    *
+   * @param namespace the schema namespace
    * @param id the schema id
    * @return {@link SchemaInfo} of the schema if ok, else null.
    * @throws URISyntaxException thrown if there are issue with construction of url.
    * @throws IOException throw when there are issues connecting to the service.
    * @throws RestClientException thrown when there are issues with request or response returned.
    */
-  public byte[] getSchema(NamespacedId id)
+  public byte[] getSchema(String namespace, String id)
     throws URISyntaxException, IOException, RestClientException {
-    URL url = concat(new URI(baseUrl), String.format("contexts/%s/schemas/%s", id.getNamespace(), id.getId())).toURL();
+    URL url = concat(new URI(baseUrl), String.format("contexts/%s/schemas/%s", namespace, id)).toURL();
     Response<SchemaInfo> response = request(url, "GET", new TypeToken<Response<SchemaInfo>>() { }.getType());
     if (response.getCount() == 1) {
       return Bytes.fromHexString(response.getValues().get(0).getSpecification());
@@ -140,16 +141,17 @@ public final class SchemaRegistryClient {
   /**
    * Gets all the versions of schemas given a schema id.
    *
+   * @param namespace the schema namespace
    * @param id the schema id
    * @return a list of schema versions.
    * @throws URISyntaxException thrown if there are issue with construction of url.
    * @throws IOException throw when there are issues connecting to the service.
    * @throws RestClientException thrown when there are issues with request or response returned.
    */
-  public List<Long> getVersions(NamespacedId id)
+  public List<Long> getVersions(String namespace, String id)
     throws URISyntaxException, IOException, RestClientException {
     URL url = concat(new URI(baseUrl),
-                     String.format("contexts/%s/schemas/%s/versions", id.getNamespace(), id.getId())).toURL();
+                     String.format("contexts/%s/schemas/%s/versions", namespace, id)).toURL();
     Response<Long> response = request(url, "GET", new TypeToken<Response<Long>>() { }.getType());
     return response.getValues();
   }

--- a/wrangler-core/src/test/java/co/cask/wrangler/clients/SchemaRegistryClientTest.java
+++ b/wrangler-core/src/test/java/co/cask/wrangler/clients/SchemaRegistryClientTest.java
@@ -21,7 +21,6 @@ import co.cask.http.HandlerContext;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
 import co.cask.http.NettyHttpService;
-import co.cask.wrangler.proto.NamespacedId;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -162,7 +161,7 @@ public class SchemaRegistryClientTest {
 
   @Test
   public void testGetSchema() throws Exception {
-    byte[] bytes = client.getSchema(new NamespacedId("c0", "foo"), 1);
+    byte[] bytes = client.getSchema("c0", "foo", 1);
     Assert.assertNotNull(bytes);
     String str = Bytes.toString(bytes);
     Assert.assertEquals("{\"foo\" : \"test\"}", str);
@@ -170,13 +169,13 @@ public class SchemaRegistryClientTest {
 
   @Test
   public void testGetVersions() throws Exception {
-    List<Long> response = client.getVersions(new NamespacedId("c0", "foo"));
+    List<Long> response = client.getVersions("c0", "foo");
     Assert.assertEquals(4, response.size());
     Assert.assertNotNull(response);
   }
 
   @Test (expected = RestClientException.class)
   public void testGetWrongSchemaIdVersions() throws Exception {
-    client.getVersions(new NamespacedId("c0", "foo1"));
+    client.getVersions("c0", "foo1");
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/Namespace.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/Namespace.java
@@ -16,32 +16,36 @@
 
 package co.cask.wrangler.proto;
 
+import co.cask.cdap.api.NamespaceSummary;
+
 import java.util.Objects;
 
 /**
- * A unique identifier for an entity within a namespace.
- * The 'id' field is not globally unique, but is unique within the context.
- * It is named 'id' for backward compatibility reasons.
+ * Uniquely identifies a namespace generation.
  */
-public class NamespacedId {
-  protected final Namespace namespace;
-  protected final String id;
+public class Namespace {
+  protected final String name;
+  protected final long generation;
 
-  protected NamespacedId(NamespacedId other) {
-    this(other.namespace, other.id);
+  protected Namespace(Namespace other) {
+    this(other.name, other.generation);
   }
 
-  public NamespacedId(Namespace namespace, String id) {
-    this.namespace = namespace;
-    this.id = id;
+  public Namespace(String name, long generation) {
+    this.name = name;
+    this.generation = generation;
   }
 
-  public Namespace getNamespace() {
-    return namespace;
+  public Namespace(NamespaceSummary summary) {
+    this(summary.getName(), summary.getGeneration());
   }
 
-  public String getId() {
-    return id;
+  public String getName() {
+    return name;
+  }
+
+  public long getGeneration() {
+    return generation;
   }
 
   @Override
@@ -52,13 +56,13 @@ public class NamespacedId {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    NamespacedId that = (NamespacedId) o;
-    return Objects.equals(namespace, that.namespace) &&
-      Objects.equals(id, that.id);
+    Namespace that = (Namespace) o;
+    return generation == that.generation &&
+      Objects.equals(name, that.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(namespace, id);
+    return Objects.hash(name, generation);
   }
 }

--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/connection/Connection.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/connection/Connection.java
@@ -41,7 +41,7 @@ public final class Connection extends ConnectionMeta {
                     Map<String, String> properties) {
     super(type, name, description, properties);
     this.namespacedId = id;
-    this.context = id.getNamespace();
+    this.context = id.getNamespace().getName();
     this.id = id.getId();
     this.created = created;
     this.updated = updated;
@@ -54,9 +54,8 @@ public final class Connection extends ConnectionMeta {
   /**
    * @return id of the connection.
    */
-  public NamespacedId getId() {
-    // only null if this object was created through deserialization
-    return namespacedId == null ? new NamespacedId(context, id) : namespacedId;
+  public String getId() {
+    return id;
   }
 
   /**

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryHandler.java
@@ -145,9 +145,8 @@ public class BigQueryHandler extends AbstractWranglerHandler {
   @Path("/contexts/{context}/connections/{connection-id}/bigquery")
   public void listDatasets(HttpServiceRequest request, HttpServiceResponder responder,
                            @PathParam("context") String namespace, @PathParam("connection-id") String connectionId) {
-    respond(request, responder, namespace, () -> {
-      Connection connection = getValidatedConnection(new NamespacedId(namespace, connectionId),
-                                                     ConnectionType.BIGQUERY);
+    respond(request, responder, namespace, ns -> {
+      Connection connection = getValidatedConnection(new NamespacedId(ns, connectionId), ConnectionType.BIGQUERY);
 
       BigQuery bigQuery = GCPUtils.getBigQueryService(connection);
       String connectionProject = GCPUtils.getProjectId(connection);
@@ -197,8 +196,8 @@ public class BigQueryHandler extends AbstractWranglerHandler {
                          @PathParam("context") String namespace,
                          @PathParam("connection-id") String connectionId,
                          @PathParam("dataset-id") String datasetStr) {
-    respond(request, responder, namespace, () -> {
-      Connection connection = getValidatedConnection(new NamespacedId(namespace, connectionId),
+    respond(request, responder, namespace, ns -> {
+      Connection connection = getValidatedConnection(new NamespacedId(ns, connectionId),
                                                      ConnectionType.BIGQUERY);
       BigQuery bigQuery = GCPUtils.getBigQueryService(connection);
 
@@ -252,8 +251,8 @@ public class BigQueryHandler extends AbstractWranglerHandler {
                         @PathParam("dataset-id") String datasetStr,
                         @PathParam("table-id") String tableId,
                         @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    respond(request, responder, namespace, () -> {
-      Connection connection = getValidatedConnection(new NamespacedId(namespace, connectionId),
+    respond(request, responder, namespace, ns -> {
+      Connection connection = getValidatedConnection(new NamespacedId(ns, connectionId),
                                                      ConnectionType.BIGQUERY);
 
       Map<String, String> connectionProperties = connection.getProperties();
@@ -278,7 +277,7 @@ public class BigQueryHandler extends AbstractWranglerHandler {
       properties.put(BUCKET, bucket);
 
       String identifier = ServiceUtils.generateMD5(String.format("%s:%s", scope, tableId));
-      NamespacedId workspaceId = new NamespacedId(namespace, identifier);
+      NamespacedId workspaceId = new NamespacedId(ns, identifier);
       WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(workspaceId, tableId)
         .setScope(scope)
         .setProperties(properties)
@@ -318,8 +317,8 @@ public class BigQueryHandler extends AbstractWranglerHandler {
                             @PathParam("context") String namespace,
                             @PathParam("connection-id") String connectionId,
                             @QueryParam("wid") String workspaceId) {
-    respond(request, responder, namespace, () -> {
-      Map<String, String> config = getWorkspace(new NamespacedId(namespace, connectionId)).getProperties();
+    respond(request, responder, namespace, ns -> {
+      Map<String, String> config = getWorkspace(new NamespacedId(ns, connectionId)).getProperties();
 
       Map<String, String> properties = new HashMap<>();
       String externalDatasetName =

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionTypeConfig.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionTypeConfig.java
@@ -33,14 +33,14 @@ import javax.annotation.Nullable;
 public class ConnectionTypeConfig extends Config {
   private final Set<ConnectionType> disabledTypes;
   private final List<Connection> connections;
-  private final NamespacedId defaultConnection;
+  private final String defaultConnection;
 
   public ConnectionTypeConfig() {
     this(Collections.emptySet(), Collections.emptyList(), null);
   }
 
   public ConnectionTypeConfig(Set<ConnectionType> disabledTypes, List<Connection> connections,
-                              @Nullable NamespacedId defaultConnection) {
+                              @Nullable String defaultConnection) {
     this.disabledTypes = disabledTypes;
     this.connections = connections;
     this.defaultConnection = defaultConnection;
@@ -64,7 +64,7 @@ public class ConnectionTypeConfig extends Config {
    * Return the connection configured to be shown as default in dataprep - null if not provided
    */
   @Nullable
-  public NamespacedId getDefaultConnection() {
+  public String getDefaultConnection() {
     return defaultConnection;
   }
 

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/directive/ServicePipelineContext.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/directive/ServicePipelineContext.java
@@ -32,9 +32,10 @@ import java.util.Map;
  * Implementation of {@PipelineContext}, for use in Service.
  */
 class ServicePipelineContext implements ExecutorContext {
-  // this is different than serviceContext.getNamespace(), as it's
+  // this is different than serviceContext.getNamespace(), as it's the namespace of the workspace, not the namespace
+  // that we're executing in
   private final String namespace;
-  private final ExecutorContext.Environment environment;
+  private final Environment environment;
   private final HttpServiceContext serviceContext;
   private final DatasetContextLookupProvider lookupProvider;
   private final TransientStore store;

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSHandler.java
@@ -153,11 +153,11 @@ public class GCSHandler extends AbstractWranglerHandler {
                          @PathParam("connection-id") String connectionId,
                          @QueryParam("path") String path,
                          @QueryParam("limit") @DefaultValue("1000") int objectLimit) {
-    respond(request, responder, namespace, () -> {
+    respond(request, responder, namespace, ns -> {
       String bucketName = "";
       String prefix = null;
 
-      Connection connection = getValidatedConnection(new NamespacedId(namespace, connectionId), ConnectionType.GCS);
+      Connection connection = getValidatedConnection(new NamespacedId(ns, connectionId), ConnectionType.GCS);
 
       int bucketStart = path.indexOf("/");
       if (bucketStart != -1) {
@@ -284,14 +284,14 @@ public class GCSHandler extends AbstractWranglerHandler {
                          @PathParam("bucket") String bucket,
                          @QueryParam("blob") String blobPath,
                          @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    respond(request, responder, namespace, () -> {
+    respond(request, responder, namespace, ns -> {
       String contentType = request.getHeader(PropertyIds.CONTENT_TYPE);
 
       if (blobPath == null || blobPath.isEmpty()) {
         throw new BadRequestException("Required query param 'path' is missing in the input");
       }
 
-      Connection connection = getValidatedConnection(new NamespacedId(namespace, connectionId), ConnectionType.GCS);
+      Connection connection = getValidatedConnection(new NamespacedId(ns, connectionId), ConnectionType.GCS);
 
       Map<String, String> properties = new HashMap<>();
       Storage storage = GCPUtils.getStorageService(connection);
@@ -312,7 +312,7 @@ public class GCSHandler extends AbstractWranglerHandler {
       properties.put(PropertyIds.SAMPLER_TYPE, SamplingMethod.NONE.getMethod());
       properties.put(PropertyIds.CONNECTION_ID, connectionId);
       properties.put("bucket", bucket);
-      NamespacedId namespacedId = new NamespacedId(namespace, id);
+      NamespacedId namespacedId = new NamespacedId(ns, id);
       WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(namespacedId, file.getName())
         .setScope(scope)
         .setProperties(properties)
@@ -393,7 +393,7 @@ public class GCSHandler extends AbstractWranglerHandler {
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace, @PathParam("connection-id") String connectionId,
                             @QueryParam("wid") String workspaceId) {
-    respond(request, responder, namespace, () -> {
+    respond(request, responder, namespace, ns -> {
       if (workspaceId == null) {
         throw new BadRequestException("Workspace ID must be passed as query parameter 'wid'.");
       }
@@ -401,10 +401,10 @@ public class GCSHandler extends AbstractWranglerHandler {
       return TransactionRunners.run(getContext(), context -> {
         ConnectionStore store = ConnectionStore.get(context);
         WorkspaceDataset ws = WorkspaceDataset.get(context);
-        Connection connection = getValidatedConnection(store, new NamespacedId(namespace, connectionId),
+        Connection connection = getValidatedConnection(store, new NamespacedId(ns, connectionId),
                                                        ConnectionType.GCS);
 
-        NamespacedId namespacedIdWorkspaceId = new NamespacedId(namespace, workspaceId);
+        NamespacedId namespacedIdWorkspaceId = new NamespacedId(ns, workspaceId);
         Map<String, String> config = ws.getWorkspace(namespacedIdWorkspaceId).getProperties();
         String formatStr = config.getOrDefault(PropertyIds.FORMAT, Format.TEXT.name());
         Format format = Format.valueOf(formatStr);

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaHandler.java
@@ -115,7 +115,7 @@ public final class KafkaHandler extends AbstractWranglerHandler {
   @POST
   @Path("contexts/{context}/connections/kafka")
   public void list(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace) {
-    respond(request, responder, namespace, () -> {
+    respond(request, responder, namespace, ns -> {
       // Extract the body of the request and transform it to the Connection object.
       RequestExtractor extractor = new RequestExtractor(request);
       ConnectionMeta connection = extractor.getConnectionMeta(ConnectionType.KAFKA);
@@ -153,16 +153,16 @@ public final class KafkaHandler extends AbstractWranglerHandler {
                    @PathParam("id") String id, @PathParam("topic") String topic,
                    @QueryParam("lines") int lines,
                    @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    respond(request, responder, namespace, () -> TransactionRunners.run(getContext(), context -> {
+    respond(request, responder, namespace, ns -> TransactionRunners.run(getContext(), context -> {
       ConnectionStore store = ConnectionStore.get(context);
       WorkspaceDataset ws = WorkspaceDataset.get(context);
-      Connection connection = getValidatedConnection(store, new NamespacedId(namespace, id), ConnectionType.KAFKA);
+      Connection connection = getValidatedConnection(store, new NamespacedId(ns, id), ConnectionType.KAFKA);
 
       KafkaConfiguration config = new KafkaConfiguration(connection);
       KafkaConsumer<String, String> consumer = new KafkaConsumer<>(config.get());
       consumer.subscribe(Lists.newArrayList(topic));
       String uuid = ServiceUtils.generateMD5(String.format("%s:%s.%s", scope, id, topic));
-      NamespacedId namespacedId = new NamespacedId(namespace, uuid);
+      NamespacedId namespacedId = new NamespacedId(ns, uuid);
 
       Map<String, String> properties = new HashMap<>();
       properties.put(PropertyIds.ID, uuid);
@@ -231,8 +231,8 @@ public final class KafkaHandler extends AbstractWranglerHandler {
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace,
                             @PathParam("id") String id, @PathParam("topic") String topic) {
-    respond(request, responder, namespace, () -> {
-      Connection conn = getValidatedConnection(new NamespacedId(namespace, id), ConnectionType.KAFKA);
+    respond(request, responder, namespace, ns -> {
+      Connection conn = getValidatedConnection(new NamespacedId(ns, id), ConnectionType.KAFKA);
       Map<String, String> connProperties = conn.getProperties();
 
       Map<String, String> properties = new HashMap<>();

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/schema/SchemaRegistryHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/schema/SchemaRegistryHandler.java
@@ -70,7 +70,7 @@ public class SchemaRegistryHandler extends AbstractWranglerHandler {
   public void create(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace,
                      @QueryParam("id") String id, @QueryParam("name") String name,
                      @QueryParam("description") String description, @QueryParam("type") String type) {
-    respond(request, responder, namespace, () -> {
+    respond(request, responder, namespace, ns -> {
       if (id == null || id.isEmpty()) {
         throw new BadRequestException("Schema id must be specified.");
       }
@@ -84,7 +84,7 @@ public class SchemaRegistryHandler extends AbstractWranglerHandler {
       if (description == null || description.isEmpty()) {
         throw new BadRequestException("Schema description must be specified.");
       }
-      SchemaDescriptor descriptor = new SchemaDescriptor(new NamespacedId(namespace, id),
+      SchemaDescriptor descriptor = new SchemaDescriptor(new NamespacedId(ns, id),
                                                          name, description, descriptorType);
       TransactionRunners.run(getContext(), context -> {
         SchemaRegistry registry = SchemaRegistry.get(context);
@@ -130,7 +130,7 @@ public class SchemaRegistryHandler extends AbstractWranglerHandler {
   @Path("contexts/{context}/schemas/{id}")
   public void upload(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace,
                      @PathParam("id") String id) {
-    respond(request, responder, namespace, () -> {
+    respond(request, responder, namespace, ns -> {
       byte[] bytes;
       ByteBuffer content = request.getContent();
       if (content != null && content.hasRemaining()) {
@@ -144,7 +144,7 @@ public class SchemaRegistryHandler extends AbstractWranglerHandler {
         throw new BadRequestException("No schema was provided in the request body");
       }
 
-      NamespacedId namespacedId = new NamespacedId(namespace, id);
+      NamespacedId namespacedId = new NamespacedId(ns, id);
       long version = TransactionRunners.run(getContext(), context -> {
         SchemaRegistry registry = SchemaRegistry.get(context);
         return registry.add(namespacedId, bytes);
@@ -174,8 +174,8 @@ public class SchemaRegistryHandler extends AbstractWranglerHandler {
   @Path("contexts/{context}/schemas/{id}")
   public void delete(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace,
                      @PathParam("id") String id) {
-    respond(request, responder, namespace, () -> {
-      NamespacedId namespacedId = new NamespacedId(getContext().getNamespace(), id);
+    respond(request, responder, namespace, ns -> {
+      NamespacedId namespacedId = new NamespacedId(ns, id);
       TransactionRunners.run(getContext(), context -> {
         SchemaRegistry registry = SchemaRegistry.get(context);
         if (registry.hasSchema(namespacedId)) {
@@ -206,10 +206,10 @@ public class SchemaRegistryHandler extends AbstractWranglerHandler {
   @Path("contexts/{context}/schemas/{id}/versions/{version}")
   public void delete(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace,
                      @PathParam("id") String id, @PathParam("version") long version) {
-    respond(request, responder, namespace, () -> {
+    respond(request, responder, namespace, ns -> {
       TransactionRunners.run(getContext(), context -> {
         SchemaRegistry registry = SchemaRegistry.get(context);
-        registry.remove(new NamespacedId(namespace, id), version);
+        registry.remove(new NamespacedId(ns, id), version);
       });
       return new ServiceResponse<Void>("Successfully deleted version '" + version + "' of schema " + id);
     });
@@ -234,9 +234,9 @@ public class SchemaRegistryHandler extends AbstractWranglerHandler {
   @Path("contexts/{context}/schemas/{id}/versions/{version}")
   public void get(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace,
                   @PathParam("id") String id, @PathParam("version") long version) {
-    respond(request, responder, namespace, () -> TransactionRunners.run(getContext(), context -> {
+    respond(request, responder, namespace, ns -> TransactionRunners.run(getContext(), context -> {
       SchemaRegistry registry = SchemaRegistry.get(context);
-      return new ServiceResponse<>(registry.getEntry(new NamespacedId(namespace, id), version));
+      return new ServiceResponse<>(registry.getEntry(new NamespacedId(ns, id), version));
     }));
   }
 
@@ -260,9 +260,9 @@ public class SchemaRegistryHandler extends AbstractWranglerHandler {
   @Path("contexts/{context}/schemas/{id}")
   public void get(HttpServiceRequest request, HttpServiceResponder responder,
                   @PathParam("context") String namespace, @PathParam("id") String id) {
-    respond(request, responder, namespace, () -> TransactionRunners.run(getContext(), context -> {
+    respond(request, responder, namespace, ns -> TransactionRunners.run(getContext(), context -> {
       SchemaRegistry registry = SchemaRegistry.get(context);
-      return new ServiceResponse<>(registry.getEntry(new NamespacedId(namespace, id)));
+      return new ServiceResponse<>(registry.getEntry(new NamespacedId(ns, id)));
     }));
   }
 
@@ -283,9 +283,9 @@ public class SchemaRegistryHandler extends AbstractWranglerHandler {
   @Path("contexts/{context}/schemas/{id}/versions")
   public void versions(HttpServiceRequest request, HttpServiceResponder responder,
                        @PathParam("context") String namespace, @PathParam("id") String id) {
-    respond(request, responder, namespace, () -> TransactionRunners.run(getContext(), context -> {
+    respond(request, responder, namespace, ns -> TransactionRunners.run(getContext(), context -> {
       SchemaRegistry registry = SchemaRegistry.get(context);
-      return new ServiceResponse<>(registry.getVersions(new NamespacedId(namespace, id)));
+      return new ServiceResponse<>(registry.getVersions(new NamespacedId(ns, id)));
     }));
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerHandler.java
@@ -129,8 +129,8 @@ public class SpannerHandler extends AbstractWranglerHandler {
   public void getSpannerInstances(HttpServiceRequest request, HttpServiceResponder responder,
                                   @PathParam("context") String namespace,
                                   @PathParam("connection-id") String connectionId) {
-    respond(request, responder, namespace, () -> {
-      Connection connection = getValidatedConnection(new NamespacedId(namespace, connectionId), ConnectionType.SPANNER);
+    respond(request, responder, namespace, ns -> {
+      Connection connection = getValidatedConnection(new NamespacedId(ns, connectionId), ConnectionType.SPANNER);
       List<SpannerInstance> instances = getInstances(connection);
       return new ServiceResponse<>(instances);
     });
@@ -153,8 +153,8 @@ public class SpannerHandler extends AbstractWranglerHandler {
                                   @PathParam("context") String namespace,
                                   @PathParam("connection-id") String connectionId,
                                   @PathParam("instance-id") String instanceId) {
-    respond(request, responder, namespace, () -> {
-      Connection connection = getValidatedConnection(new NamespacedId(namespace, connectionId), ConnectionType.SPANNER);
+    respond(request, responder, namespace, ns -> {
+      Connection connection = getValidatedConnection(new NamespacedId(ns, connectionId), ConnectionType.SPANNER);
       List<SpannerDatabase> databases = getDatabases(connection, instanceId);
       return new ServiceResponse<>(databases);
     });
@@ -182,8 +182,8 @@ public class SpannerHandler extends AbstractWranglerHandler {
                                @PathParam("connection-id") String connectionId,
                                @PathParam("instance-id") String instanceId,
                                @PathParam("database-id") String databaseId) {
-    respond(request, responder, namespace, () -> {
-      Connection connection = getValidatedConnection(new NamespacedId(namespace, connectionId), ConnectionType.SPANNER);
+    respond(request, responder, namespace, ns -> {
+      Connection connection = getValidatedConnection(new NamespacedId(ns, connectionId), ConnectionType.SPANNER);
       List<SpannerTable> tables = getTables(connection, instanceId, databaseId);
       return new ServiceResponse<>(tables);
     });
@@ -216,8 +216,8 @@ public class SpannerHandler extends AbstractWranglerHandler {
                         @PathParam("table-id") String tableId,
                         @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope,
                         @QueryParam("limit") @DefaultValue(DEFAULT_ROW_LIMIT) String limit) {
-    respond(request, responder, namespace, () -> {
-      Connection connection = getValidatedConnection(new NamespacedId(namespace, connectionId), ConnectionType.SPANNER);
+    respond(request, responder, namespace, ns -> {
+      Connection connection = getValidatedConnection(new NamespacedId(ns, connectionId), ConnectionType.SPANNER);
       Schema schema = getTableSchema(connection, instanceId, databaseId, tableId);
       List<Row> data = getTableData(connection, instanceId, databaseId, tableId, schema, Long.parseLong(limit));
 
@@ -239,7 +239,7 @@ public class SpannerHandler extends AbstractWranglerHandler {
       workspaceProperties.put(PropertyIds.CONNECTION_TYPE, ConnectionType.SPANNER.getType());
       workspaceProperties.put(PropertyIds.CONNECTION_ID, connectionId);
       workspaceProperties.put(PropertyIds.PLUGIN_SPECIFICATION, GSON.toJson(specification));
-      NamespacedId workspaceId = new NamespacedId(namespace, identifier);
+      NamespacedId workspaceId = new NamespacedId(ns, identifier);
       WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(workspaceId, tableId)
         .setScope(scope)
         .setProperties(workspaceProperties)
@@ -275,8 +275,8 @@ public class SpannerHandler extends AbstractWranglerHandler {
   @GET
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace, @PathParam("workspace-id") String workspaceId) {
-    respond(request, responder, namespace, () -> {
-      Map<String, String> config = getWorkspace(new NamespacedId(namespace, workspaceId)).getProperties();
+    respond(request, responder, namespace, ns -> {
+      Map<String, String> config = getWorkspace(new NamespacedId(ns, workspaceId)).getProperties();
 
       // deserialize and send spanner source specification
       SpannerSpecification conf =


### PR DESCRIPTION
Added namespace generation to entity keys to make it behave like
all workspaces and connections are deleted when a CDAP namespace
is deleted then re-created.