### PR TITLE
use the system app api instead of data-fabric

### DIFF
--- a/wrangler-storage/pom.xml
+++ b/wrangler-storage/pom.xml
@@ -33,14 +33,14 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-data-fabric</artifactId>
-      <version>${cdap.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-system-app-unit-test</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-system-app-api</artifactId>
+      <version>${cdap.version}</version>
     </dependency>
     <dependency>
       <groupId>co.cask.wrangler</groupId>


### PR DESCRIPTION
Now that the SPI classes are in their own module, the dependency
should be on the system app api, not on data fabric.