### PR TITLE
Fix wrangler startup exception.

### DIFF
--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/adls/ADLSHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/adls/ADLSHandler.java
@@ -41,6 +41,7 @@ import io.cdap.wrangler.dataset.workspace.WorkspaceDataset;
 import io.cdap.wrangler.dataset.workspace.WorkspaceMeta;
 import io.cdap.wrangler.proto.BadRequestException;
 import io.cdap.wrangler.proto.NamespacedId;
+import io.cdap.wrangler.proto.NotFoundException;
 import io.cdap.wrangler.proto.PluginSpec;
 import io.cdap.wrangler.proto.ServiceResponse;
 import io.cdap.wrangler.proto.StatusCodeException;
@@ -70,7 +71,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -170,7 +170,7 @@ public class ADLSHandler extends AbstractWranglerHandler {
   private List<ADLSDirectoryEntryInfo> initClientReturnResponse(ADLStoreClient client, String path)
           throws IOException {
     if (!client.checkExists(path)) {
-      throw new NotFoundException("Given path doesn't exist");
+      throw new NotFoundException(String.format("Given path doesn't exist: %s", path));
     }
     List<DirectoryEntry> list = client.enumerateDirectory(path);
     ADLSDirectoryEntryInfo info;
@@ -269,13 +269,11 @@ public class ADLSHandler extends AbstractWranglerHandler {
   private InputStream clientInputStream(ADLStoreClient client, FileQueryDetails fileQueryDetails)
           throws IOException {
     DirectoryEntry file = client.getDirectoryEntry(fileQueryDetails.getFilePath());
-    InputStream inputStream = client.getReadStream(file.fullName);
-    return inputStream;
+    return client.getReadStream(file.fullName);
   }
 
   private DirectoryEntry getFileFromClient(ADLStoreClient client, String path) throws IOException {
-    DirectoryEntry file = client.getDirectoryEntry(path);
-    return file;
+    return client.getDirectoryEntry(path);
   }
 
   private ADLSConnectionSample loadSamplableFile(NamespacedId connectionId,
@@ -377,7 +375,7 @@ public class ADLSHandler extends AbstractWranglerHandler {
     });
 
     return new ADLSConnectionSample(namespacedWorkspaceId.getId(), name, ConnectionType.ADLS.getType(),
-            SamplingMethod.NONE.getMethod(), connectionId.getId());
+                                    SamplingMethod.NONE.getMethod(), connectionId.getId());
   }
 
   /**


### PR DESCRIPTION
[This change](https://github.com/data-integrations/wrangler/commit/c67f7eb021fbb81cca628de2b430289fedb5d7af#diff-99a4887d9c984f0475fac039e21fe0a0R73) introduced a reference to javax.ws.rs.NotFoundException, which is not packaged with wrangler-service artifact. It compiles because the class comes in as a transitive dependency from the cdap-api module, though this is not sufficient for deploying an application from the artifact.

This results in a ClassNotFoundException when starting up CDAP sandbox. The impact is that wrangler does not start up:
```
2019-05-29 11:46:14,977 - WARN  [bootstrap-service:i.c.c.i.b.e.BaseStepExecutor@71] - Bootstrap step Create dataprep application failed to execute
io.cdap.cdap.common.InvalidArtifactException: Missing class javax.ws.rs.NotFoundException. It may be caused by missing dependency jar(s) in the artifact jar.
        at io.cdap.cdap.internal.app.deploy.InMemoryConfigurator.createResponse(InMemoryConfigurator.java:187) ~[na:na]
        at io.cdap.cdap.internal.app.deploy.InMemoryConfigurator.config(InMemoryConfigurator.java:116) ~[na:na]
        at io.cdap.cdap.internal.app.deploy.pipeline.LocalArtifactLoaderStage.process(LocalArtifactLoaderStage.java:110) ~[na:na]
        at io.cdap.cdap.internal.app.deploy.pipeline.LocalArtifactLoaderStage.process(LocalArtifactLoaderStage.java:57) ~[na:na]
        at io.cdap.cdap.pipeline.AbstractStage.process(AbstractStage.java:53) ~[na:na]
        at io.cdap.cdap.internal.pipeline.SynchronousPipeline.execute(SynchronousPipeline.java:57) ~[na:na]
        at io.cdap.cdap.internal.app.deploy.LocalApplicationManager.deploy(LocalApplicationManager.java:132) ~[na:na]
        at io.cdap.cdap.internal.app.services.ApplicationLifecycleService.deployApp(ApplicationLifecycleService.java:668) ~[na:na]
        at io.cdap.cdap.internal.app.services.ApplicationLifecycleService.deployApp(ApplicationLifecycleService.java:471) ~[na:na]
        at io.cdap.cdap.internal.bootstrap.executor.AppCreator.execute(AppCreator.java:64) ~[na:na]
        at io.cdap.cdap.internal.bootstrap.executor.AppCreator.execute(AppCreator.java:39) ~[na:na]
        at io.cdap.cdap.internal.bootstrap.executor.BaseStepExecutor.lambda$execute$0(BaseStepExecutor.java:64) ~[na:na]
        at io.cdap.cdap.common.service.Retries.lambda$runWithInterruptibleRetries$2(Retries.java:233) ~[na:na]
        at io.cdap.cdap.common.service.Retries.callWithRetries(Retries.java:183) ~[na:na]
        at io.cdap.cdap.common.service.Retries.callWithInterruptibleRetries(Retries.java:257) ~[na:na]
        at io.cdap.cdap.common.service.Retries.runWithInterruptibleRetries(Retries.java:232) ~[na:na]
        at io.cdap.cdap.internal.bootstrap.executor.BaseStepExecutor.execute(BaseStepExecutor.java:64) ~[na:na]
        at io.cdap.cdap.internal.bootstrap.BootstrapService.executeStep(BootstrapService.java:163) [na:na]
        at io.cdap.cdap.internal.bootstrap.BootstrapService.bootstrap(BootstrapService.java:132) [na:na]
        at io.cdap.cdap.internal.bootstrap.BootstrapService.bootstrap(BootstrapService.java:113) [na:na]
        at io.cdap.cdap.internal.bootstrap.BootstrapService.lambda$startUp$1(BootstrapService.java:80) [na:na]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_202]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_202]
        at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_202]
Caused by: java.lang.NoClassDefFoundError: javax/ws/rs/NotFoundException
        at io.cdap.wrangler.service.DataPrepService.configure(DataPrepService.java:65) ~[na:na]
        at io.cdap.cdap.api.service.AbstractService.configure(AbstractService.java:39) ~[na:na]
        at io.cdap.cdap.app.DefaultAppConfigurer.addService(DefaultAppConfigurer.java:196) ~[na:na]
        at io.cdap.cdap.api.app.AbstractApplication.addService(AbstractApplication.java:125) ~[na:na]
        at io.cdap.wrangler.DataPrep.configure(DataPrep.java:48) ~[na:na]
        at io.cdap.cdap.api.app.AbstractApplication.configure(AbstractApplication.java:59) ~[na:na]
        at io.cdap.cdap.internal.app.deploy.InMemoryConfigurator.createResponse(InMemoryConfigurator.java:155) ~[na:na]
        ... 23 common frames omitted
Caused by: java.lang.ClassNotFoundException: javax.ws.rs.NotFoundException
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382) ~[na:1.8.0_202]
        at io.cdap.cdap.common.lang.InterceptableClassLoader.findClass(InterceptableClassLoader.java:44) ~[na:na]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[na:1.8.0_202]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[na:1.8.0_202]
        ... 30 common frames omitted
```

We should use Wrangler's NotFoundException, as it will then map the exception to a 404 response status accordingly. This also resolves the ClassNotFoundException.