### PR TITLE
CDAP-15397 fix execution of user scoped UDDs

### DIFF
--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
@@ -574,6 +574,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
   public void execute(HttpServiceRequest request, HttpServiceResponder responder,
                       @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
+      composite.reload(namespace);
       try {
         RequestExtractor handler = new RequestExtractor(request);
         Request directiveRequest = handler.getContent("UTF-8", Request.class);
@@ -699,6 +700,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
                       @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
       try {
+        composite.reload(namespace);
         RequestExtractor handler = new RequestExtractor(request);
         Request directiveRequest = handler.getContent("UTF-8", Request.class);
         if (directiveRequest == null) {
@@ -780,6 +782,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
   public void schema(HttpServiceRequest request, HttpServiceResponder responder,
                      @PathParam("context") String namespace, @PathParam("id") String id) {
     respond(request, responder, namespace, ns -> {
+      composite.reload(namespace);
       RequestExtractor handler = new RequestExtractor(request);
       Request user = handler.getContent("UTF-8", Request.class);
       if (user == null) {
@@ -864,6 +867,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
   public void usage(HttpServiceRequest request, HttpServiceResponder responder,
                     @PathParam("context") String namespace) {
     respond(request, responder, namespace, ns -> {
+      // CDAP-15397 - reload must be called before it can be safely used
       composite.reload(namespace);
       DirectiveConfig config = TransactionRunners.run(getContext(), context -> {
         ConfigStore store = ConfigStore.get(context);

--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -196,7 +196,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
       } catch (CompileException e) {
         throw new IllegalArgumentException(e.getMessage(), e);
       } catch (DirectiveParseException e) {
-        throw new IllegalArgumentException(e.getMessage());
+        throw new IllegalArgumentException(e.getMessage(), e);
       }
 
       // Based on the configuration create output schema.
@@ -205,7 +205,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
           oSchema = Schema.parseJson(config.schema);
         }
       } catch (IOException e) {
-        throw new IllegalArgumentException("Format of output schema specified is invalid. Please check the format.");
+        throw new IllegalArgumentException("Format of output schema specified is invalid. Please check the format.", e);
       }
 
       // Check if configured field is present in the input schema.
@@ -224,7 +224,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
           try {
             new Precondition(config.precondition);
           } catch (PreconditionException e) {
-            throw new IllegalArgumentException(e.getMessage());
+            throw new IllegalArgumentException(e.getMessage(), e);
           }
         }
       }
@@ -236,7 +236,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
 
     } catch (Exception e) {
       LOG.error(e.getMessage());
-      throw new IllegalArgumentException(e.getMessage());
+      throw new IllegalArgumentException(e.getMessage(), e);
     }
   }
 
@@ -305,6 +305,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
       new SystemDirectiveRegistry(),
       new UserDirectiveRegistry(context)
     );
+    registry.reload(context.getNamespace());
 
     String directives = config.directives;
     if (config.udds != null && !config.udds.trim().isEmpty()) {
@@ -321,7 +322,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
     } catch (IOException e) {
       throw new IllegalArgumentException(
         String.format("Stage:%s - Format of output schema specified is invalid. Please check the format.",
-                      context.getStageName())
+                      context.getStageName()), e
       );
     }
 
@@ -330,7 +331,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
       try {
         condition = new Precondition(config.precondition);
       } catch (PreconditionException e) {
-        throw new IllegalArgumentException(e.getMessage());
+        throw new IllegalArgumentException(e.getMessage(), e);
       }
     }
 
@@ -353,7 +354,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
       // If there is a issue, we need to fail the pipeline that has the plugin.
       throw new IllegalArgumentException(
         String.format("Stage:%s - Issue in retrieving the configuration from the service. %s",
-                      getContext().getStageName(), e.getMessage())
+                      getContext().getStageName(), e.getMessage()), e
       );
     }
 
@@ -363,7 +364,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
       pipeline.initialize(recipe, ctx);
     } catch (Exception e) {
       throw new Exception(
-        String.format("Stage:%s - %s", getContext().getStageName(), e.getMessage())
+        String.format("Stage:%s - %s", getContext().getStageName(), e.getMessage()), e
       );
     }
 
@@ -447,7 +448,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
         if (e instanceof DirectiveExecutionException) {
           throw new Exception(String.format("Stage:%s - Reached error threshold %d, terminating processing " +
                                               "due to error : %s", getContext().getStageName(), config.threshold,
-                                            e.getMessage()));
+                                            e.getMessage()), e);
 
         } else {
           throw new Exception(String.format("Stage:%s - Reached error threshold %d, terminating processing " +


### PR DESCRIPTION
User directives must be reloaded before they are used, as
in-memory objects are not shared across Service requests.

Also improving wrangler errors to also include the cause when
throwing an exception.