### PR TITLE
CDAP-14604 remove non-namespaced endpoints

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryHandler.java
@@ -16,6 +16,8 @@
 
 package co.cask.wrangler.service.bigquery;
 
+import co.cask.cdap.api.annotation.TransactionControl;
+import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
@@ -100,20 +102,9 @@ public class BigQueryHandler extends AbstractWranglerHandler {
   private static final String SCHEMA = "schema";
   private static final String BUCKET = "bucket";
 
-  /**
-   * Tests BigQuery Connection.
-   *
-   * @param request HTTP Request handler.
-   * @param responder HTTP Response handler.
-   */
-  @POST
-  @Path("/connections/bigquery/test")
-  public void testBiqQueryConnection(HttpServiceRequest request, HttpServiceResponder responder) {
-    testBiqQueryConnection(request, responder, getContext().getNamespace());
-  }
-
   @POST
   @Path("/contexts/{context}/connections/bigquery/test")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void testBiqQueryConnection(HttpServiceRequest request, HttpServiceResponder responder,
                                      @PathParam("context") String namespace) {
     respond(request, responder, () -> {
@@ -128,21 +119,9 @@ public class BigQueryHandler extends AbstractWranglerHandler {
     });
   }
 
-  /**
-   * List all datasets.
-   *
-   * @param request HTTP requets handler.
-   * @param responder HTTP response handler.
-   */
-  @GET
-  @Path("connections/{connection-id}/bigquery")
-  public void listDatasets(HttpServiceRequest request, HttpServiceResponder responder,
-                           @PathParam("connection-id") String connectionId) {
-    listDatasets(request, responder, getContext().getNamespace(), connectionId);
-  }
-
   @GET
   @Path("/contexts/{context}/connections/{connection-id}/bigquery")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void listDatasets(HttpServiceRequest request, HttpServiceResponder responder,
                            @PathParam("context") String namespace, @PathParam("connection-id") String connectionId) {
     respond(request, responder, namespace, ns -> {
@@ -175,23 +154,8 @@ public class BigQueryHandler extends AbstractWranglerHandler {
    *   The project prefix is optional. When not given, the connection project should be used.
    */
   @GET
-  @Path("connections/{connection-id}/bigquery/{dataset-id}/tables")
-  public void listTables(HttpServiceRequest request, HttpServiceResponder responder,
-                         @PathParam("connection-id") String connectionId,
-                         @PathParam("dataset-id") String datasetStr) {
-    listTables(request, responder, getContext().getNamespace(), connectionId, datasetStr);
-  }
-
-  /**
-   * List all tables in a dataset.
-   *
-   * @param request HTTP requets handler.
-   * @param responder HTTP response handler.
-   * @param datasetStr the dataset id as a string. It will be of the form [project:]name.
-   *   The project prefix is optional. When not given, the connection project should be used.
-   */
-  @GET
   @Path("contexts/{context}/connections/{connection-id}/bigquery/{dataset-id}/tables")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void listTables(HttpServiceRequest request, HttpServiceResponder responder,
                          @PathParam("context") String namespace,
                          @PathParam("connection-id") String connectionId,
@@ -223,16 +187,6 @@ public class BigQueryHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("connections/{connection-id}/bigquery/{dataset-id}/tables/{table-id}/read")
-  public void readTable(HttpServiceRequest request, HttpServiceResponder responder,
-                        @PathParam("connection-id") String connectionId,
-                        @PathParam("dataset-id") String datasetStr,
-                        @PathParam("table-id") String tableId,
-                        @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    readTable(request, responder, getContext().getNamespace(), connectionId, datasetStr, tableId, scope);
-  }
-
   /**
    * Read a table.
    *
@@ -245,6 +199,7 @@ public class BigQueryHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections/{connection-id}/bigquery/{dataset-id}/tables/{table-id}/read")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void readTable(HttpServiceRequest request, HttpServiceResponder responder,
                         @PathParam("context") String namespace,
                         @PathParam("connection-id") String connectionId,
@@ -297,22 +252,15 @@ public class BigQueryHandler extends AbstractWranglerHandler {
     });
   }
 
-  @Path("connections/{connection-id}/bigquery/specification")
-  @GET
-  public void specification(HttpServiceRequest request, HttpServiceResponder responder,
-                            @PathParam("connection-id") String connectionId,
-                            @QueryParam("wid") String workspaceId) {
-    specification(request, responder, getContext().getNamespace(), connectionId, workspaceId);
-  }
-
   /**
    * Specification for the source.
    *
    * @param request HTTP request handler.
    * @param responder HTTP response handler.
    */
-  @Path("contexts/{context}/connections/{connection-id}/bigquery/specification")
   @GET
+  @Path("contexts/{context}/connections/{connection-id}/bigquery/specification")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace,
                             @PathParam("connection-id") String connectionId,

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/common/AbstractWranglerHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/common/AbstractWranglerHandler.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.NamespaceSummary;
 import co.cask.cdap.api.service.http.AbstractSystemHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
+import co.cask.cdap.spi.data.transaction.TransactionException;
 import co.cask.cdap.spi.data.transaction.TransactionRunners;
 import co.cask.wrangler.dataset.connections.ConnectionNotFoundException;
 import co.cask.wrangler.dataset.connections.ConnectionStore;

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionHandler.java
@@ -17,6 +17,8 @@
 package co.cask.wrangler.service.connections;
 
 import co.cask.cdap.api.NamespaceSummary;
+import co.cask.cdap.api.annotation.TransactionControl;
+import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.cdap.api.service.http.SystemHttpServiceContext;
@@ -138,12 +140,6 @@ public class ConnectionHandler extends AbstractWranglerHandler {
     }
   }
 
-  @POST
-  @Path("connections/create")
-  public void create(HttpServiceRequest request, HttpServiceResponder responder) {
-    create(request, responder, getContext().getNamespace());
-  }
-
   /**
    * Creates a connection object in the connections store.
    *
@@ -166,6 +162,7 @@ public class ConnectionHandler extends AbstractWranglerHandler {
    */
   @POST
   @Path("contexts/{context}/connections/create")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void create(HttpServiceRequest request, HttpServiceResponder responder,
                      @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -182,13 +179,6 @@ public class ConnectionHandler extends AbstractWranglerHandler {
       // Return the id in the response.
       return new ServiceResponse<>(Collections.singletonList(id.getId()));
     });
-  }
-
-  @POST
-  @Path("connections/{id}/update")
-  public void update(HttpServiceRequest request, HttpServiceResponder responder,
-                     @PathParam("id") String id) {
-    update(request, responder, getContext().getNamespace(), id);
   }
 
   /**
@@ -216,6 +206,7 @@ public class ConnectionHandler extends AbstractWranglerHandler {
    */
   @POST
   @Path("contexts/{context}/connections/{id}/update")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void update(HttpServiceRequest request, HttpServiceResponder responder,
                      @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -233,13 +224,6 @@ public class ConnectionHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("connections")
-  public void list(HttpServiceRequest request, HttpServiceResponder responder,
-                   @DefaultValue(ALL_TYPES) @QueryParam("type") String type) {
-    list(request, responder, getContext().getNamespace(), type);
-  }
-
   /**
    * Lists all the connections available in the connection store.
    *
@@ -248,6 +232,7 @@ public class ConnectionHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void list(HttpServiceRequest request, HttpServiceResponder responder,
                    @PathParam("context") String namespace, @DefaultValue(ALL_TYPES) @QueryParam("type") String type) {
     respond(request, responder, namespace, ns -> {
@@ -278,13 +263,6 @@ public class ConnectionHandler extends AbstractWranglerHandler {
     return connection.map(Connection::getId).orElse(null);
   }
 
-  @DELETE
-  @Path("connections/{id}")
-  public void delete(HttpServiceRequest request, HttpServiceResponder responder,
-                     @PathParam("id") String id) {
-    delete(request, responder, getContext().getNamespace(), id);
-  }
-
   /**
    * Deletes a connection from the connection store.
    *
@@ -294,6 +272,7 @@ public class ConnectionHandler extends AbstractWranglerHandler {
    */
   @DELETE
   @Path("contexts/{context}/connections/{id}")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void delete(HttpServiceRequest request, HttpServiceResponder responder,
                      @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -312,13 +291,6 @@ public class ConnectionHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("connections/{id}")
-  public void get(HttpServiceRequest request, HttpServiceResponder responder,
-                  @PathParam("id") String id) {
-    get(request, responder, getContext().getNamespace(), id);
-  }
-
   /**
    * Given a connection id, returns the complete information about the connection.
    *
@@ -328,17 +300,10 @@ public class ConnectionHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections/{id}")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void get(HttpServiceRequest request, HttpServiceResponder responder,
                   @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> getConnection(new NamespacedId(ns, id)));
-  }
-
-
-  @GET
-  @Path("connections/{id}/properties")
-  public void properties(HttpServiceRequest request, HttpServiceResponder responder,
-                         @PathParam("id") String id) {
-    properties(request, responder, getContext().getNamespace(), id);
   }
 
   /**
@@ -350,17 +315,10 @@ public class ConnectionHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections/{id}/properties")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void properties(HttpServiceRequest request, HttpServiceResponder responder,
                          @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> getConnection(new NamespacedId(ns, id)).getProperties());
-  }
-
-  @PUT
-  @Path("connections/{id}/properties")
-  public void updateProp(HttpServiceRequest request, HttpServiceResponder responder,
-                         @PathParam("id") String id,
-                         @QueryParam("key") String key, @QueryParam("value") String value) {
-    updateProp(request, responder, getContext().getNamespace(), id, key, value);
   }
 
   /**
@@ -372,6 +330,7 @@ public class ConnectionHandler extends AbstractWranglerHandler {
    */
   @PUT
   @Path("contexts/{context}/connections/{id}/properties")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void updateProp(HttpServiceRequest request, HttpServiceResponder responder,
                          @PathParam("context") String namespace, @PathParam("id") String id,
                          @QueryParam("key") String key, @QueryParam("value") String value) {
@@ -391,13 +350,6 @@ public class ConnectionHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("connections/{id}/clone")
-  public void clone(HttpServiceRequest request, HttpServiceResponder responder,
-                    @PathParam("id") final String id) {
-    clone(request, responder, getContext().getNamespace(), id);
-  }
-
   /**
    * Given a connection id, Clones and returns a new connection.
    *
@@ -407,6 +359,7 @@ public class ConnectionHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections/{id}/clone")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void clone(HttpServiceRequest request, HttpServiceResponder responder,
                     @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -423,6 +376,7 @@ public class ConnectionHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("connectionTypes")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void getConnectionTypes(HttpServiceRequest request, HttpServiceResponder responder) {
     responder.sendJson(enabledConnectionTypes);
   }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/database/DatabaseHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/database/DatabaseHandler.java
@@ -16,6 +16,8 @@
 
 package co.cask.wrangler.service.database;
 
+import co.cask.cdap.api.annotation.TransactionControl;
+import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.artifact.ArtifactInfo;
 import co.cask.cdap.api.artifact.CloseableClassLoader;
 import co.cask.cdap.api.plugin.PluginClass;
@@ -197,12 +199,6 @@ public class DatabaseHandler extends AbstractWranglerHandler {
     }
   }
 
-  @GET
-  @Path("jdbc/drivers")
-  public void listDrivers(HttpServiceRequest request, HttpServiceResponder responder) {
-    listDrivers(request, responder, getContext().getNamespace());
-  }
-
   /**
    * Lists all the JDBC drivers installed.
    * <p>
@@ -239,6 +235,7 @@ public class DatabaseHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/jdbc/drivers")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void listDrivers(HttpServiceRequest request, HttpServiceResponder responder,
                           @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -275,12 +272,6 @@ public class DatabaseHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("jdbc/allowed")
-  public void listAvailableDrivers(HttpServiceRequest request, HttpServiceResponder responder) {
-    listAvailableDrivers(request, responder, getContext().getNamespace());
-  }
-
   /**
    * List all the possible drivers supported.
    *
@@ -305,6 +296,7 @@ public class DatabaseHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/jdbc/allowed")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void listAvailableDrivers(HttpServiceRequest request, HttpServiceResponder responder,
                                    @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -319,27 +311,9 @@ public class DatabaseHandler extends AbstractWranglerHandler {
     });
   }
 
-  /**
-   * Tests the connection.
-   *
-   * Following is the response when the connection is successfull.
-   *
-   * {
-   *   "status" : 200,
-   *   "message" : "Successfully connected to database."
-   * }
-   *
-   * @param request HTTP request handler.
-   * @param responder HTTP response handler.
-   */
-  @POST
-  @Path("connections/jdbc/test")
-  public void testConnection(HttpServiceRequest request, HttpServiceResponder responder) {
-    testConnection(request, responder, getContext().getNamespace());
-  }
-
   @POST
   @Path("contexts/{context}/connections/jdbc/test")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void testConnection(HttpServiceRequest request, HttpServiceResponder responder,
                              @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -359,12 +333,6 @@ public class DatabaseHandler extends AbstractWranglerHandler {
     });
   }
 
-  @POST
-  @Path("connections/databases")
-  public void listDatabases(HttpServiceRequest request, HttpServiceResponder responder) {
-    listDatabases(request, responder, getContext().getNamespace());
-  }
-
   /**
    * Lists all databases.
    *
@@ -373,6 +341,7 @@ public class DatabaseHandler extends AbstractWranglerHandler {
    */
   @POST
   @Path("contexts/{context}/connections/databases")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void listDatabases(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -415,13 +384,6 @@ public class DatabaseHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("connections/{id}/tables")
-  public void listTables(HttpServiceRequest request, HttpServiceResponder responder,
-                         @PathParam("id") String id) {
-    listTables(request, responder, getContext().getNamespace(), id);
-  }
-
   /**
    * Lists all the tables within a database.
    *
@@ -431,6 +393,7 @@ public class DatabaseHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections/{id}/tables")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void listTables(HttpServiceRequest request, HttpServiceResponder responder,
                          @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -476,15 +439,6 @@ public class DatabaseHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("connections/{id}/tables/{table}/read")
-  public void read(HttpServiceRequest request, HttpServiceResponder responder,
-                   @PathParam("id") String id, @PathParam("table") String table,
-                   @QueryParam("lines") int lines,
-                   @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    read(request, responder, getContext().getNamespace(), id, table, lines, scope);
-  }
-
   /**
    * Reads a table into workspace.
    *
@@ -497,6 +451,7 @@ public class DatabaseHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections/{id}/tables/{table}/read")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void read(HttpServiceRequest request, HttpServiceResponder responder,
                    @PathParam("context") String namespace, @PathParam("id") String id, @PathParam("table") String table,
                    @QueryParam("lines") int lines,
@@ -577,13 +532,6 @@ public class DatabaseHandler extends AbstractWranglerHandler {
     return rows;
   }
 
-  @Path("connections/{id}/tables/{table}/specification")
-  @GET
-  public void specification(HttpServiceRequest request, HttpServiceResponder responder,
-                            @PathParam("id") String id, @PathParam("table") String table) {
-    specification(request, responder, getContext().getNamespace(), id, table);
-  }
-
   /**
    * Specification for the source.
    *
@@ -592,8 +540,9 @@ public class DatabaseHandler extends AbstractWranglerHandler {
    * @param id of the connection.
    * @param table in the database.
    */
-  @Path("contexts/{context}/connections/{id}/tables/{table}/specification")
   @GET
+  @Path("contexts/{context}/connections/{id}/tables/{table}/specification")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace, @PathParam("id") String id,
                             @PathParam("table") String table) {

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/directive/DirectivesHandler.java
@@ -16,6 +16,8 @@
 
 package co.cask.wrangler.service.directive;
 
+import co.cask.cdap.api.annotation.TransactionControl;
+import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.artifact.ArtifactInfo;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.schema.Schema;
@@ -40,6 +42,7 @@ import co.cask.wrangler.api.DirectiveParseException;
 import co.cask.wrangler.api.ExecutorContext;
 import co.cask.wrangler.api.GrammarMigrator;
 import co.cask.wrangler.api.Pair;
+import co.cask.wrangler.api.RecipeException;
 import co.cask.wrangler.api.RecipeParser;
 import co.cask.wrangler.api.RecipeSymbol;
 import co.cask.wrangler.api.Row;
@@ -165,16 +168,9 @@ public class DirectivesHandler extends AbstractWranglerHandler {
 
   @GET
   @Path("health")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void healthCheck(HttpServiceRequest request, HttpServiceResponder responder) {
     responder.sendStatus(HttpURLConnection.HTTP_OK);
-  }
-
-  @PUT
-  @Path("workspaces/{id}")
-  public void create(HttpServiceRequest request, HttpServiceResponder responder,
-                     @PathParam("id") String id, @QueryParam("name") String name,
-                     @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    create(request, responder, getContext().getNamespace(), id, name, scope);
   }
 
   /**
@@ -194,6 +190,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @PUT
   @Path("contexts/{context}/workspaces/{id}")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void create(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace,
                      @PathParam("id") String id, @QueryParam("name") String name,
                      @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
@@ -213,13 +210,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
       });
       return new ServiceResponse<Void>(String.format("Successfully created workspace '%s'", id));
     });
-  }
-
-  @GET
-  @Path("workspaces")
-  public void list(HttpServiceRequest request, HttpServiceResponder responder,
-                   @QueryParam("scope") @DefaultValue("default") String scope) {
-    list(request, responder, getContext().getNamespace(), scope);
   }
 
   /**
@@ -244,6 +234,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/workspaces")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void list(HttpServiceRequest request, HttpServiceResponder responder,
                    @PathParam("context") String namespace, @QueryParam("scope") @DefaultValue("default") String scope) {
     respond(request, responder, namespace, ns -> {
@@ -253,13 +244,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
       });
       return new ServiceResponse<>(workspaces);
     });
-  }
-
-  @DELETE
-  @Path("workspaces/{id}")
-  public void delete(HttpServiceRequest request, HttpServiceResponder responder,
-                     @PathParam("id") String id) {
-    delete(request, responder, getContext().getNamespace(), id);
   }
 
   /**
@@ -278,6 +262,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @DELETE
   @Path("contexts/{context}/workspaces/{id}")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void delete(HttpServiceRequest request, HttpServiceResponder responder,
                      @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -287,13 +272,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
       });
       return new ServiceResponse<Void>(String.format("Successfully deleted workspace '%s'", id));
     });
-  }
-
-  @DELETE
-  @Path("workspaces/")
-  public void deleteGroup(HttpServiceRequest request, HttpServiceResponder responder,
-                          @QueryParam("group") String group) {
-    deleteGroup(request, responder, getContext().getNamespace(), group);
   }
 
   /**
@@ -312,6 +290,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @DELETE
   @Path("contexts/{context}/workspaces/")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void deleteGroup(HttpServiceRequest request, HttpServiceResponder responder,
                           @PathParam("context") String namespace, @QueryParam("group") String group) {
     respond(request, responder, namespace, ns -> {
@@ -321,13 +300,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
       });
       return new ServiceResponse<Void>(String.format("Successfully deleted workspaces within group '%s'", group));
     });
-  }
-
-  @GET
-  @Path("workspaces/{id}")
-  public void get(HttpServiceRequest request, HttpServiceResponder responder,
-                  @PathParam("id") String id) {
-    get(request, responder, getContext().getNamespace(), id);
   }
 
   /**
@@ -361,6 +333,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/workspaces/{id}")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void get(HttpServiceRequest request, HttpServiceResponder responder,
                   @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -404,12 +377,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
     return merged;
   }
 
-  @POST
-  @Path("workspaces")
-  public void upload(HttpServiceRequest request, HttpServiceResponder responder) {
-    upload(request, responder, getContext().getNamespace());
-  }
-
   /**
    * Upload data to the workspace, the workspace is created automatically on fly.
    *
@@ -418,6 +385,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @POST
   @Path("contexts/{context}/workspaces")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void upload(HttpServiceRequest request, HttpServiceResponder responder,
                      @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -503,14 +471,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
     });
   }
 
-
-  @POST
-  @Path("workspaces/{id}/upload")
-  public void uploadData(HttpServiceRequest request, HttpServiceResponder responder,
-                         @PathParam("id") String id) {
-    uploadData(request, responder, getContext().getNamespace(), id);
-  }
-
   /**
    * Upload data to the workspace.
    *
@@ -520,6 +480,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @POST
   @Path("contexts/{context}/workspaces/{id}/upload")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void uploadData(HttpServiceRequest request, HttpServiceResponder responder,
                          @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -589,12 +550,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
     });
   }
 
-  @POST
-  @Path("workspaces/{id}/execute")
-  public void execute(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("id") String id) {
-    execute(request, responder, getContext().getNamespace(), id);
-  }
-
   /**
    * Executes the directives on the record stored in the workspace.
    *
@@ -616,6 +571,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @POST
   @Path("contexts/{context}/workspaces/{id}/execute")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void execute(HttpServiceRequest request, HttpServiceResponder responder,
                       @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -730,13 +686,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
     return null;
   }
 
-  @POST
-  @Path("workspaces/{id}/summary")
-  public void summary(HttpServiceRequest request, HttpServiceResponder responder,
-                      @PathParam("id") String id) {
-    summary(request, responder, getContext().getNamespace(), id);
-  }
-
   /**
    * Summarizes the workspace by running directives.
    *
@@ -746,6 +695,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @POST
   @Path("contexts/{context}/workspaces/{id}/summary")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void summary(HttpServiceRequest request, HttpServiceResponder responder,
                       @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -826,14 +776,8 @@ public class DirectivesHandler extends AbstractWranglerHandler {
   }
 
   @POST
-  @Path("workspaces/{id}/schema")
-  public void schema(HttpServiceRequest request, HttpServiceResponder responder,
-                     @PathParam("id") String id) {
-    schema(request, responder, getContext().getNamespace(), id);
-  }
-
-  @POST
   @Path("contexts/{context}/workspaces/{id}/schema")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void schema(HttpServiceRequest request, HttpServiceResponder responder,
                      @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
@@ -875,6 +819,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("info")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void capabilities(HttpServiceRequest request, HttpServiceResponder responder) {
     respond(request, responder, () -> {
       ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -892,13 +837,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
       }
       return new ServiceResponse<>(value);
     });
-  }
-
-
-  @GET
-  @Path("usage")
-  public void usage(HttpServiceRequest request, HttpServiceResponder responder) {
-    usage(request, responder, getContext().getNamespace());
   }
 
   /**
@@ -923,6 +861,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/usage")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void usage(HttpServiceRequest request, HttpServiceResponder responder,
                     @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -959,12 +898,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("artifacts")
-  public void artifacts(HttpServiceRequest request, HttpServiceResponder responder) {
-    artifacts(request, responder, getContext().getNamespace());
-  }
-
   /**
    * This HTTP endpoint is used to retrieve artifacts that include plugins
    * of type <code>Directive.Type</code> (directive). Artifact will be reported
@@ -972,6 +905,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/artifacts")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void artifacts(HttpServiceRequest request, HttpServiceResponder responder,
                         @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -989,13 +923,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
       return new ServiceResponse<>(values);
     });
   }
-
-  @GET
-  @Path("directives")
-  public void directives(HttpServiceRequest request, HttpServiceResponder responder) {
-    directives(request, responder, getContext().getNamespace());
-  }
-
   /**
    * This HTTP endpoint is used to retrieve plugins that are
    * of type <code>Directive.Type</code> (directive). Artifact will be reported
@@ -1005,6 +932,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/directives")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void directives(HttpServiceRequest request, HttpServiceResponder responder,
                          @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -1024,12 +952,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("directives/reload")
-  public void directivesReload(HttpServiceRequest request, HttpServiceResponder responder) {
-    directivesReload(request, responder, getContext().getNamespace());
-  }
-
   /**
    * This HTTP endpoint is used to reload the plugins that are
    * of type <code>Directive.Type</code> (directive). Artifact will be reported
@@ -1037,6 +959,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/directives/reload")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void directivesReload(HttpServiceRequest request, HttpServiceResponder responder,
                                @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
@@ -1053,6 +976,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("charsets")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void charsets(HttpServiceRequest request, HttpServiceResponder responder) {
     respond(request, responder, () -> new ServiceResponse<>(Charset.availableCharsets().keySet()));
   }
@@ -1065,6 +989,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @POST
   @Path("config")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void uploadConfig(HttpServiceRequest request, HttpServiceResponder responder) {
     respond(request, responder, () -> {
       // Read the request body
@@ -1089,6 +1014,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("config")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void getConfig(HttpServiceRequest request, HttpServiceResponder responder) {
     respond(request, responder, () -> TransactionRunners.run(getContext(), context -> {
       ConfigStore configStore = ConfigStore.get(context);
@@ -1189,7 +1115,11 @@ public class DirectivesHandler extends AbstractWranglerHandler {
         RecipeParser recipe = new GrammarBasedParser(id.getNamespace().getName(), migrate, composite);
         recipe.initialize(new ConfigDirectiveContext(configStore.getConfig()));
         executor.initialize(recipe, context);
-        rows = executor.execute(sample.apply(rows));
+        try {
+          rows = executor.execute(sample.apply(rows));
+        } catch (RecipeException e) {
+          throw new BadRequestException(e.getMessage(), e);
+        }
         executor.destroy();
       }
       return rows;

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/explorer/FilesystemExplorer.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/explorer/FilesystemExplorer.java
@@ -72,15 +72,6 @@ public class FilesystemExplorer extends AbstractWranglerHandler {
   private static final String COLUMN_NAME = "body";
   private static final int FILE_SIZE = 10 * 1024 * 1024;
 
-  @TransactionPolicy(value = TransactionControl.EXPLICIT)
-  @Path("explorer/fs")
-  @GET
-  public void list(HttpServiceRequest request, HttpServiceResponder responder,
-                   @QueryParam("path") String path,
-                   @QueryParam("hidden") boolean hidden) {
-    list(request, responder, getContext().getNamespace(), path, hidden);
-  }
-
   /**
    * Lists the content of the path specified using the {@link Location}.
    *
@@ -88,23 +79,13 @@ public class FilesystemExplorer extends AbstractWranglerHandler {
    * @param responder HTTP Response Handler
    * @param path to the location in the filesystem
    */
-  @TransactionPolicy(value = TransactionControl.EXPLICIT)
-  @Path("contexts/{context}/explorer/fs")
   @GET
+  @Path("contexts/{context}/explorer/fs")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void list(HttpServiceRequest request, HttpServiceResponder responder,
                    @PathParam("context") String namespace, @QueryParam("path") String path,
                    @QueryParam("hidden") boolean hidden) {
     respond(request, responder, namespace, ns -> explorer.browse(path, hidden));
-  }
-
-  @Path("explorer/fs/read")
-  @GET
-  public void read(HttpServiceRequest request, HttpServiceResponder responder,
-                   @QueryParam("path") String path, @QueryParam("lines") int lines,
-                   @QueryParam("sampler") String sampler,
-                   @QueryParam("fraction") double fraction,
-                   @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    read(request, responder, getContext().getNamespace(), path, lines, sampler, fraction, scope);
   }
 
   /**
@@ -116,8 +97,9 @@ public class FilesystemExplorer extends AbstractWranglerHandler {
    * @param lines number of lines to extracted from file if it's a text/plain.
    * @param sampler sampling method to be used.
    */
-  @Path("contexts/{context}/explorer/fs/read")
   @GET
+  @Path("contexts/{context}/explorer/fs/read")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void read(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace,
                    @QueryParam("path") String path, @QueryParam("lines") int lines,
                    @QueryParam("sampler") String sampler,
@@ -149,13 +131,6 @@ public class FilesystemExplorer extends AbstractWranglerHandler {
     });
   }
 
-  @Path("explorer/fs/specification")
-  @GET
-  public void specification(HttpServiceRequest request, HttpServiceResponder responder,
-                            @QueryParam("path") String path, @QueryParam("wid") String workspaceId) {
-    specification(request, responder, getContext().getNamespace(), path, workspaceId);
-  }
-
   /**
    * Specification for the source.
    *
@@ -163,8 +138,9 @@ public class FilesystemExplorer extends AbstractWranglerHandler {
    * @param responder HTTP response handler.
    * @param path to the location in the filesystem.
    */
-  @Path("contexts/{context}/explorer/fs/specification")
   @GET
+  @Path("contexts/{context}/explorer/fs/specification")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace,
                             @QueryParam("path") String path, @QueryParam("wid") String workspaceId) {

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/gcs/GCSHandler.java
@@ -16,7 +16,6 @@
 
 package co.cask.wrangler.service.gcs;
 
-import co.cask.cdap.api.annotation.ReadOnly;
 import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
@@ -100,20 +99,9 @@ public class GCSHandler extends AbstractWranglerHandler {
     this.detector = new FileTypeDetector();
   }
 
-  /**
-   * Tests GCS Connection.
-   *
-   * @param request HTTP Request handler.
-   * @param responder HTTP Response handler.
-   */
-  @POST
-  @Path("/connections/gcs/test")
-  public void testGCSConnection(HttpServiceRequest request, HttpServiceResponder responder) {
-    testGCSConnection(request, responder, getContext().getNamespace());
-  }
-
   @POST
   @Path("/contexts/{context}/connections/gcs/test")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void testGCSConnection(HttpServiceRequest request, HttpServiceResponder responder,
                                 @PathParam("context") String namespace) {
     respond(request, responder, () -> {
@@ -128,26 +116,14 @@ public class GCSHandler extends AbstractWranglerHandler {
     });
   }
 
-  @TransactionPolicy(value = TransactionControl.EXPLICIT)
-  @ReadOnly
-  @GET
-  @Path("/connections/{connection-id}/gcs/explore")
-  public void exploreGCS(HttpServiceRequest request, HttpServiceResponder responder,
-                         @PathParam("connection-id") String connectionId,
-                         @QueryParam("path") String path,
-                         @QueryParam("limit") @DefaultValue("1000") int objectLimit) {
-    exploreGCS(request, responder, getContext().getNamespace(), connectionId, path, objectLimit);
-  }
-
   /**
    * Lists GCS bucket's contents for the given prefix path.
    * @param request HTTP Request handler.
    * @param responder HTTP Response handler.
    */
-  @TransactionPolicy(value = TransactionControl.EXPLICIT)
-  @ReadOnly
   @GET
   @Path("contexts/{context}/connections/{connection-id}/gcs/explore")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void exploreGCS(HttpServiceRequest request, HttpServiceResponder responder,
                          @PathParam("context") String namespace,
                          @PathParam("connection-id") String connectionId,
@@ -260,16 +236,6 @@ public class GCSHandler extends AbstractWranglerHandler {
     }
   }
 
-  @GET
-  @Path("/connections/{connection-id}/gcs/buckets/{bucket}/read")
-  public void loadObject(HttpServiceRequest request, HttpServiceResponder responder,
-                         @PathParam("connection-id") String connectionId,
-                         @PathParam("bucket") String bucket,
-                         @QueryParam("blob") String blobPath,
-                         @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    loadObject(request, responder, getContext().getNamespace(), connectionId, bucket, blobPath, scope);
-  }
-
   /**
    * Reads GCS object into workspace.
    *
@@ -278,6 +244,7 @@ public class GCSHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections/{connection-id}/gcs/buckets/{bucket}/read")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void loadObject(HttpServiceRequest request, HttpServiceResponder responder,
                          @PathParam("context") String namespace,
                          @PathParam("connection-id") String connectionId,
@@ -374,22 +341,15 @@ public class GCSHandler extends AbstractWranglerHandler {
     });
   }
 
-  @Path("/connections/{connection-id}/gcs/specification")
-  @GET
-  public void specification(HttpServiceRequest request, HttpServiceResponder responder,
-                            @PathParam("connection-id") String connectionId,
-                            @QueryParam("wid") String workspaceId) {
-    specification(request, responder, getContext().getNamespace(), connectionId, workspaceId);
-  }
-
   /**
    * Specification for the source.
    *
    * @param request HTTP request handler.
    * @param responder HTTP response handler.
    */
-  @Path("contexts/{context}/connections/{connection-id}/gcs/specification")
   @GET
+  @Path("contexts/{context}/connections/{connection-id}/gcs/specification")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace, @PathParam("connection-id") String connectionId,
                             @QueryParam("wid") String workspaceId) {

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaHandler.java
@@ -16,6 +16,8 @@
 
 package co.cask.wrangler.service.kafka;
 
+import co.cask.cdap.api.annotation.TransactionControl;
+import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.cdap.spi.data.transaction.TransactionRunners;
@@ -61,27 +63,9 @@ import javax.ws.rs.QueryParam;
  */
 public final class KafkaHandler extends AbstractWranglerHandler {
 
-  /**
-   * Tests the connection to kafka..
-   *
-   * Following is the response when the connection is successful.
-   *
-   * {
-   *   "status" : 200,
-   *   "message" : "Successfully connected to kafka."
-   * }
-   *
-   * @param request  HTTP request handler.
-   * @param responder HTTP response handler.
-   */
-  @POST
-  @Path("connections/kafka/test")
-  public void test(HttpServiceRequest request, HttpServiceResponder responder) {
-    test(request, responder, getContext().getNamespace());
-  }
-
   @POST
   @Path("contexts/{context}/connections/kafka/test")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void test(HttpServiceRequest request, HttpServiceResponder responder,
                    @PathParam("context") String namespace) {
     respond(request, responder, () -> {
@@ -100,12 +84,6 @@ public final class KafkaHandler extends AbstractWranglerHandler {
     });
   }
 
-  @POST
-  @Path("connections/kafka")
-  public void list(HttpServiceRequest request, HttpServiceResponder responder) {
-    list(request, responder, getContext().getNamespace());
-  }
-
   /**
    * List all kafka topics.
    *
@@ -114,6 +92,7 @@ public final class KafkaHandler extends AbstractWranglerHandler {
    */
   @POST
   @Path("contexts/{context}/connections/kafka")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void list(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
       // Extract the body of the request and transform it to the Connection object.
@@ -131,15 +110,6 @@ public final class KafkaHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("connections/{id}/kafka/{topic}/read")
-  public void read(HttpServiceRequest request, HttpServiceResponder responder,
-                   @PathParam("id") String id, @PathParam("topic") String topic,
-                   @QueryParam("lines") int lines,
-                   @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    read(request, responder, getContext().getNamespace(), id, topic, lines, scope);
-  }
-
   /**
    * Reads a kafka topic into workspace.
    *
@@ -149,6 +119,7 @@ public final class KafkaHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections/{id}/kafka/{topic}/read")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void read(HttpServiceRequest request, HttpServiceResponder responder, @PathParam("context") String namespace,
                    @PathParam("id") String id, @PathParam("topic") String topic,
                    @QueryParam("lines") int lines,
@@ -211,13 +182,6 @@ public final class KafkaHandler extends AbstractWranglerHandler {
     }));
   }
 
-  @Path("connections/{id}/kafka/{topic}/specification")
-  @GET
-  public void specification(HttpServiceRequest request, HttpServiceResponder responder,
-                            @PathParam("id") String id, @PathParam("topic") String topic) {
-    specification(request, responder, getContext().getNamespace(), id, topic);
-  }
-
   /**
    * Specification for the source.
    *
@@ -226,8 +190,9 @@ public final class KafkaHandler extends AbstractWranglerHandler {
    * @param id of the connection.
    * @param topic for which the specification need to be generated.
    */
-  @Path("contexts/{context}/connections/{id}/kafka/{topic}/specification")
   @GET
+  @Path("contexts/{context}/connections/{id}/kafka/{topic}/specification")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace,
                             @PathParam("id") String id, @PathParam("topic") String topic) {

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Handler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Handler.java
@@ -16,8 +16,6 @@
 
 package co.cask.wrangler.service.s3;
 
-import co.cask.cdap.api.annotation.ReadOnly;
-import co.cask.cdap.api.annotation.ReadWrite;
 import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
@@ -89,20 +87,9 @@ public class S3Handler extends AbstractWranglerHandler {
 
   private static final FileTypeDetector detector = new FileTypeDetector();
 
-  /**
-   * Tests S3 Connection.
-   *
-   * @param request HTTP Request handler.
-   * @param responder HTTP Response handler.
-   */
-  @POST
-  @Path("/connections/s3/test")
-  public void testS3Connection(HttpServiceRequest request, HttpServiceResponder responder) {
-    testS3Connection(request, responder, getContext().getNamespace());
-  }
-
   @POST
   @Path("/contexts/{context}/connections/s3/test")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void testS3Connection(HttpServiceRequest request, HttpServiceResponder responder,
                                @PathParam("context") String namespace) {
     respond(request, responder, () -> {
@@ -126,26 +113,14 @@ public class S3Handler extends AbstractWranglerHandler {
     return s3;
   }
 
-  @TransactionPolicy(value = TransactionControl.EXPLICIT)
-  @ReadOnly
-  @GET
-  @Path("/connections/{connection-id}/s3/explore")
-  public void getS3BucketInfo(HttpServiceRequest request, HttpServiceResponder responder,
-                              @PathParam("connection-id") String connectionId,
-                              @QueryParam("path") String path,
-                              @QueryParam("limit") @DefaultValue("1000") int bucketLimit) {
-    getS3BucketInfo(request, responder, getContext().getNamespace(), connectionId, path, bucketLimit);
-  }
-
   /**
    * Lists S3 bucket's contents for the given prefix path.
    * @param request HTTP Request handler.
    * @param responder HTTP Response handler.
    */
-  @TransactionPolicy(value = TransactionControl.EXPLICIT)
-  @ReadOnly
   @GET
   @Path("contexts/{context}/connections/{connection-id}/s3/explore")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void getS3BucketInfo(HttpServiceRequest request, HttpServiceResponder responder,
                               @PathParam("context") String namespace, @PathParam("connection-id") String connectionId,
                               @QueryParam("path") String path,
@@ -213,27 +188,14 @@ public class S3Handler extends AbstractWranglerHandler {
     });
   }
 
-  @POST
-  @ReadWrite
-  @Path("/connections/{connection-id}/s3/buckets/{bucket-name}/read")
-  public void loadObject(HttpServiceRequest request, HttpServiceResponder responder,
-                         @PathParam("connection-id") String connectionId,
-                         @PathParam("bucket-name") String bucketName,
-                         @QueryParam("key") String key, @QueryParam("lines") int lines,
-                         @QueryParam("sampler") String sampler, @QueryParam("fraction") double fraction,
-                         @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope) {
-    loadObject(request, responder, getContext().getNamespace(), connectionId, bucketName, key, lines, sampler,
-               fraction, scope);
-  }
-
   /**
    * Reads s3 object into workspace
    * @param request HTTP Request handler.
    * @param responder HTTP Response handler.
    */
   @POST
-  @ReadWrite
   @Path("contexts/{context}/connections/{connection-id}/s3/buckets/{bucket-name}/read")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void loadObject(HttpServiceRequest request, HttpServiceResponder responder,
                          @PathParam("context") String namespace, @PathParam("connection-id") String connectionId,
                          @PathParam("bucket-name") String bucketName,
@@ -271,15 +233,6 @@ public class S3Handler extends AbstractWranglerHandler {
     });
   }
 
-  @Path("/connections/{connection-id}/s3/buckets/{bucket-name}/specification")
-  @GET
-  public void specification(HttpServiceRequest request, HttpServiceResponder responder,
-                            @PathParam("connection-id") String connectionId,
-                            @PathParam("bucket-name") String bucketName, @QueryParam("key") String key,
-                            @QueryParam("wid") String workspaceId) {
-    specification(request, responder, getContext().getNamespace(), connectionId, bucketName, key, workspaceId);
-  }
-
   /**
    * Specification for the source.
    *
@@ -288,8 +241,9 @@ public class S3Handler extends AbstractWranglerHandler {
    * @param bucketName S3 object's bucket name
    * @param key S3 object's key
    */
-  @Path("contexts/{context}/connections/{connection-id}/s3/buckets/{bucket-name}/specification")
   @GET
+  @Path("contexts/{context}/connections/{connection-id}/s3/buckets/{bucket-name}/specification")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace, @PathParam("connection-id") String connectionId,
                             @PathParam("bucket-name") String bucketName, @QueryParam("key") String key,

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/spanner/SpannerHandler.java
@@ -16,6 +16,8 @@
 
 package co.cask.wrangler.service.spanner;
 
+import co.cask.cdap.api.annotation.TransactionControl;
+import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
@@ -90,17 +92,9 @@ public class SpannerHandler extends AbstractWranglerHandler {
   private static final String DEFAULT_ROW_LIMIT = "1000";
   private static final Gson GSON = new Gson();
 
-  /**
-   * Tests Spanner Connection.
-   */
-  @POST
-  @Path("/connections/spanner/test")
-  public void testSpannerConnection(HttpServiceRequest request, HttpServiceResponder responder) {
-    testSpannerConnection(request, responder, getContext().getNamespace());
-  }
-
   @POST
   @Path("/contexts/{context}/connections/spanner/test")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void testSpannerConnection(HttpServiceRequest request, HttpServiceResponder responder,
                                     @PathParam("context") String namespace) {
     respond(request, responder, () -> {
@@ -113,19 +107,12 @@ public class SpannerHandler extends AbstractWranglerHandler {
     });
   }
 
-
-  @GET
-  @Path("/connections/{connection-id}/spanner/instances")
-  public void getSpannerInstances(HttpServiceRequest request, HttpServiceResponder responder,
-                                  @PathParam("connection-id") String connectionId) {
-    getSpannerInstances(request, responder, getContext().getNamespace(), connectionId);
-  }
-
   /**
    * Lists spanner instances in the project
    */
   @GET
   @Path("contexts/{context}/connections/{connection-id}/spanner/instances")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void getSpannerInstances(HttpServiceRequest request, HttpServiceResponder responder,
                                   @PathParam("context") String namespace,
                                   @PathParam("connection-id") String connectionId) {
@@ -136,19 +123,12 @@ public class SpannerHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("/connections/{connection-id}/spanner/instances/{instance-id}/databases")
-  public void getSpannerDatabases(HttpServiceRequest request, HttpServiceResponder responder,
-                                  @PathParam("connection-id") String connectionId,
-                                  @PathParam("instance-id") String instanceId) {
-    getSpannerDatabases(request, responder, getContext().getNamespace(), connectionId, instanceId);
-  }
-
   /**
    * Lists spanner databases for a spanner instance
    */
   @GET
   @Path("contexts/{context}/connections/{connection-id}/spanner/instances/{instance-id}/databases")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void getSpannerDatabases(HttpServiceRequest request, HttpServiceResponder responder,
                                   @PathParam("context") String namespace,
                                   @PathParam("connection-id") String connectionId,
@@ -160,15 +140,6 @@ public class SpannerHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("/connections/{connection-id}/spanner/instances/{instance-id}/databases/{database-id}/tables")
-  public void getSpannerTables(HttpServiceRequest request, HttpServiceResponder responder,
-                               @PathParam("connection-id") String connectionId,
-                               @PathParam("instance-id") String instanceId,
-                               @PathParam("database-id") String databaseId) {
-    getSpannerTables(request, responder, getContext().getNamespace(), connectionId, instanceId, databaseId);
-  }
-
   /**
    * Lists spanner tables for a spanner database
    *
@@ -177,6 +148,7 @@ public class SpannerHandler extends AbstractWranglerHandler {
    */
   @GET
   @Path("contexts/{context}/connections/{connection-id}/spanner/instances/{instance-id}/databases/{database-id}/tables")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void getSpannerTables(HttpServiceRequest request, HttpServiceResponder responder,
                                @PathParam("context") String namespace,
                                @PathParam("connection-id") String connectionId,
@@ -189,25 +161,13 @@ public class SpannerHandler extends AbstractWranglerHandler {
     });
   }
 
-  @GET
-  @Path("/connections/{connection-id}/spanner/instances/{instance-id}/databases/{database-id}/tables/{table-id}/read")
-  public void readTable(HttpServiceRequest request, HttpServiceResponder responder,
-                        @PathParam("connection-id") String connectionId,
-                        @PathParam("instance-id") String instanceId,
-                        @PathParam("database-id") String databaseId,
-                        @PathParam("table-id") String tableId,
-                        @QueryParam("scope") @DefaultValue(WorkspaceDataset.DEFAULT_SCOPE) String scope,
-                        @QueryParam("limit") @DefaultValue(DEFAULT_ROW_LIMIT) String limit) {
-    readTable(request, responder, getContext().getNamespace(), connectionId, instanceId, databaseId,
-              tableId, scope, limit);
-  }
-
   /**
    * Read spanner table into a workspace and return the workspace identifier
    */
   @GET
   @Path("contexts/{context}/connections/{connection-id}/spanner/instances/{instance-id}/"
     + "databases/{database-id}/tables/{table-id}/read")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void readTable(HttpServiceRequest request, HttpServiceResponder responder,
                         @PathParam("context") String namespace,
                         @PathParam("connection-id") String connectionId,
@@ -260,19 +220,13 @@ public class SpannerHandler extends AbstractWranglerHandler {
     });
   }
 
-  @Path("/spanner/workspaces/{workspace-id}/specification")
-  @GET
-  public void specification(HttpServiceRequest request, HttpServiceResponder responder,
-                            @PathParam("workspace-id") String workspaceId) {
-    specification(request, responder, getContext().getNamespace(), workspaceId);
-  }
-
   /**
    * Get the specification for the spanner source plugin.
    *
    */
-  @Path("contexts/{context}/spanner/workspaces/{workspace-id}/specification")
   @GET
+  @Path("contexts/{context}/spanner/workspaces/{workspace-id}/specification")
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void specification(HttpServiceRequest request, HttpServiceResponder responder,
                             @PathParam("context") String namespace, @PathParam("workspace-id") String workspaceId) {
     respond(request, responder, namespace, ns -> {

--- a/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/WorkspaceDataset.java
+++ b/wrangler-storage/src/main/java/co/cask/wrangler/dataset/workspace/WorkspaceDataset.java
@@ -270,7 +270,7 @@ public class WorkspaceDataset {
   }
 
   private List<Field<?>> toFields(Workspace workspace) {
-    List<Field<?>> fields = new ArrayList<>(10);
+    List<Field<?>> fields = new ArrayList<>(11);
     fields.add(Fields.stringField(NAMESPACE_COL, workspace.getNamespace().getName()));
     fields.add(Fields.longField(GENERATION_COL, workspace.getNamespace().getGeneration()));
     fields.add(Fields.stringField(ID_COL, workspace.getId()));


### PR DESCRIPTION
Removed the non namespaced endpoints now that the UI has migrated
over to the namespaced endpoints.

Also changed endpoints to use explicit transaction control to avoid
unneeded extra transactions now that the services have been migrated
to the storage SPI.

Also fixed exception handling in the directives execution endpoint
to make sure the directive error message is displayed to the user
and not some generic transaction exception message.