### PR TITLE
CDAP-15352 fix installed drivers list endpoint

### DIFF
--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/database/DatabaseHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/database/DatabaseHandler.java
@@ -21,9 +21,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Multimap;
 import com.google.common.io.Closeables;
 import io.cdap.cdap.api.annotation.TransactionControl;
 import io.cdap.cdap.api.annotation.TransactionPolicy;
@@ -79,7 +77,6 @@ import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -143,36 +140,38 @@ public class DatabaseHandler extends AbstractWranglerHandler {
 
   static final class DriverInfo {
     private final String jdbcUrlPattern;
+    private final String className;
     private final String name;
     private final String tag;
     private final String port;
     private final boolean basicAllowed;
 
-    DriverInfo(String name, String jdbcUrlPattern, String tag, String port, boolean basicAllowed) {
+    DriverInfo(String name, String className, String jdbcUrlPattern, String tag, String port, boolean basicAllowed) {
       this.name = name;
+      this.className = className;
       this.jdbcUrlPattern = jdbcUrlPattern;
       this.tag = tag;
       this.port = port;
       this.basicAllowed = basicAllowed;
     }
 
-    public String getJdbcUrlPattern() {
+    String getJdbcUrlPattern() {
       return jdbcUrlPattern;
     }
 
-    public String getName() {
+    String getName() {
       return name;
     }
 
-    public String getTag() {
+    String getTag() {
       return tag;
     }
 
-    public String getPort() {
+    String getPort() {
       return port;
     }
 
-    public boolean isBasicAllowed() {
+    boolean isBasicAllowed() {
       return basicAllowed;
     }
 
@@ -185,7 +184,7 @@ public class DatabaseHandler extends AbstractWranglerHandler {
     void execute(java.sql.Connection connection) throws Exception;
   }
 
-  private final Multimap<String, DriverInfo> drivers = ArrayListMultimap.create();
+  private final Map<String, DriverInfo> drivers = new HashMap<>();
 
   @Override
   public void initialize(SystemHttpServiceContext context) throws Exception {
@@ -201,15 +200,22 @@ public class DatabaseHandler extends AbstractWranglerHandler {
   }
 
   @VisibleForTesting
-  static void loadDrivers(InputStream is, Multimap<String, DriverInfo> drivers) throws IOException {
+  static void loadDrivers(InputStream is, Map<String, DriverInfo> drivers) throws IOException {
     try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
       String line;
       while ((line = br.readLine()) != null) {
         String[] columns = line.split(",");
         if (columns.length == 6) {
-          DriverInfo info = new DriverInfo(columns[0], columns[2], columns[3], columns[4],
+          DriverInfo info = new DriverInfo(columns[0], columns[1], columns[2], columns[3], columns[4],
                                            Boolean.parseBoolean(columns[5]));
-          drivers.put(columns[1].trim(), info);
+          if (drivers.containsKey(info.tag)) {
+            // this only happens if the drivers.mapping file is invalid
+            // TODO: (CDAP-15353) wrangler should not assume names are unique
+            throw new IllegalStateException(
+              "Wrangler's allowed JDBC plugins has been misconfigured. "
+                + "Please make sure the driver plugin names in the drivers.mapping file are unique.");
+          }
+          drivers.put(info.tag, info);
         }
       }
     }
@@ -264,24 +270,24 @@ public class DatabaseHandler extends AbstractWranglerHandler {
           if (!JDBC.equalsIgnoreCase(type)) {
             continue;
           }
-          String className = plugin.getClassName();
-          if (!drivers.containsKey(className)) {
+          // TODO: (CDAP-15353) Wrangler should not assume plugin names are unique
+          // if info is null, it means it's not an 'allowed' driver from the drivers.mapping file that is returned by
+          // the jdbc/allowed endpoint.
+          if (!drivers.containsKey(plugin.getName())) {
             continue;
           }
-          Collection<DriverInfo> infos = drivers.get(className);
-          for (DriverInfo info : infos) {
-            Map<String, String> properties = new HashMap<>();
-            properties.put("class", plugin.getClassName());
-            properties.put("type", plugin.getType());
-            properties.put("name", plugin.getName());
-            List<String> fields = getMacros(info.getJdbcUrlPattern());
-            fields.add("url");
+          DriverInfo info = drivers.get(plugin.getName());
+          Map<String, String> properties = new HashMap<>();
+          properties.put("class", plugin.getClassName());
+          properties.put("type", plugin.getType());
+          properties.put("name", plugin.getName());
+          List<String> fields = getMacros(info.getJdbcUrlPattern());
+          fields.add("url");
 
-            JDBCDriverInfo jdbcDriverInfo =
-              new JDBCDriverInfo(info.getName(), artifact.getVersion(), info.getJdbcUrlPattern(), info.getPort(),
-                                 fields, properties);
-            values.add(jdbcDriverInfo);
-          }
+          JDBCDriverInfo jdbcDriverInfo =
+            new JDBCDriverInfo(info.getName(), artifact.getVersion(), info.getJdbcUrlPattern(), info.getPort(),
+                               fields, properties);
+          values.add(jdbcDriverInfo);
         }
       }
       return new ServiceResponse<>(values);
@@ -317,11 +323,9 @@ public class DatabaseHandler extends AbstractWranglerHandler {
                                    @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
       List<AllowedDriverInfo> values = new ArrayList<>();
-      Collection<Map.Entry<String, DriverInfo>> entries = drivers.entries();
-      for (Map.Entry<String, DriverInfo> driver : entries) {
-        String shortTag = driver.getValue().getTag();
-        values.add(new AllowedDriverInfo(driver.getKey(), driver.getValue().getName(), shortTag, shortTag,
-                                         driver.getValue().getPort(), driver.getValue().isBasicAllowed()));
+      for (DriverInfo driver : drivers.values()) {
+        values.add(new AllowedDriverInfo(driver.className, driver.name, driver.tag, driver.tag,
+                                         driver.port, driver.basicAllowed));
       }
       return new ServiceResponse<>(values);
     });

--- a/wrangler-service/src/main/resources/drivers.mapping
+++ b/wrangler-service/src/main/resources/drivers.mapping
@@ -1,4 +1,4 @@
-Oracle Thin,oracle.jdbc.driver.OracleDriver,jdbc:oracle:thin:@${hostname}:${port}:${database},oracle,1521,true
+Oracle Thin,oracle.jdbc.driver.OracleDriver,jdbc:oracle:thin:@${hostname}:${port}:${database},oracle-thin,1521,true
 Oracle Database 12c,oracle.jdbc.OracleDriver,jdbc:oracle:thin:${username}/${password}@//${hostname}:${port}/${database},oracle,1521,true
 MySQL,com.mysql.jdbc.Driver,jdbc:mysql://${hostname}:${port}/${database},mysql,3306,true
 PostgreSQL (v6.5 and earlier),postgresql.Driver,jdbc:postgresql://${hostname}:${port}/${database},postgresql65,5432,true

--- a/wrangler-service/src/test/java/io/cdap/wrangler/service/database/DatabaseHandlerTest.java
+++ b/wrangler-service/src/test/java/io/cdap/wrangler/service/database/DatabaseHandlerTest.java
@@ -17,8 +17,6 @@
 package io.cdap.wrangler.service.database;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.cdap.wrangler.api.Row;
@@ -43,6 +41,7 @@ import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -82,12 +81,12 @@ public class DatabaseHandlerTest {
 
   @Test
   public void testReadingDriverConfiguration() throws Exception {
-    Multimap<String, DatabaseHandler.DriverInfo> drivers = ArrayListMultimap.create();
+    Map<String, DatabaseHandler.DriverInfo> drivers = new HashMap<>();
     int expectedDrivers = 12;
     try (InputStream is = DatabaseHandler.class.getClassLoader().getResourceAsStream("drivers.mapping")) {
       DatabaseHandler.loadDrivers(is, drivers);
       JsonArray values = new JsonArray();
-      Collection<Map.Entry<String, DatabaseHandler.DriverInfo>> entries = drivers.entries();
+      Collection<Map.Entry<String, DatabaseHandler.DriverInfo>> entries = drivers.entrySet();
       for (Map.Entry<String, DatabaseHandler.DriverInfo> driver : entries) {
         JsonObject object = new JsonObject();
         object.addProperty("class", driver.getKey());


### PR DESCRIPTION
The database handler was incorrectly joining hardcoded information
about the mysql and oracle jdbc drivers to the actual drivers
installed. When the generic mysql driver was installed, the drivers
endpoint would return two entries, one for the generic mysql
driver and one incorrect mix between the generic mysql driver and
the information for the google cloud mysql driver.

A similar problem existed with the oracle and oracle thin drivers.
The short term fix done here was to look up driver information by
the driver name instead of the driver class name, and to make sure
all driver names are unique (at least when going through wrangler).