### PR TITLE
[CDAP-15069] Fix reading of workspace properties

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/directive/DirectivesHandler.java
@@ -345,7 +345,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
         req = (JsonObject) GSON.toJsonTree(workspaceReq);
       }
       Map<String, String> properties = workspace.getProperties();
-      JsonObject prop = workspaceReq == null ? new JsonObject() : (JsonObject) GSON.toJsonTree(properties);
+      JsonObject prop = (JsonObject) GSON.toJsonTree(properties);
 
       prop.addProperty("name", name);
       prop.addProperty("id", name);


### PR DESCRIPTION
Fix bug introduced during migration of the workspace dataset to new storage SPI:
- properties are always present and must be deserialized regardless of whether there is a request 