### PR TITLE
Fix Json2SchemaTest

### DIFF
--- a/wrangler-core/src/test/java/io/cdap/wrangler/utils/Json2SchemaTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/utils/Json2SchemaTest.java
@@ -109,7 +109,7 @@ public class Json2SchemaTest {
                                         Schema.of(Schema.LogicalType.TIME_MICROS))),
                                       Schema.Field.of("timestamp", Schema.nullableOf(
                                         Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))),
-                                      Schema.Field.of("d", Schema.nullableOf(Schema.decimalOf(6, 5))));
+                                      Schema.Field.of("d", Schema.nullableOf(Schema.decimalOf(38, 5))));
 
     Assert.assertEquals(expected, actual);
   }


### PR DESCRIPTION
This happened because of hard coding precision to 38 in https://github.com/data-integrations/wrangler/pull/327/files#diff-19cfb712a90405c01c06564c4beedbd3R91

![image](https://user-images.githubusercontent.com/14131070/57547352-39096280-7313-11e9-8452-91712307bf3a.png)
