### PR TITLE
CDAP-15396 remove unhelpful message about aliasing

### DIFF
--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -345,9 +345,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
         ConfigDirectiveContext dContext = new ConfigDirectiveContext(url);
         recipe.initialize(dContext);
       } else {
-        // this is normal in cloud environments
-        LOG.info(String.format("Stage:%s - The Dataprep service is not accessible in this environment. "
-                                 + "No aliasing and restriction will be applied.", getContext().getStageName()));
+        // this is normal in cloud environments and almost nothing uses directive aliasing/restrictions
         recipe.initialize(null);
       }
     } catch (IOException | URISyntaxException e) {


### PR DESCRIPTION
Removed an info message when the wrangler service is not
discoverable. Aliasing is not exposed in the UI so basically
nobody uses it.