### PR TITLE
Added a way to determine if a connection is a built-in connection or …

### DIFF
--- a/wrangler-proto/src/main/java/co/cask/wrangler/proto/connection/Connection.java
+++ b/wrangler-proto/src/main/java/co/cask/wrangler/proto/connection/Connection.java
@@ -37,14 +37,23 @@ public final class Connection extends ConnectionMeta {
   // Time in second - when it was last updated.
   private final long updated;
 
+  // Determines if the connection is configured automatically
+  private final boolean preconfigured;
+
   public Connection(NamespacedId id, ConnectionType type, String name, String description, long created, long updated,
                     Map<String, String> properties) {
+    this(id, type, name, description, created, updated, properties, false);
+  }
+
+  public Connection(NamespacedId id, ConnectionType type, String name, String description, long created, long updated,
+                    Map<String, String> properties, boolean preconfigured) {
     super(type, name, description, properties);
     this.namespacedId = id;
     this.context = id.getNamespace().getName();
     this.id = id.getId();
     this.created = created;
     this.updated = updated;
+    this.preconfigured = preconfigured;
   }
 
   public String getNamespace() {
@@ -72,6 +81,10 @@ public final class Connection extends ConnectionMeta {
     return updated;
   }
 
+  public boolean isPreconfigured() {
+    return preconfigured;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -86,12 +99,13 @@ public final class Connection extends ConnectionMeta {
     Connection that = (Connection) o;
     return created == that.created &&
       updated == that.updated &&
+      preconfigured == that.preconfigured &&
       Objects.equals(id, that.id);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), id, created, updated);
+    return Objects.hash(super.hashCode(), id, created, updated, preconfigured);
   }
 
   /**
@@ -107,6 +121,7 @@ public final class Connection extends ConnectionMeta {
       ", created=" + created +
       ", updated=" + updated +
       ", properties=" + properties +
+      ", preconfigured=" + preconfigured +
       '}';
   }
 
@@ -129,6 +144,7 @@ public final class Connection extends ConnectionMeta {
     private final NamespacedId id;
     private long created = -1L;
     private long updated = -1L;
+    private boolean preconfigured = false;
 
     public Builder(NamespacedId id) {
       this.id = id;
@@ -144,6 +160,11 @@ public final class Connection extends ConnectionMeta {
       return this;
     }
 
+    public Builder setPreconfigured(boolean preconfigured) {
+      this.preconfigured = preconfigured;
+      return this;
+    }
+
     public Connection build() {
       if (created < 0) {
         throw new IllegalStateException("Created time must be above 0.");
@@ -151,7 +172,7 @@ public final class Connection extends ConnectionMeta {
       if (updated < 0) {
         throw new IllegalStateException("Updated time must be above 0.");
       }
-      return new Connection(id, type, name, description, created, updated, properties);
+      return new Connection(id, type, name, description, created, updated, properties, preconfigured);
     }
   }
 }

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionHandler.java
@@ -129,7 +129,7 @@ public class ConnectionHandler extends AbstractWranglerHandler {
         TransactionRunners.run(getContext(), context -> {
           ConnectionStore store = ConnectionStore.get(context);
           if (!store.connectionExists(namespace, defaultConnection.getName())) {
-            store.create(namespace, defaultConnection);
+            store.create(namespace, defaultConnection, true);
           }
         });
       } catch (Exception e) {

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionTypeConfig.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/connections/ConnectionTypeConfig.java
@@ -17,7 +17,6 @@
 package co.cask.wrangler.service.connections;
 
 import co.cask.cdap.api.Config;
-import co.cask.wrangler.proto.NamespacedId;
 import co.cask.wrangler.proto.connection.Connection;
 import co.cask.wrangler.proto.connection.ConnectionType;
 

--- a/wrangler-storage/src/test/java/co/cask/wrangler/dataset/ConnectionStoreTest.java
+++ b/wrangler-storage/src/test/java/co/cask/wrangler/dataset/ConnectionStoreTest.java
@@ -220,6 +220,36 @@ public class ConnectionStoreTest extends SystemAppTestBase {
     Assert.assertTrue(run(connectionStore -> connectionStore.list(nsGen2, x -> true)).isEmpty());
   }
 
+  @Test
+  public void testPreconfiguredConnections() {
+    Namespace nsGen1 = new Namespace("ns1", 1L);
+
+    ConnectionMeta preconfiguredMeta = ConnectionMeta.builder()
+      .setName("Built-in connection")
+      .setType(ConnectionType.FILE)
+      .putProperty("k1", "v1")
+      .build();
+    ConnectionMeta manuallyCreatedMeta = ConnectionMeta.builder()
+      .setName("Manually created connection")
+      .setType(ConnectionType.FILE)
+      .putProperty("k1", "v1")
+      .build();
+
+    NamespacedId preconfigured = run(connectionStore -> connectionStore.create(nsGen1, preconfiguredMeta, true));
+    NamespacedId manuallyCreated = run(connectionStore -> connectionStore.create(nsGen1, manuallyCreatedMeta));
+
+    Connection preconfiguredConnection =
+      run(connectionStore -> connectionStore.get(new NamespacedId(nsGen1, preconfigured.getId())));
+    Connection manuallyCreatedConnection =
+      run(connectionStore -> connectionStore.get(new NamespacedId(nsGen1, manuallyCreated.getId())));
+
+    // test that built-in connection returns that it is built-in
+    Assert.assertTrue(preconfiguredConnection.isPreconfigured());
+
+    // test that a manually created connection returns that it is not built-in
+    Assert.assertFalse(manuallyCreatedConnection.isPreconfigured());
+  }
+
   private void assertConnectionMetaEquality(ConnectionMeta expected, Connection actual) {
     // can't just compare objects since the store sets created, id, and updated fields
     Assert.assertEquals(expected.getName(), actual.getName());


### PR DESCRIPTION
…is manually added

JIRA: https://issues.cask.co/browse/CDAP-14385

UI needs to disable the popover (edit, duplicate, delete) for default connections that are preconfigured by the system. This PR is to add a boolean indicator on the connections response to indicate whether the connection is a default system connection or not.
