### PR TITLE
CDAP-14691 fix conflicts in workspace id

### DIFF
--- a/wrangler-service/src/main/java/io/cdap/wrangler/PropertyIds.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/PropertyIds.java
@@ -20,8 +20,6 @@ package io.cdap.wrangler;
  * This class {@link PropertyIds} is a collection of static strings.
  */
 public final class PropertyIds {
-  // Id of the workspace
-  public static final String ID = "id";
 
   // Name of the workspace
   public static final String NAME = "name";

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
@@ -198,15 +198,15 @@ public class DirectivesHandler extends AbstractWranglerHandler {
       String workspaceName = name == null || name.isEmpty() ? id : name;
 
       Map<String, String> properties = new HashMap<>();
-      properties.put(PropertyIds.ID, id);
       properties.put(PropertyIds.NAME, workspaceName);
-      WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(new NamespacedId(ns, id), workspaceName)
+      NamespacedId workspaceId = new NamespacedId(ns, id);
+      WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(workspaceName)
         .setScope(scope)
         .setProperties(properties)
         .build();
       TransactionRunners.run(getContext(), context -> {
         WorkspaceDataset ws = WorkspaceDataset.get(context);
-        ws.writeWorkspaceMeta(workspaceMeta);
+        ws.writeWorkspaceMeta(workspaceId, workspaceMeta);
       });
       return new ServiceResponse<Void>(String.format("Successfully created workspace '%s'", id));
     });
@@ -400,7 +400,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
         WorkspaceDataset ws = WorkspaceDataset.get(context);
         // adding data to the workspace.
         if (!ws.hasWorkspace(id)) {
-          ws.writeWorkspaceMeta(WorkspaceMeta.builder(id, name).build());
+          ws.writeWorkspaceMeta(id, WorkspaceMeta.builder(name).build());
         }
 
         RequestExtractor handler = new RequestExtractor(request);
@@ -455,7 +455,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
 
         // Write properties for workspace.
         Map<String, String> properties = new HashMap<>();
-        properties.put(PropertyIds.ID, id.getId());
         properties.put(PropertyIds.NAME, name);
         properties.put(PropertyIds.DELIMITER, delimiter);
         properties.put(PropertyIds.CHARSET, charset);

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/Workspace.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/Workspace.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
  * Contains all information about a workspace.
  */
 public class Workspace extends WorkspaceMeta {
+  private final NamespacedId id;
   private final long created;
   private final long updated;
   private final byte[] data;
@@ -35,11 +36,16 @@ public class Workspace extends WorkspaceMeta {
 
   private Workspace(NamespacedId id, String name, String scope, DataType type, Map<String, String> properties,
                     long created, long updated, @Nullable byte[] data, @Nullable Request request) {
-    super(id, name, scope, type, properties);
+    super(name, scope, type, properties);
+    this.id = id;
     this.created = created;
     this.updated = updated;
     this.data = data == null ? null : Arrays.copyOf(data, data.length);
     this.request = request;
+  }
+
+  public NamespacedId getNamespacedId() {
+    return id;
   }
 
   public long getCreated() {
@@ -74,13 +80,14 @@ public class Workspace extends WorkspaceMeta {
     Workspace workspace = (Workspace) o;
     return created == workspace.created &&
       updated == workspace.updated &&
+      Objects.equals(id, workspace.id) &&
       Arrays.equals(data, workspace.data) &&
       Objects.equals(request, workspace.request);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(super.hashCode(), created, updated, request);
+    int result = Objects.hash(super.hashCode(), id, created, updated, request);
     result = 31 * result + Arrays.hashCode(data);
     return result;
   }
@@ -90,7 +97,7 @@ public class Workspace extends WorkspaceMeta {
   }
 
   public static Builder builder(Workspace existing) {
-    return new Builder(existing, existing.getName())
+    return new Builder(existing.getNamespacedId(), existing.getName())
       .setType(existing.getType())
       .setScope(existing.getScope())
       .setCreated(existing.getCreated())
@@ -104,13 +111,15 @@ public class Workspace extends WorkspaceMeta {
    * Creates Workspace objects.
    */
   public static class Builder extends WorkspaceMeta.Builder<Builder> {
+    private final NamespacedId id;
     private long created;
     private long updated;
     private byte[] data;
     private Request request;
 
     Builder(NamespacedId id, String name) {
-      super(id, name);
+      super(name);
+      this.id = id;
     }
 
     public Builder setCreated(long created) {

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/WorkspaceMeta.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/WorkspaceMeta.java
@@ -16,8 +16,6 @@
 
 package io.cdap.wrangler.dataset.workspace;
 
-import io.cdap.wrangler.proto.NamespacedId;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,14 +24,13 @@ import java.util.Objects;
 /**
  * Metadata about a workspace.
  */
-public class WorkspaceMeta extends NamespacedId {
+public class WorkspaceMeta {
   private final String name;
   private final String scope;
   private final DataType type;
   private final Map<String, String> properties;
 
-  protected WorkspaceMeta(NamespacedId id, String name, String scope, DataType type, Map<String, String> properties) {
-    super(id);
+  protected WorkspaceMeta(String name, String scope, DataType type, Map<String, String> properties) {
     this.name = name;
     this.scope = scope;
     this.type = type;
@@ -64,22 +61,20 @@ public class WorkspaceMeta extends NamespacedId {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    if (!super.equals(o)) {
-      return false;
-    }
     WorkspaceMeta that = (WorkspaceMeta) o;
-    return Objects.equals(scope, that.scope) &&
+    return Objects.equals(name, that.name) &&
+      Objects.equals(scope, that.scope) &&
       type == that.type &&
       Objects.equals(properties, that.properties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), scope, type, properties);
+    return Objects.hash(name, scope, type, properties);
   }
 
-  public static Builder builder(NamespacedId id, String name) {
-    return new Builder(id, name);
+  public static Builder builder(String name) {
+    return new Builder(name);
   }
 
   /**
@@ -89,14 +84,12 @@ public class WorkspaceMeta extends NamespacedId {
    */
   @SuppressWarnings("unchecked")
   public static class Builder<T extends Builder> {
-    protected final NamespacedId id;
     protected final String name;
     protected String scope;
     protected DataType type;
     protected Map<String, String> properties;
 
-    Builder(NamespacedId id, String name) {
-      this.id = id;
+    Builder(String name) {
       this.name = name;
       this.properties = new HashMap<>();
       this.scope = WorkspaceDataset.DEFAULT_SCOPE;
@@ -120,7 +113,7 @@ public class WorkspaceMeta extends NamespacedId {
     }
 
     public WorkspaceMeta build() {
-      return new WorkspaceMeta(id, name, scope, type, properties);
+      return new WorkspaceMeta(name, scope, type, properties);
     }
   }
 }


### PR DESCRIPTION
Changed workspace creation such that each new workspace is given
an actual unique identifier instead of hashing some non-unique
attribute of the connection.

This fixes bugs where a workspace for a table in one database
could clobber the workspace for a table from a different database
that has the same name, and similar conflict problems with all
of the other connection types.

A side effect of this is that there can now be more than one
workspace for the same data object being wrangled. For example,
a database table can now have more than one namespace. This was
already the case for files, but not for other connection types.