### PR TITLE
Implementation of error record forwarding to the front end

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/ErrorRecord.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/ErrorRecord.java
@@ -17,25 +17,24 @@
 package io.cdap.wrangler.api;
 
 import io.cdap.wrangler.api.annotations.Public;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Specifies the structure for Error records.
  */
 @Public
-public final class ErrorRecord {
+public final class ErrorRecord extends ErrorRecordBase {
   // Actual row that is errored.
   private final Row row;
 
-  // Message as to why the row errored.
-  private final String message;
-
-  // Code associated with the message.
-  private final int code;
+  public ErrorRecord(Row row, String message, int code, boolean showInWrangler) {
+    super(message, code, showInWrangler);
+    this.row = row;
+  }
 
   public ErrorRecord(Row row, String message, int code) {
-    this.row = row;
-    this.message = message;
-    this.code = code;
+    this(row, message, code, false);
   }
 
   /**
@@ -45,17 +44,4 @@ public final class ErrorRecord {
     return row;
   }
 
-  /**
-   * @return Message associated with the {@link Row}.
-   */
-  public String getMessage() {
-    return message;
-  }
-
-  /**
-   * @return Code associated with the error.
-   */
-  public int getCode() {
-    return code;
-  }
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/ErrorRecordBase.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/ErrorRecordBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,40 +16,34 @@
 
 package io.cdap.wrangler.api;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
- * Exception throw when the record needs to emitted to error collector.
+ * Base class for error record that includes the critical fields.
  */
-public class ErrorRowException extends Exception {
-  // Message as to why the record errored.
-  private String message;
+public class ErrorRecordBase {
 
-  // Code associated with the error message.
-  private int code;
+  // Message as to why the row errored.
+  protected final String message;
+  // Code associated with the message.
+  protected final int code;
+  protected final boolean showInWrangler;
 
-  private boolean showInWrangler;
-
-  public ErrorRowException(String message, int code, boolean showInWrangler) {
+  public ErrorRecordBase(String message, int code, boolean showInWrangler) {
     this.message = message;
     this.code = code;
     this.showInWrangler = showInWrangler;
   }
 
-  public ErrorRowException(String message, int code) {
-    this(message, code, false);
-  }
-
   /**
-   * @return Message as why the record errored.
+   * @return Message associated with the {@link Row}.
    */
   public String getMessage() {
     return message;
   }
 
   /**
-   * @return code related to the message.
+   * @return Code associated with the error.
    */
   public int getCode() {
     return code;

--- a/wrangler-core/src/main/java/io/cdap/wrangler/executor/RecipePipelineExecutor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/executor/RecipePipelineExecutor.java
@@ -42,10 +42,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The class <code>RecipePipelineExecutor</code> compiles the recipe and executes
- * the directives.
+ * The class <code>RecipePipelineExecutor</code> compiles the recipe and executes the directives.
  */
 public final class RecipePipelineExecutor implements RecipePipeline<Row, StructuredRecord, ErrorRecord> {
+
   private static final Logger LOG = LoggerFactory.getLogger(RecipePipelineExecutor.class);
   private ExecutorContext context;
   private List<Executor> directives;
@@ -53,8 +53,7 @@ public final class RecipePipelineExecutor implements RecipePipeline<Row, Structu
   private RecordConvertor convertor = new RecordConvertor();
 
   /**
-   * Configures the pipeline based on the directives. It parses the recipe,
-   * converting it into executable directives.
+   * Configures the pipeline based on the directives. It parses the recipe, converting it into executable directives.
    *
    * @param parser Wrangle directives parser.
    */
@@ -71,8 +70,7 @@ public final class RecipePipelineExecutor implements RecipePipeline<Row, Structu
   }
 
   /**
-   * Invokes each directives destroy method to perform any cleanup
-   * required by each individual directive.
+   * Invokes each directives destroy method to perform any cleanup required by each individual directive.
    */
   @Override
   public void destroy() {
@@ -100,7 +98,8 @@ public final class RecipePipelineExecutor implements RecipePipeline<Row, Structu
       List<StructuredRecord> output = convertor.toStructureRecord(rows, schema);
       return output;
     } catch (RecordConvertorException e) {
-      throw new RecipeException("Problem converting into output record. Reason : " + e.getMessage());
+      throw new RecipeException(
+          "Problem converting into output record. Reason : " + e.getMessage());
     }
   }
 
@@ -140,7 +139,9 @@ public final class RecipePipelineExecutor implements RecipePipeline<Row, Structu
           }
         } catch (ErrorRowException e) {
           messages.add(String.format("%s", e.getMessage()));
-          collector.add(new ErrorRecord(newRows.get(0), String.join(",", messages), e.getCode()));
+          collector
+            .add(new ErrorRecord(newRows.get(0), String.join(",", messages), e.getCode(),
+              e.isShownInWrangler()));
         }
         i++;
       }

--- a/wrangler-core/src/test/java/io/cdap/wrangler/registry/CompositeDirectiveRegistryTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/registry/CompositeDirectiveRegistryTest.java
@@ -98,6 +98,7 @@ public class CompositeDirectiveRegistryTest {
       // no-op
     }
   }
+
   @Test
   public void testIteratorUsage() throws Exception {
     DirectiveRegistry registry = new CompositeDirectiveRegistry(

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/ErrorRecordsException.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/ErrorRecordsException.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.proto;
+
+import io.cdap.wrangler.api.ErrorRecordBase;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * An exception that contains error records.
+ */
+public class ErrorRecordsException extends RuntimeException {
+  static final int MAX_NUM_ERRORS_IN_SUMMARY = 10;
+  static final String ERROR_SUMMARY_ITEM_DELIM = "\n";
+
+  private final List<ErrorRecordBase> errorRecords;
+
+  public ErrorRecordsException(List<ErrorRecordBase> errorRecords) {
+    super(summarize(errorRecords));
+    this.errorRecords = errorRecords;
+  }
+
+  public List<ErrorRecordBase> getErrorRecords() {
+    return errorRecords;
+  }
+
+  static String summarize(List<ErrorRecordBase> errorRecords) {
+    List<String> lines = errorRecords
+      .stream()
+      // Group similar conformance issues by hashing them.
+      .collect(Collectors.groupingBy(ErrorRecordBase::getMessage))
+      .entrySet()
+      .stream()
+      // Most common issues come first.
+      .sorted(Comparator.comparingInt(a -> -a.getValue().size()))
+      // Create one string per unique error.
+      .map(entry -> String.format("%s - %d rows", entry.getKey(), entry.getValue().size()))
+      .collect(Collectors.toList());
+
+    if (lines.size() > MAX_NUM_ERRORS_IN_SUMMARY) {
+      lines = lines.subList(0, MAX_NUM_ERRORS_IN_SUMMARY - 1);
+      lines.add("... and other errors hidden for brevity");
+    }
+
+    return String.join(ERROR_SUMMARY_ITEM_DELIM, lines);
+  }
+}

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/ServiceResponse.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/ServiceResponse.java
@@ -47,7 +47,11 @@ public class ServiceResponse<T> {
   }
 
   public ServiceResponse(Collection<T> values, boolean truncated) {
-    this.message = "Success";
+    this(values, truncated, "Success");
+  }
+
+  public ServiceResponse(Collection<T> values, boolean truncated, String message) {
+    this.message = message;
     this.count = values.size();
     this.values = values;
     this.truncated = Boolean.toString(truncated);

--- a/wrangler-proto/src/test/java/io/cdap/wrangler/proto/ErrorRecordsExceptionTest.java
+++ b/wrangler-proto/src/test/java/io/cdap/wrangler/proto/ErrorRecordsExceptionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.proto;
+
+import io.cdap.wrangler.api.ErrorRecordBase;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ErrorRecordsExceptionTest {
+
+  @Test
+  public void summarizeLimitsLargeLists() {
+    List<ErrorRecordBase> errs = IntStream.range(0, 100)
+        .boxed()
+        .map(i -> new ErrorRecordBase(String.format("error # %d", i), i, true))
+        .collect(Collectors.toList());
+
+    String result = ErrorRecordsException.summarize(errs);
+
+    Assert.assertEquals("wrong number of summary entries",
+        ErrorRecordsException.MAX_NUM_ERRORS_IN_SUMMARY,
+        result.split(ErrorRecordsException.ERROR_SUMMARY_ITEM_DELIM).length);
+    Assert.assertTrue(String.format("result had wrong ending: %s", result),
+        result.endsWith("for brevity"));
+  }
+
+  @Test
+  public void summarizeLeavesMaxSizedLists() {
+    List<ErrorRecordBase> errs = IntStream
+        .range(1, ErrorRecordsException.MAX_NUM_ERRORS_IN_SUMMARY + 1)
+        .boxed()
+        .map(i -> new ErrorRecordBase(String.format("error # %d", i), i, true))
+        .collect(Collectors.toList());
+
+    String result = ErrorRecordsException.summarize(errs);
+
+    Assert.assertEquals("wrong number of summary entries",
+        ErrorRecordsException.MAX_NUM_ERRORS_IN_SUMMARY,
+        result.split(ErrorRecordsException.ERROR_SUMMARY_ITEM_DELIM).length);
+  }
+
+  @Test
+  public void summarizeCollapsesRepeatedErrors() {
+    List<ErrorRecordBase> errs = IntStream.range(1, 102)
+        .boxed()
+        .map(i -> new ErrorRecordBase(String.format("error %s", i % 2 == 0 ? "foo" : "bar"), i,
+            true))
+        .collect(Collectors.toList());
+
+    String[] results = ErrorRecordsException.summarize(errs)
+        .split(ErrorRecordsException.ERROR_SUMMARY_ITEM_DELIM);
+
+    Assert.assertArrayEquals(new String[]{"error bar - 51 rows", "error foo - 50 rows"}, results);
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/common/AbstractWranglerHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/common/AbstractWranglerHandler.java
@@ -29,6 +29,7 @@ import io.cdap.wrangler.dataset.workspace.WorkspaceDataset;
 import io.cdap.wrangler.dataset.workspace.WorkspaceNotFoundException;
 import io.cdap.wrangler.proto.BadRequestException;
 import io.cdap.wrangler.proto.Contexts;
+import io.cdap.wrangler.proto.ErrorRecordsException;
 import io.cdap.wrangler.proto.Namespace;
 import io.cdap.wrangler.proto.NamespacedId;
 import io.cdap.wrangler.proto.Recipe;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
@@ -147,6 +149,9 @@ public class AbstractWranglerHandler extends AbstractSystemHttpServiceHandler {
       responder.sendJson(results);
     } catch (StatusCodeException e) {
       responder.sendJson(e.getCode(), new ServiceResponse<>(e.getMessage()));
+    } catch (ErrorRecordsException e) {
+      responder.sendJson(HttpURLConnection.HTTP_BAD_REQUEST,
+        new ServiceResponse<>(e.getErrorRecords(), false, e.getMessage()));
     } catch (JsonSyntaxException e) {
       responder.sendJson(HttpURLConnection.HTTP_BAD_REQUEST, new ServiceResponse<Void>(e.getMessage()));
     } catch (Throwable t) {
@@ -196,6 +201,9 @@ public class AbstractWranglerHandler extends AbstractSystemHttpServiceHandler {
       responder.sendJson(results);
     } catch (StatusCodeException e) {
       responder.sendJson(e.getCode(), new ServiceResponse<>(e.getMessage()));
+    } catch (ErrorRecordsException e) {
+      responder.sendJson(HttpURLConnection.HTTP_BAD_REQUEST,
+          new ServiceResponse<>(e.getErrorRecords(), false, e.getMessage()));
     } catch (JsonSyntaxException e) {
       responder.sendJson(HttpURLConnection.HTTP_BAD_REQUEST, new ServiceResponse<Void>(e.getMessage()));
     } catch (Throwable t) {

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
@@ -45,6 +45,8 @@ import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveConfig;
 import io.cdap.wrangler.api.DirectiveLoadException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ErrorRecord;
+import io.cdap.wrangler.api.ErrorRecordBase;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.GrammarMigrator;
 import io.cdap.wrangler.api.Pair;
@@ -67,6 +69,7 @@ import io.cdap.wrangler.parser.GrammarBasedParser;
 import io.cdap.wrangler.parser.MigrateToV2;
 import io.cdap.wrangler.parser.RecipeCompiler;
 import io.cdap.wrangler.proto.BadRequestException;
+import io.cdap.wrangler.proto.ErrorRecordsException;
 import io.cdap.wrangler.proto.NamespacedId;
 import io.cdap.wrangler.proto.Request;
 import io.cdap.wrangler.proto.ServiceResponse;
@@ -94,6 +97,7 @@ import io.cdap.wrangler.utils.ObjectSerDe;
 import io.cdap.wrangler.validator.ColumnNameValidator;
 import io.cdap.wrangler.validator.Validator;
 import io.cdap.wrangler.validator.ValidatorException;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -117,6 +121,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -1123,6 +1128,15 @@ public class DirectivesHandler extends AbstractWranglerHandler {
         } catch (RecipeException e) {
           throw new BadRequestException(e.getMessage(), e);
         }
+
+        List<ErrorRecordBase> errors = executor.errors()
+          .stream()
+          .filter(ErrorRecordBase::isShownInWrangler)
+          .collect(Collectors.toList());
+        if (errors.size() > 0) {
+          throw new ErrorRecordsException(errors);
+        }
+
         executor.destroy();
       }
       return rows;


### PR DESCRIPTION
This patch adds error record forwarding via a Bad Request result code to the frontend of wrangler.

Previously, error records produced by directives would simply cause rows to be filtered out from the wrangle view. Although this behaviour is preserved by default, directives can now pass a flag to the error row to have that data be sent to the frontend. This can be extended with more detailed error information in the future.