### PR TITLE
[CDAP-14571] Support for macros in dataprep

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/bigquery/BigQueryHandler.java
@@ -148,7 +148,7 @@ public class BigQueryHandler extends AbstractWranglerHandler {
   /**
    * List all tables in a dataset.
    *
-   * @param request HTTP requets handler.
+   * @param request HTTP requests handler.
    * @param responder HTTP response handler.
    * @param datasetStr the dataset id as a string. It will be of the form [project:]name.
    *   The project prefix is optional. When not given, the connection project should be used.
@@ -190,7 +190,7 @@ public class BigQueryHandler extends AbstractWranglerHandler {
   /**
    * Read a table.
    *
-   * @param request HTTP requets handler.
+   * @param request HTTP requests handler.
    * @param responder HTTP response handler.
    * @param connectionId Connection Id for BigQuery Service.
    * @param datasetStr id of the dataset on BigQuery.

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaHandler.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/kafka/KafkaHandler.java
@@ -87,7 +87,7 @@ public final class KafkaHandler extends AbstractWranglerHandler {
   /**
    * List all kafka topics.
    *
-   * @param request HTTP requets handler.
+   * @param request HTTP requests handler.
    * @param responder HTTP response handler.
    */
   @POST
@@ -113,7 +113,7 @@ public final class KafkaHandler extends AbstractWranglerHandler {
   /**
    * Reads a kafka topic into workspace.
    *
-   * @param request HTTP requets handler.
+   * @param request HTTP requests handler.
    * @param responder HTTP response handler.
    * @param id Connection id for which the tables need to be listed from database.
    */

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/macro/ServiceMacroEvaluator.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/macro/ServiceMacroEvaluator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.wrangler.service.macro;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.macro.InvalidMacroException;
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.service.http.SystemHttpServiceContext;
+
+import java.util.Map;
+
+/**
+ * Dataprep Service macro evaluator.
+ */
+public class ServiceMacroEvaluator implements MacroEvaluator {
+  private static final String SECURE_FUNCTION = "secure";
+  private final String namespace;
+  private final SystemHttpServiceContext context;
+  private final Map<String, String> arguments;
+
+  public ServiceMacroEvaluator(String namespace, SystemHttpServiceContext context) {
+    this.namespace = namespace;
+    this.context = context;
+    this.arguments = context.getRuntimeArguments();
+  }
+
+  @Override
+  public String lookup(String property) throws InvalidMacroException {
+    String val = arguments.get(property);
+    if (val == null) {
+      throw new InvalidMacroException(String.format("Argument '%s' is not defined.", property));
+    }
+    return val;
+  }
+
+  @Override
+  public String evaluate(String macroFunction, String... arguments) throws InvalidMacroException {
+    if (!SECURE_FUNCTION.equals(macroFunction)) {
+      throw new InvalidMacroException(String.format("%s is not a supported macro function.", macroFunction));
+    }
+    if (arguments.length != 1) {
+      throw new InvalidMacroException("Secure macro function only supports 1 argument.");
+    }
+    try {
+      SecureStoreData secureStoreData = context.get(namespace, arguments[0]);
+      return Bytes.toString(secureStoreData.get());
+    } catch (Exception e) {
+      throw new InvalidMacroException("Failed to resolve macro '" + macroFunction + "(" + arguments[0] + ")'", e);
+    }
+  }
+}

--- a/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Configuration.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/s3/S3Configuration.java
@@ -16,7 +16,6 @@
 
 package co.cask.wrangler.service.s3;
 
-import co.cask.wrangler.proto.connection.ConnectionMeta;
 import com.amazonaws.auth.AWSCredentials;
 import com.google.common.collect.ImmutableList;
 
@@ -32,9 +31,7 @@ public class S3Configuration implements AWSCredentials {
   private final String accessSecretKey;
   private final String region;
 
-  S3Configuration(ConnectionMeta connection) {
-    Map<String, String> properties = connection.getProperties();
-
+  S3Configuration(Map<String, String> properties) {
     if (properties == null || properties.size() == 0) {
       throw new IllegalArgumentException("S3 properties are not defined. Check connection setting.");
     }


### PR DESCRIPTION
Changes tested on standalone. 
These changes use `SystemHttpServiceContext#evaluateMacros` api to evaluate macros for below fields:
- Database Connection
    - username
    - password
- S3 Connection
    - access key
    - access id

With macro support, Database connection and S3 connection can provide secure macros for these fields. 
