### PR TITLE
Improve error handling in wrangler

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/DirectiveExecutionException.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/DirectiveExecutionException.java
@@ -35,5 +35,13 @@ public class DirectiveExecutionException extends Exception {
   public DirectiveExecutionException(Throwable e) {
     super(e);
   }
+
+  public DirectiveExecutionException(String directiveName, String errorMessage) {
+    this(String.format("Error encountered while executing '%s' : %s", directiveName, errorMessage));
+  }
+
+  public DirectiveExecutionException(String directiveName, String errorMessage, Throwable e) {
+    this(String.format("Error encountered while executing '%s' : %s", directiveName, errorMessage), e);
+  }
 }
 

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/DirectiveParseException.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/DirectiveParseException.java
@@ -43,6 +43,14 @@ public class DirectiveParseException extends Exception {
     super(message);
   }
 
+  public DirectiveParseException(String directiveName, String errorMessage) {
+    this(String.format("Error encountered while parsing '%s' : %s", directiveName, errorMessage));
+  }
+
+  public DirectiveParseException(String directiveName, String errorMessage, Throwable e) {
+    this(String.format("Error encountered while parsing '%s' : %s", directiveName, errorMessage), e);
+  }
+
   public Iterator<SyntaxError> errors() {
     return errors;
   }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/ErrorRowException.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/ErrorRowException.java
@@ -31,6 +31,10 @@ public class ErrorRowException extends Exception {
     this.code = code;
   }
 
+  public ErrorRowException(String directiveName, String errorMessage, int code) {
+    this(String.format("Error encountered while executing '%s' : %s", directiveName, errorMessage), code);
+  }
+
   /**
    * @return Message as why the record errored.
    */

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/IncrementTransientVariable.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/IncrementTransientVariable.java
@@ -71,7 +71,7 @@ public class IncrementTransientVariable implements Directive {
     try {
       el.compile(expression);
     } catch (ELException e) {
-      throw new DirectiveParseException(e.getMessage());
+      throw new DirectiveParseException(NAME, e.getMessage(), e);
     }
   }
 
@@ -100,7 +100,7 @@ public class IncrementTransientVariable implements Directive {
           context.getTransientStore().increment(TransientVariableScope.GLOBAL, variable, incrementBy);
         }
       } catch (ELException e) {
-        throw new DirectiveExecutionException(e.getMessage());
+        throw new DirectiveExecutionException(NAME, e.getMessage(), e);
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
@@ -69,7 +69,7 @@ public class SetTransientVariable implements Directive {
     try {
       el.compile(expression);
     } catch (ELException e) {
-      throw new DirectiveParseException(e.getMessage());
+      throw new DirectiveParseException(NAME, e.getMessage(), e);
     }
   }
 
@@ -103,7 +103,7 @@ public class SetTransientVariable implements Directive {
           context.getTransientStore().set(TransientVariableScope.GLOBAL, variable, result.getObject());
         }
       } catch (ELException e) {
-        throw new DirectiveExecutionException(e.getMessage());
+        throw new DirectiveExecutionException(NAME, e.getMessage(), e);
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/column/ColumnsReplace.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/ColumnsReplace.java
@@ -73,9 +73,7 @@ public class ColumnsReplace implements Directive {
           Unix4jCommandBuilder builder = Unix4j.echo(name).sed(sed);
           row.setColumn(i, builder.toStringResult());
         } catch (IllegalArgumentException e) {
-          throw new DirectiveExecutionException(
-            String.format(toString() + " : " + e.getMessage())
-          );
+          throw new DirectiveExecutionException(NAME, e.getMessage(), e);
         }
       }
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/Copy.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/Copy.java
@@ -30,8 +30,6 @@ import io.cdap.wrangler.api.annotations.Categories;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
-import io.cdap.wrangler.i18n.Messages;
-import io.cdap.wrangler.i18n.MessagesFactory;
 
 import java.util.List;
 
@@ -43,7 +41,6 @@ import java.util.List;
 @Categories(categories = { "column"})
 @Description("Copies values from a source column into a destination column.")
 public class Copy implements Directive {
-  private static final Messages MSG = MessagesFactory.getMessages();
   public static final String NAME = "copy";
   private ColumnName source;
   private ColumnName destination;
@@ -77,7 +74,7 @@ public class Copy implements Directive {
     for (Row row : rows) {
       int sidx = row.find(source.value());
       if (sidx == -1) {
-        throw new DirectiveExecutionException(MSG.get("column.not.found", toString(), source.value()));
+        throw new DirectiveExecutionException(NAME, String.format("Column '%s' does not exist.", source.value()));
       }
 
       int didx = row.find(destination.value());
@@ -93,8 +90,9 @@ public class Copy implements Directive {
         // if destination column exists, and force is set to false, then throw exception, else
         // overwrite it.
         if (!force) {
-          throw new DirectiveExecutionException(toString() + " : Destination column '" + destination.value()
-                                    + "' does not exist in the row. Use 'force' option to add new column.");
+          throw new DirectiveExecutionException(
+            NAME, String.format("Destination column '%s' already exists in the row. Use 'force' " +
+                                  "option to overwrite the column.", destination.value()));
         }
         row.setValue(didx, row.getValue(sidx));
       }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/Rename.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/Rename.java
@@ -74,11 +74,9 @@ public final class Rename implements Directive {
           row.setColumn(idx, target.value());
         } else {
           throw new DirectiveExecutionException(
-            String.format(
-              "%s : %s column already exists. Apply the directive 'drop %s' before renaming %s to %s.", toString(),
-              target.value(), target.value(), source.value(), source.value()
-            )
-          );
+            NAME, String.format("Column '%s' already exists. Apply the 'drop %s' directive before " +
+                                  "renaming '%s' to '%s'.",
+                                target.value(), target.value(), source.value(), target.value()));
         }
       }
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
@@ -79,8 +79,8 @@ public final class SetType implements Directive {
         } catch (DirectiveExecutionException e) {
           throw e;
         } catch (Exception e) {
-          throw new DirectiveExecutionException(String.format("Invalid data: Column '%s' can not be converted to '%s'",
-                                                              col, type));
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' cannot be converted to a '%s'.", col, type), e);
         }
       }
     }
@@ -162,11 +162,11 @@ public final class SetType implements Directive {
         } else if (object instanceof Float) {
           return ((Float) object) > 0 ? true : false;
         } else if (object instanceof Double) {
-          return ((Double) object)  > 0 ? true : false;
+          return ((Double) object) > 0 ? true : false;
         } else if (object instanceof Integer) {
-          return ((Integer) object)  > 0 ? true : false;
+          return ((Integer) object) > 0 ? true : false;
         } else if (object instanceof Long) {
-          return ((Long) object)  > 0 ? true : false;
+          return ((Long) object) > 0 ? true : false;
         } else if (object instanceof byte[]) {
           return Bytes.toBoolean((byte[]) object);
         } else {
@@ -258,9 +258,9 @@ public final class SetType implements Directive {
 
       default:
         throw new DirectiveExecutionException(
-          String.format("Unknown data type '%s' found in the directive. " +
-                  "Accepted types are: int, short, long, double, boolean, string, bytes", toType)
-        );
+          NAME, String.format(
+            "Column '%s' is of unsupported type '%s'. Supported types are: " +
+              "int, short, long, double, boolean, string, bytes", col, toType));
     }
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/SplitToColumns.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SplitToColumns.java
@@ -76,20 +76,25 @@ public class SplitToColumns implements Directive {
       int idx = row.find(column);
       if (idx != -1) {
         Object object = row.getValue(idx);
-        if (object instanceof String) {
-          String[] lines = ((String) object).split(regex);
-          int i = 1;
-          for (String line : lines) {
-            row.add(String.format("%s_%d", column, i), line);
-            ++i;
-          }
-          results.add(row);
-        } else {
+
+        if (object == null) {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object != null ? object.getClass().getName() : "null", column)
-          );
+            NAME, String.format("Column '%s' has null value. It should be a non-null 'String'.", column));
         }
+
+        if (!(object instanceof String)) {
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String'.",
+                                column, object.getClass().getSimpleName()));
+        }
+
+        String[] lines = ((String) object).split(regex);
+        int i = 1;
+        for (String line : lines) {
+          row.add(String.format("%s_%d", column, i), line);
+          ++i;
+        }
+        results.add(row);
       }
     }
     return results;

--- a/wrangler-core/src/main/java/io/cdap/directives/column/Swap.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/Swap.java
@@ -29,8 +29,6 @@ import io.cdap.wrangler.api.annotations.Categories;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
-import io.cdap.wrangler.i18n.Messages;
-import io.cdap.wrangler.i18n.MessagesFactory;
 
 import java.util.List;
 
@@ -43,7 +41,6 @@ import java.util.List;
 @Description("Swaps the column names of two columns.")
 public class Swap implements Directive {
   public static final String NAME = "swap";
-  private static final Messages MSG = MessagesFactory.getMessages();
   private String left;
   private String right;
 
@@ -73,11 +70,11 @@ public class Swap implements Directive {
       int didx = row.find(right);
 
       if (sidx == -1) {
-        throw new DirectiveExecutionException(MSG.get("column.not.found", toString(), left));
+        throw new DirectiveExecutionException(NAME, String.format("Column '%s' does not exist.", left));
       }
 
       if (didx == -1) {
-        throw new DirectiveExecutionException(MSG.get("column.not.found", toString(), right));
+        throw new DirectiveExecutionException(NAME, String.format("Column '%s' does not exist.", right));
       }
 
       row.setColumn(sidx, right);

--- a/wrangler-core/src/main/java/io/cdap/directives/currency/ParseAsCurrency.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/currency/ParseAsCurrency.java
@@ -104,7 +104,7 @@ public class ParseAsCurrency implements Directive {
           BigDecimal number = (BigDecimal) fmt.parse(value);
           row.addOrSet(destination, number.doubleValue());
         } catch (ParseException e) {
-          throw new ErrorRowException(e.getMessage(), 1);
+          throw new ErrorRowException(NAME, e.getMessage(), 1);
         }
       }
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/date/DiffDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/date/DiffDate.java
@@ -96,8 +96,7 @@ public class DiffDate implements Directive {
     // Else attempt to find the column.
     int idx = row.find(colName);
     if (idx == -1) {
-      throw new DirectiveExecutionException(toString() + " : '" +
-                                              colName + "' column is not defined in the row.");
+      throw new DirectiveExecutionException(NAME, "Column '" + colName + "' does not exist.");
     }
     Object o = row.getValue(idx);
     if (o == null || !(o instanceof ZonedDateTime)) {

--- a/wrangler-core/src/main/java/io/cdap/directives/date/FormatDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/date/FormatDate.java
@@ -80,9 +80,7 @@ public class FormatDate implements Directive {
       int idx = dt.find(column);
 
       if (idx == -1) {
-        throw new DirectiveExecutionException(toString() + " : '" + column + "' column is not defined in the row. " +
-                                                "Please check the wrangling step."
-        );
+        throw new DirectiveExecutionException(NAME, String.format("Column '%s' does not exist.", column));
       }
 
       Object object = row.getValue(idx);
@@ -95,9 +93,8 @@ public class FormatDate implements Directive {
           zonedDateTime = (ZonedDateTime) object;
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Apply 'parse-as-date' directive first.", toString(),
-                          object.getClass().getName(), column)
-          );
+            NAME, String.format("Column '%s' has invalid type '%s'. Apply 'parse-as-date' directive first.",
+                                column, object.getClass().getSimpleName()));
         }
 
         dt.setValue(idx, destinationFmt.format(zonedDateTime));

--- a/wrangler-core/src/main/java/io/cdap/directives/external/InvokeHttp.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/external/InvokeHttp.java
@@ -96,21 +96,18 @@ public class InvokeHttp implements Directive {
         String[] components = header.split("=");
         if (components.length != 2) {
           throw new DirectiveParseException (
-            String.format("Incorrect header '%s' specified. " +
-                            "Header should be specified as 'key=value' pairs separated by a comma (,).", header)
-          );
+            NAME, String.format("Incorrect header '%s' specified. Header should be specified as 'key=value' " +
+                                  "pairs separated by a comma (,).", header));
         }
         String key = components[0].trim();
         String value = components[1].trim();
         if (key.isEmpty()) {
           throw new DirectiveParseException(
-            String.format("Key specified for header '%s' cannot be empty.", header)
-          );
+            NAME, String.format("Key specified for header '%s' cannot be empty.", header));
         }
         if (value.isEmpty()) {
           throw new DirectiveParseException(
-            String.format("Value specified for header '%s' cannot be empty.", header)
-          );
+            NAME, String.format("Value specified for header '%s' cannot be empty.", header));
         }
         headers.put(key, value);
       }
@@ -140,7 +137,7 @@ public class InvokeHttp implements Directive {
         }
       } catch (Exception e) {
         // If there are any issues, they will be pushed on the error port.
-        throw new ErrorRowException(e.getMessage(), 500);
+        throw new ErrorRowException(NAME, e.getMessage(), 500);
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/language/SetCharset.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/language/SetCharset.java
@@ -95,10 +95,8 @@ public class SetCharset implements Directive {
         buffer = (ByteBuffer) object;
       } else {
         throw new DirectiveExecutionException(
-          String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                        object != null ? object.getClass().getName() : "null", column)
-
-        );
+          NAME, String.format("Column '%s' is of invalid type '%s'. It should be of type 'byte array' or " +
+                                "'ByteBuffer'.", column, object.getClass().getSimpleName()));
       }
 
       try {
@@ -106,8 +104,7 @@ public class SetCharset implements Directive {
         row.setValue(idx, result.toString());
       } catch (Error e) {
         throw new DirectiveExecutionException(
-          String.format("Problem converting to character set '%s'", charset)
-        );
+          NAME, String.format("Can not convert to character set '%s', %s", charset, e.getMessage()), e);
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/lookup/CatalogLookup.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/lookup/CatalogLookup.java
@@ -66,14 +66,12 @@ public class CatalogLookup implements Directive {
     String type = ((Text) args.value("catalog")).value();
     if (!type.equalsIgnoreCase("ICD-9") && !type.equalsIgnoreCase("ICD-10-2016") &&
       !type.equalsIgnoreCase("ICD-10-2017")) {
-      throw new DirectiveParseException("Invalid ICD type - should be 9 (ICD-9) or 10 (ICD-10-2016 " +
-                                           "or ICD-10-2017).");
+      throw new DirectiveParseException(
+        NAME, "Invalid ICD type - should be 9 (ICD-9) or 10 (ICD-10-2016 or ICD-10-2017).");
     } else {
       catalog = new ICDCatalog(type.toLowerCase());
       if (!catalog.configure()) {
-        throw new DirectiveParseException(
-          String.format("Failed to configure ICD StaticCatalog. Check with your administrator")
-        );
+        throw new DirectiveParseException(NAME, "Failed to configure ICD StaticCatalog. Check with your administrator");
       }
     }
     this.name = catalog.getCatalog().replaceAll("-", "_");

--- a/wrangler-core/src/main/java/io/cdap/directives/nlp/Stemming.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/nlp/Stemming.java
@@ -73,7 +73,14 @@ public class Stemming implements Directive {
       int idx = row.find(column);
       if (idx != -1) {
         Object object = row.getValue(idx);
-        if (object != null && (object instanceof List || object instanceof String[] || object instanceof String)) {
+
+        if (object == null) {
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has null value. It should be a non-null 'String', " +
+                                  "'Array of String' or 'List of String'.", column));
+        }
+
+        if ((object instanceof List || object instanceof String[] || object instanceof String)) {
           List<String> words = null;
           if (object instanceof String[]) {
             words = Arrays.asList((String[]) object);
@@ -89,15 +96,12 @@ public class Stemming implements Directive {
             row.add(String.format("%s_porter", column), stemmed);
           } catch (IOException e) {
             throw new DirectiveExecutionException(
-              String.format("%s : Unable to apply porter stemmer on column '%s'. %s", toString(), column,
-                            e.getMessage())
-            );
+              NAME, String.format("Unable to apply porter stemmer on column '%s'. %s", column, e.getMessage()), e);
           }
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String, String[] or List<String>.",
-                          toString(), object != null ? object.getClass().getName() : "null", column)
-          );
+            NAME, String.format("Invalid type '%s' of column '%s'. It should be of type 'String', " +
+                                  "Array of String' or 'List of String'.", column, object.getClass().getSimpleName()));
         }
       } else {
         row.add(String.format("%s_porter", column), stemmed);

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/CsvParser.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/CsvParser.java
@@ -50,10 +50,11 @@ import java.util.Set;
  * A CSV Parser Stage for parsing the {@link Row} provided based on configuration.
  */
 @Plugin(type = Directive.TYPE)
-@Name("parse-as-csv")
+@Name(CsvParser.NAME)
 @Categories(categories = { "parser", "csv"})
 @Description("Parses a column as CSV (comma-separated values).")
 public class CsvParser implements Directive {
+  public static final String NAME = "parse-as-csv";
   private ColumnName columnArg;
   private Text delimiterArg;
   private Bool headerArg;
@@ -90,7 +91,8 @@ public class CsvParser implements Directive {
       if (delimiterArg.value().startsWith("\\")) {
         String unescapedStr = StringEscapeUtils.unescapeJava(delimiterArg.value());
         if (unescapedStr == null) {
-          throw new DirectiveParseException("Invalid delimiter for CSV Parser: " + delimiterArg.value());
+          throw new DirectiveParseException(
+            NAME, String.format("Invalid delimiter for CSV Parser '%s'", delimiterArg.value()));
         }
         delimiter = unescapedStr.charAt(0);
       }
@@ -152,7 +154,7 @@ public class CsvParser implements Directive {
         }
       } catch (IOException e) {
         // When there is error parsing data, the data is written to error.
-        throw new ErrorRowException(e.getMessage(), 1);
+        throw new ErrorRowException(NAME, e.getMessage(), 1);
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/FixedLengthParser.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/FixedLengthParser.java
@@ -94,16 +94,21 @@ public final class FixedLengthParser implements Directive {
       int idx = row.find(col);
       if (idx != -1) {
         Object object = row.getValue(idx);
+
+        if (object == null) {
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has null value. It should be a non-null 'String'.", col));
+        }
+
         if (object instanceof String) {
           String data = (String) object;
           int length = data.length();
           // If the recordLength length doesn't match the string length.
           if (length < recordLength) {
             throw new ErrorRowException(
-              String.format("Fewer bytes than length of row specified - expected atleast %d bytes, found %s bytes.",
-                            recordLength, length),
-              2
-            );
+              NAME, String.format("Column '%s' contains a value with fewer characters than the specified length " +
+                                    "of row. Expected at least %d characters but found %s characters.",
+                                  col, recordLength, length), 2);
           }
 
           int index = 1;
@@ -125,9 +130,8 @@ public final class FixedLengthParser implements Directive {
           }
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object != null ? object.getClass().getName() : "null", col)
-          );
+            NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String'.",
+                                col, object.getClass().getSimpleName()));
         }
       }
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/HL7Parser.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/HL7Parser.java
@@ -103,6 +103,13 @@ public class HL7Parser implements Directive {
         int idx = row.find(column);
         if (idx != -1) {
           Object object = row.getValue(idx);
+
+          if (object == null) {
+            throw new DirectiveExecutionException(
+              NAME, String.format("Column '%s' has null value. It should be a non-null 'String'.", column)
+            );
+          }
+
           // Handling the first parsing on HL7 message
           if (object instanceof String) {
             Message message = parser.parse((String) object);
@@ -111,13 +118,14 @@ public class HL7Parser implements Directive {
                                   MessageVisitors.visitPopulatedElements(visitor)).getDelegate();
           } else {
             throw new DirectiveExecutionException(
-              String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.",
-                            toString(), object != null ? object.getClass().getName() : "null", column)
+              NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String'.",
+                                  column, object.getClass().getSimpleName())
             );
           }
+
         }
       } catch (HL7Exception e) {
-        throw new DirectiveExecutionException(toString() + " : " + e.getMessage());
+        throw new DirectiveExecutionException(NAME, e.getMessage(), e);
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/JsParser.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/JsParser.java
@@ -114,10 +114,8 @@ public class JsParser implements Directive {
             element = (JsonElement) value;
           } else {
             throw new DirectiveExecutionException(
-              String.format("%s : Invalid type '%s' of column '%s'. " +
-                              "Should be of type string or a valid Json object.",
-                            toString(), element != null ? element.getClass().getName() : "null", column)
-            );
+              NAME, String.format("Column '%s' is of invalid type '%s'. It should be of type 'String'" +
+                                    " or 'JsonObject' or 'JsonArray'.", column, value.getClass().getSimpleName()));
           }
 
           row.remove(idx);
@@ -143,7 +141,7 @@ public class JsParser implements Directive {
             }
           }
         } catch (JSONException e) {
-          throw new ErrorRowException(toString() + " : " + e.getMessage(), 1);
+          throw new ErrorRowException(NAME, e.getMessage(), 1);
         }
       }
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/JsPath.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/JsPath.java
@@ -98,8 +98,8 @@ public class JsPath implements Directive {
         value instanceof JsonObject ||
         value instanceof JsonArray)) {
         throw new DirectiveExecutionException(
-          String.format("%s : Invalid value type '%s' of column '%s'. Should be of type JsonElement, " +
-                          "String.", toString(), value.getClass().getName(), src)
+          NAME, String.format("Column '%s' is of invalid type '%s'. It should be of type 'String' " +
+                                "or 'JsonObject' or 'JsonArray'.", src, value.getClass().getSimpleName())
         );
       }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/ParseAvroFile.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/ParseAvroFile.java
@@ -90,7 +90,7 @@ public class ParseAvroFile implements Directive {
               results.add(newRow);
             }
           } catch (IOException e) {
-            throw new DirectiveExecutionException(toString() + " : Failed to parse Avro data file." + e.getMessage());
+            throw new DirectiveExecutionException(NAME, "Failed to parse Avro data file. " + e.getMessage(), e);
           } finally {
             if (reader != null) {
               try {
@@ -101,8 +101,8 @@ public class ParseAvroFile implements Directive {
             }
           }
         } else {
-          throw new DirectiveExecutionException(toString() + " : column " + column +
-                                                  " should be of type byte array avro file.");
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' is of invalid type. It should be of type 'byte array'.", column));
         }
       }
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/ParseDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/ParseDate.java
@@ -101,8 +101,8 @@ public class ParseDate implements Directive {
           }
         } else {
           throw new ErrorRowException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object.getClass().getName(), column), 1);
+            NAME, String.format("Column '%s' is of invalid type '%s'. It should be of type 'String'.",
+                                column, object.getClass().getSimpleName()), 1);
         }
       }
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/ParseExcel.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/ParseExcel.java
@@ -110,8 +110,8 @@ public class ParseExcel implements Directive {
             bytes = new byte[buffer.remaining()];
             buffer.get(bytes);
           } else {
-            throw new DirectiveExecutionException(toString() + " : column " + column +
-                                                    " is not byte array or byte buffer.");
+            throw new DirectiveExecutionException(
+              NAME, String.format("Column '%s' should be of type 'byte array' or 'ByteBuffer'.", column));
           }
 
           if (bytes != null) {
@@ -126,8 +126,8 @@ public class ParseExcel implements Directive {
 
             if (excelsheet == null) {
               throw new DirectiveExecutionException(
-                String.format("Failed to extract sheet '%s' from the excel. Sheet '%s' does not exist.", sheet, sheet)
-              );
+                NAME, String.format("Failed to extract sheet '%s' from the excel. " +
+                                      "Sheet '%s' does not exist.", sheet, sheet));
             }
 
             Map<Integer, String> columnNames = new TreeMap<>();
@@ -199,7 +199,7 @@ public class ParseExcel implements Directive {
         }
       }
     } catch (Exception e) {
-      throw new ErrorRowException(e.getMessage(), 1);
+      throw new ErrorRowException(NAME, e.getMessage(), 1);
     } finally {
       if (input != null) {
         Closeables.closeQuietly(input);

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/ParseLog.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/ParseLog.java
@@ -84,6 +84,12 @@ public class ParseLog implements Directive {
       if (idx != -1) {
         Object object = row.getValue(idx);
 
+        if (object == null) {
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has null value. It should be a non-null 'String' or 'byte array'.",
+                                column));
+        }
+
         String log;
         if (object instanceof String) {
           log = (String) object;
@@ -91,9 +97,8 @@ public class ParseLog implements Directive {
           log = new String((byte[]) object);
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String or byte[].",
-                          toString(), object != null ? object.getClass().getName() : "null", column)
-          );
+            NAME, String.format("Column '%s' is of invalid type '%s'. It should be of type 'String' or 'byte array'.",
+                                column, object.getClass().getSimpleName()));
         }
         line.set(row);
         try {

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/ParseSimpleDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/ParseSimpleDate.java
@@ -97,13 +97,13 @@ public class ParseSimpleDate implements Directive {
                                                                .atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)));
             row.setValue(idx, zonedDateTime);
           } catch (ParseException e) {
-            throw new ErrorRowException(String.format("Failed to parse '%s' with pattern '%s'",
-                                                      object, formatter.toPattern()), 1);
+            throw new ErrorRowException(
+              NAME, String.format("Failed to parse '%s' with pattern '%s'", object, formatter.toPattern()), 1);
           }
         } else {
           throw new ErrorRowException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object.getClass().getName(), column), 2);
+            NAME, String.format("Column '%s' is of invalid type '%s'. It should be of type 'String'.",
+                                column, object.getClass().getSimpleName()), 2);
         }
       }
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/ParseTimestamp.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/ParseTimestamp.java
@@ -107,34 +107,36 @@ public class ParseTimestamp implements Directive {
     try {
       unit = TimeUnit.valueOf(unitValue.toUpperCase());
     } catch (IllegalArgumentException e) {
-      throw new DirectiveParseException(String.format("'%s' is not a supported time unit. Supported time " +
-                                                        "units are %s", unitValue, SUPPORTED_TIME_UNITS));
+      throw new DirectiveParseException(
+        NAME, String.format("Time unit '%s' is not a supported time unit. Supported time units are %s",
+                            unitValue, SUPPORTED_TIME_UNITS), e);
     }
 
     if (!SUPPORTED_TIME_UNITS.contains(unit)) {
-      throw new DirectiveParseException(String.format("'%s' is not a supported time unit. Supported time " +
-                                                        "units are %s", unitValue, SUPPORTED_TIME_UNITS));
+      throw new DirectiveParseException(
+        NAME, String.format("Time unit '%s' is not a supported time unit. Supported time units are %s",
+                            unitValue, SUPPORTED_TIME_UNITS));
     }
 
     return unit;
   }
 
   private long getLongValue(Object object) throws ErrorRowException {
-    String errorMsg = String.format("%s : Invalid type '%s' of column '%s'. Must be of type Long or String.",
-                                    toString(), object.getClass().getName(), column);
+    String errorMsg = String.format("Invalid type '%s' of column '%s'. Must be of type 'Long' or 'String'.",
+                                    object.getClass().getSimpleName(), column);
     try {
       if (object instanceof Long) {
-        return  (long) object;
+        return (long) object;
       } else if (object instanceof String) {
         return Long.parseLong((String) object);
       }
     } catch (Exception e) {
       // Exception while casting the object, do not handle it here, so that ErrorRowException is thrown.
-      errorMsg = String.format("%s : Invalid value for column '%s'. Must be of type Long or String representing long.",
-                               toString(), column);
+      errorMsg = String.format("Invalid value for column '%s'. Must be of type 'Long' or 'String' " +
+                                 "representing long.", column);
     }
 
-    throw new ErrorRowException(errorMsg, 2);
+    throw new ErrorRowException(NAME, errorMsg, 2);
   }
 
   private ZonedDateTime getZonedDateTime(long ts, TimeUnit unit, ZoneId zoneId) {

--- a/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
@@ -59,13 +59,14 @@ public class Fail implements Directive {
   public void initialize(Arguments args) throws DirectiveParseException {
     Expression expression = args.value("condition");
     if (expression.value().isEmpty()) {
-      throw new DirectiveParseException("No condition has been specified.");
+      throw new DirectiveParseException(
+        NAME, "No condition has been specified. Make sure condition is provided");
     }
     condition = expression.value();
     try {
       el.compile(condition);
     } catch (ELException e) {
-      throw new DirectiveParseException(e.getMessage());
+      throw new DirectiveParseException(NAME, e.getMessage(), e);
     }
   }
 
@@ -91,11 +92,10 @@ public class Fail implements Directive {
         ELResult result = el.execute(ctx);
         if (result.getBoolean()) {
           throw new DirectiveExecutionException(
-            String.format("Condition '%s' evaluated to true. Terminating processing.", condition)
-          );
+            NAME, String.format("Condition '%s' evaluated to true. Terminating processing.", condition));
         }
       } catch (ELException e) {
-        throw new DirectiveExecutionException(e.getMessage());
+        throw new DirectiveExecutionException(NAME, e.getMessage(), e);
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
@@ -75,7 +75,7 @@ public class RecordConditionFilter implements Directive {
     try {
       el.compile(condition);
     } catch (ELException e) {
-      throw new DirectiveParseException(e.getMessage());
+      throw new DirectiveParseException(NAME, e.getMessage(), e);
     }
   }
 
@@ -116,7 +116,7 @@ public class RecordConditionFilter implements Directive {
           continue;
         }
       } catch (ELException e) {
-        throw new DirectiveExecutionException(e.getMessage());
+        throw new DirectiveExecutionException(NAME, e.getMessage(), e);
       }
       results.add(row);
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordRegexFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordRegexFilter.java
@@ -69,7 +69,8 @@ public class RecordRegexFilter implements Directive {
     } else if (matchType.equalsIgnoreCase("if-not-matched")) {
       matched = false;
     } else {
-      throw new DirectiveParseException("Match type specified is not 'if-matched' or 'if-not-matched'");
+      throw new DirectiveParseException(
+        NAME, "Match type specified is not 'if-matched' or 'if-not-matched'");
     }
     column = ((ColumnName) args.value("column")).value();
     String regex = ((Text) args.value("regex")).value();
@@ -95,6 +96,13 @@ public class RecordRegexFilter implements Directive {
       int idx = row.find(column);
       if (idx != -1) {
         Object object = row.getValue(idx);
+
+        if (object == null) {
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has null value. It should be a non-null 'String', " +
+                                  "'JSONObject' or 'Number'.", column));
+        }
+
         if (object instanceof JSONObject) {
           if (pattern == null && JSONObject.NULL.equals(object)) {
             continue;
@@ -109,8 +117,8 @@ public class RecordRegexFilter implements Directive {
           }
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid value type '%s' of column '%s'. Should be of type String.",
-                          toString(), object != null ? object.getClass().getName() : "null", column)
+            NAME, String.format("Column '%s' is of invalid type '%s'. It should be of type " +
+                                  "'String', 'JSONObject' or 'Number'.", column, object.getClass().getSimpleName())
           );
         }
         results.add(row);

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
@@ -77,7 +77,7 @@ public class SendToError implements Directive {
       el.compile(condition);
     } catch (ELException e) {
       throw new DirectiveParseException(
-        String.format("Invalid condition '%s'.", condition)
+        NAME, String.format(" Invalid condition '%s'.", condition)
       );
     }
     if (args.contains("metric")) {
@@ -123,10 +123,10 @@ public class SendToError implements Directive {
           if (message == null) {
             message = condition;
           }
-          throw new ErrorRowException(message, 1);
+          throw new ErrorRowException(NAME, message, 1);
         }
       } catch (ELException e) {
-        throw new DirectiveExecutionException(e.getMessage());
+        throw new DirectiveExecutionException(NAME, e.getMessage(), e);
       }
       results.add(row);
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SendToErrorAndContinue.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SendToErrorAndContinue.java
@@ -78,8 +78,7 @@ public class SendToErrorAndContinue implements Directive {
       el.compile(condition);
     } catch (ELException e) {
       throw new DirectiveParseException(
-        String.format("Invalid condition '%s'.", condition)
-      );
+        NAME, String.format("Invalid condition '%s'.", condition), e);
     }
     if (args.contains("metric")) {
       metric = ((Identifier) args.value("metric")).value();
@@ -133,7 +132,7 @@ public class SendToErrorAndContinue implements Directive {
           throw new ReportErrorAndProceed(message, 1);
         }
       } catch (ELException e) {
-        throw new DirectiveExecutionException(e.getMessage());
+        throw new DirectiveExecutionException(NAME, e.getMessage(), e);
       }
       results.add(row);
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SplitToRows.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SplitToRows.java
@@ -76,7 +76,13 @@ public class SplitToRows implements Directive {
       int idx = row.find(column);
       if (idx != -1) {
         Object object = row.getValue(idx);
-        if (object != null && object instanceof String) {
+
+        if (object == null) {
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has null value. It should be a non-null 'String'.", column));
+        }
+
+        if (object instanceof String) {
           String[] lines = ((String) object).split(regex);
           for (String line : lines) {
             Row r = new Row(row);
@@ -85,10 +91,8 @@ public class SplitToRows implements Directive {
           }
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object != null ? object.getClass().getName() : "null", column)
-          );
-
+            NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String'.",
+                                column, object.getClass().getSimpleName()));
         }
       }
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/CharacterCut.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/CharacterCut.java
@@ -74,18 +74,22 @@ public class CharacterCut implements Directive {
       int idx = row.find(source);
       if (idx != -1) {
         Object value = row.getValue(idx);
+
+        if (value == null) {
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has null value. It should be a non-null 'String'.", source));
+        }
+
         if (value instanceof String) {
           String result = Unix4j.fromString((String) value).cut("-c", range).toStringResult();
           row.addOrSet(destination, result);
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          value.getClass().getName(), source)
-          );
+            NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String'.",
+                                source, value.getClass().getSimpleName()));
         }
       } else {
-        throw new DirectiveExecutionException(toString() + " : Scope column '" + source +
-                                                "' does not exist in the row.");
+        throw new DirectiveExecutionException(NAME, "Scope column '" + source + "' does not exist.");
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
@@ -80,7 +80,7 @@ public class ColumnExpression implements Directive {
     try {
       el.compile(expression);
     } catch (ELException e) {
-      throw new DirectiveParseException(e.getMessage());
+      throw new DirectiveParseException(NAME, e.getMessage(), e);
     }
   }
 
@@ -117,7 +117,7 @@ public class ColumnExpression implements Directive {
           row.setValue(idx, result.getObject());
         }
       } catch (ELException e) {
-        throw new DirectiveExecutionException(e.getMessage());
+        throw new DirectiveExecutionException(NAME, e.getMessage(), e);
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
@@ -88,9 +88,7 @@ public class Decode implements Directive {
     type = type.toUpperCase();
     if (!type.equals("BASE64") && !type.equals("BASE32") && !type.equals("HEX")) {
       throw new DirectiveParseException(
-        String.format("Type of decoding specified '%s' is not supported. Supports base64, base32 & hex.",
-                      type)
-      );
+        NAME, String.format("Decoding type '%s' is not supported. Supported types are base64, base32 & hex.", type));
     }
     this.method = Method.valueOf(type);
   }
@@ -120,9 +118,8 @@ public class Decode implements Directive {
         value = (byte[]) object;
       } else {
         throw new DirectiveExecutionException(
-          String.format("%s : Invalid value type '%s' of column '%s'. Should be of type string or byte array, "
-            , toString(), value.getClass().getName(), column)
-        );
+          NAME, String.format("Column '%s' has invalid type '%s'. It should be a non-null 'String' or 'byte array'.",
+                              column, object.getClass().getSimpleName()));
       }
 
       byte[] out = new byte[0];
@@ -135,13 +132,12 @@ public class Decode implements Directive {
           out = hexEncode.decode(value);
         } catch (DecoderException e) {
           throw new DirectiveExecutionException(
-            String.format("%s : Failed to decode hex value.", toString())
-          );
+            NAME, String.format("Failed to decode hex value. %s", e.getMessage()), e);
         }
       } else {
         throw new DirectiveExecutionException(
-          String.format("%s : Invalid type of encoding '%s' specified", toString(), method.toString())
-        );
+          NAME, String.format("Specified decoding type '%s' is not supported. Supported types are base64, " +
+                                "base32 & hex.", method.toString()));
       }
 
       String obj = new String(out, StandardCharsets.UTF_8);

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
@@ -87,9 +87,8 @@ public class Encode implements Directive {
     value = value.toUpperCase();
     if (!value.equals("BASE64") && !value.equals("BASE32") && !value.equals("HEX")) {
       throw new DirectiveParseException(
-        String.format("Type of encoding specified '%s' is not supported. Supports base64, base32 & hex.",
-                      value)
-      );
+        NAME, String.format("Type of encoding specified '%s' is not supported. Supported types are " +
+                              "base64, base32 & hex.", value));
     }
     this.method = Method.valueOf(value);
   }
@@ -119,9 +118,8 @@ public class Encode implements Directive {
         value = (byte[]) object;
       } else {
         throw new DirectiveExecutionException(
-          String.format("%s : Invalid value type '%s' of column '%s'. Should be of type string or byte array, "
-            , toString(), value.getClass().getName(), column)
-        );
+          NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String' or 'byte array'.",
+                              column, object.getClass().getSimpleName()));
       }
 
       byte[] out = new byte[0];
@@ -133,8 +131,8 @@ public class Encode implements Directive {
         out = hexEncode.encode(value);
       } else {
         throw new DirectiveExecutionException(
-          String.format("%s : Invalid type of encoding '%s' specified", toString(), method.toString())
-        );
+          NAME, String.format("Specified encoding type '%s' is not supported. Supported types are base64, " +
+                                "base32 & hex.", method.toString()));
       }
 
       String obj = new String(out, StandardCharsets.UTF_8);

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/FillNullOrEmpty.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/FillNullOrEmpty.java
@@ -59,9 +59,7 @@ public class FillNullOrEmpty implements Directive {
     this.column = ((ColumnName) args.value("column")).value();
     this.value = ((Text) args.value("value")).value();
     if (value != null && value.isEmpty()) {
-      throw new DirectiveParseException(
-        "Fixed value cannot be a empty string"
-      );
+      throw new DirectiveParseException(NAME, "Fixed value cannot be an empty string");
     }
   }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/MaskShuffle.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/MaskShuffle.java
@@ -83,9 +83,7 @@ public class MaskShuffle implements Directive {
       if (idx != -1) {
         masked.setValue(idx, maskShuffle((String) row.getValue(idx), 0));
       } else {
-        throw new DirectiveExecutionException(toString() + " : '" +
-                                  column + "' column is not defined. Please check the wrangling step."
-        );
+        throw new DirectiveExecutionException(NAME, String.format("Column '%s' does not exist.", column));
       }
       results.add(masked);
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Quantization.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Quantization.java
@@ -87,6 +87,13 @@ public class Quantization implements Directive {
       if (idx != -1) {
         try {
           Object object = row.getValue(idx);
+
+          if (object == null) {
+            throw new DirectiveExecutionException(
+              NAME, String.format("Column '%s' has null value. It should be a non-null 'String', " +
+                                    "'Float' or 'Double'.", col1));
+          }
+
           Double d;
           if (object instanceof String) {
             d = Double.parseDouble((String) object);
@@ -96,9 +103,8 @@ public class Quantization implements Directive {
             d = ((Float) object).doubleValue();
           } else {
             throw new DirectiveExecutionException(
-              String.format("%s : Invalid type '%s' of column '%s'. Should be of type String, Float or Double.",
-                            toString(), object != null ? object.getClass().getName() : "null", col1)
-            );
+              NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String', " +
+                                    "'Float' or 'Double'.", col1, object.getClass().getSimpleName()));
           }
           String value = rangeMap.get(d);
           int destIdx = row.find(col2);
@@ -108,12 +114,12 @@ public class Quantization implements Directive {
             row.setValue(destIdx, value);
           }
         } catch (NumberFormatException e) {
-          throw new DirectiveExecutionException(toString(), e);
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has invalid type. It should be of type 'String', " +
+                                  "'Float' or 'Double'.", col1), e);
         }
       } else {
-        throw new DirectiveExecutionException(
-          String.format("%s : %s was not found or is not of type string. Please check the wrangle configuration.",
-                        toString(), col1));
+        throw new DirectiveExecutionException(NAME, "Column '" + col1 + "' does not exist.");
       }
       results.add(row);
     }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/SplitEmail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/SplitEmail.java
@@ -94,12 +94,11 @@ public class SplitEmail implements Directive {
           }
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object != null ? object.getClass().getName() : "null", column)
-          );
+            NAME, String.format("Column '%s' has invalid type '%s'. " +
+                                  "It should be of type 'String'.", column, object.getClass().getSimpleName()));
         }
       } else {
-        throw new DirectiveExecutionException(toString() + " : Column '" + column + "' does not exist in the row.");
+        throw new DirectiveExecutionException(NAME, String.format("Column '%s' does not exist.", column));
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/SplitURL.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/SplitURL.java
@@ -91,19 +91,15 @@ public class SplitURL implements Directive {
             row.add(column + "_query", url.getQuery());
           } catch (MalformedURLException e) {
             throw new DirectiveExecutionException(
-              String.format(
-                "Malformed url '%s' found in column '%s'", (String) object, column
-              )
-            );
+              NAME, String.format("Malformed url '%s' found in column '%s'.", (String) object, column), e);
           }
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object != null ? object.getClass().getName() : "null", column)
-          );
+            NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String'.",
+                                column, object.getClass().getSimpleName()));
         }
       } else {
-        throw new DirectiveExecutionException(toString() + " : Column '" + column + "' does not exist in the row.");
+        throw new DirectiveExecutionException(NAME, String.format("Column '%s' does not exist.", column));
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/UrlDecode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/UrlDecode.java
@@ -68,6 +68,12 @@ public class UrlDecode implements Directive {
       int idx = row.find(column);
       if (idx != -1) {
         Object object = row.getValue(idx);
+
+        if (object == null) {
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has null value. It should be a non-null 'String'.", column));
+        }
+
         if (object instanceof String) {
           try {
             row.setValue(idx, URLDecoder.decode((String) object, "UTF-8"));
@@ -76,12 +82,11 @@ public class UrlDecode implements Directive {
           }
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object != null ? object.getClass().getName() : "null", column)
-          );
+            NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String'.",
+                                column, object.getClass().getSimpleName()));
         }
       } else {
-        throw new DirectiveExecutionException(toString() + " : Column '" + column + "' does not exist in the row.");
+        throw new DirectiveExecutionException(NAME, String.format("Column '%s' does not exist.", column));
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/UrlEncode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/UrlEncode.java
@@ -68,6 +68,12 @@ public class UrlEncode implements Directive {
       int idx = row.find(column);
       if (idx != -1) {
         Object object = row.getValue(idx);
+
+        if (object == null) {
+          throw new DirectiveExecutionException(
+            NAME, String.format("Column '%s' has null value. It should be a non-null 'String'.", column));
+        }
+
         if (object instanceof String) {
           try {
             row.setValue(idx, URLEncoder.encode((String) object, "UTF-8"));
@@ -76,12 +82,11 @@ public class UrlEncode implements Directive {
           }
         } else {
           throw new DirectiveExecutionException(
-            String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                          object != null ? object.getClass().getName() : "null", column)
-          );
+            NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String'.",
+                                column, object.getClass().getSimpleName()));
         }
       } else {
-        throw new DirectiveExecutionException(toString() + " : Column '" + column + "' does not exist in the row.");
+        throw new DirectiveExecutionException(NAME, String.format("Column '%s' does not exist.", column));
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsCSV.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsCSV.java
@@ -85,7 +85,7 @@ public class WriteAsCSV implements Directive {
         }
         row.add(column, bOut.toString());
       } catch (IOException e) {
-        throw new DirectiveExecutionException(toString() + " : Failed to write CSV row. " + e.getMessage());
+        throw new DirectiveExecutionException(NAME, e.getMessage(), e);
       }
     }
     return rows;

--- a/wrangler-core/src/main/java/io/cdap/directives/xml/XmlToJson.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/xml/XmlToJson.java
@@ -83,8 +83,9 @@ public class XmlToJson implements Directive {
       int idx = row.find(col);
       if (idx != -1) {
         Object object = row.getValue(idx);
+
         if (object == null) {
-          throw new DirectiveExecutionException(toString() + " : Did not find '" + col + "' in the row.");
+          throw new DirectiveExecutionException(NAME, "' : Column '" + col + "' does not exist.");
         }
 
         try {
@@ -95,16 +96,14 @@ public class XmlToJson implements Directive {
             row.remove(idx);
           } else {
             throw new DirectiveExecutionException(
-              String.format("%s : Invalid type '%s' of column '%s'. Should be of type String.", toString(),
-                            col, object != null ? object.getClass().getName() : "null")
-            );
+              NAME, String.format("Column '%s' has invalid type '%s'. It should be of type 'String'.",
+                                  col, object.getClass().getSimpleName()));
           }
         } catch (JSONException e) {
-          throw new DirectiveExecutionException(toString() + " : " + e.getMessage());
+          throw new DirectiveExecutionException(NAME, e.getMessage(), e);
         }
       }
     }
     return rows;
   }
-
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/executor/RecipePipelineExecutor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/executor/RecipePipelineExecutor.java
@@ -100,7 +100,7 @@ public final class RecipePipelineExecutor implements RecipePipeline<Row, Structu
       List<StructuredRecord> output = convertor.toStructureRecord(rows, schema);
       return output;
     } catch (RecordConvertorException e) {
-      throw new RecipeException("Problem converting into output record. Reason : " + e.getMessage());
+      throw new RecipeException("Problem converting into output record. Reason : " + e.getMessage(), e);
     }
   }
 

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/GrammarBasedParser.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/GrammarBasedParser.java
@@ -96,16 +96,15 @@ public class GrammarBasedParser implements RecipeParser {
         // Checks if the directive has been excluded from being used.
         if (!root.equals(command) && context.isExcluded(command)) {
           throw new DirectiveParseException(
-            String.format("Aliased directive '%s' has been configured as restricted directive and "
-                            + "is hence unavailable. Please contact your administrator", command)
+            command, String.format("Aliased directive '%s' has been configured as restricted directive and "
+                                     + "is hence unavailable. Please contact your administrator", command)
           );
         }
 
         if (context.isExcluded(root)) {
           throw new DirectiveParseException(
-            String.format("Directive '%s' has been configured as restricted directive and is hence unavailable. " +
-                            "Please contact your administrator", command)
-          );
+            command, String.format("Directive '%s' has been configured as restricted directive and is hence " +
+                                     "unavailable. Please contact your administrator", command));
         }
 
         DirectiveInfo info = registry.get(namespace, root);

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/MapArguments.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/MapArguments.java
@@ -58,9 +58,8 @@ public class MapArguments implements Arguments {
     int required = definition.getTokens().size() - definition.getOptionalTokensCount();
     if ((required > group.size() - 1) || ((group.size() - 1) > definition.getTokens().size())) {
       throw new DirectiveParseException(
-        String.format("Improper usage of directive '%s', usage - '%s'",
-                      definition.getDirectiveName(), definition.toString())
-      );
+        definition.getDirectiveName(), String.format("Improper usage of directive '%s', usage - '%s'",
+                                                     definition.getDirectiveName(), definition.toString()));
     }
 
     List<TokenDefinition> specifications = definition.getTokens();

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/MigrateToV2.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/MigrateToV2.java
@@ -250,7 +250,7 @@ public final class MigrateToV2 implements GrammarMigrator {
             transformed.add(String.format("filter-by-regex if-not-matched %s %s;", col(column), quote(pattern)));
           } else {
             throw new DirectiveParseException(
-              String.format("Unknown option '%s' specified for filter-rows-on directive at line no %s", cmd, lineno)
+              "filter-rows-on", String.format("Unknown option '%s' specified at line no %s", cmd, lineno)
             );
           }
         }
@@ -822,9 +822,7 @@ public final class MigrateToV2 implements GrammarMigrator {
     } else {
       if (!optional) {
         throw new DirectiveParseException(
-          String.format("Missing field '%s' at line number %d for directive <%s>.",
-                        field, lineno, directive)
-        );
+          directive, String.format("Missing field '%s' at line number %d.", field, lineno));
       }
     }
     return value;

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/SimpleTextParser.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/SimpleTextParser.java
@@ -97,16 +97,15 @@ public class SimpleTextParser implements RecipeParser {
       // Checks if the directive has been excluded from being used.
       if (!root.equals(command) && context.isExcluded(command)) {
         throw new DirectiveParseException(
-          String.format("Aliased directive '%s' has been configured as restricted directive and "
-                          + "is hence unavailable. Please contact your administrator", command)
+          command, String.format("Aliased directive '%s' has been configured as restricted directive and "
+                                   + "is hence unavailable. Please contact your administrator", command)
         );
       }
 
       if (context.isExcluded(root)) {
         throw new DirectiveParseException(
-          String.format("Executor '%s' has been configured as restricted directive and is hence unavailable. " +
-                          "Please contact your administrator", command)
-        );
+          command, String.format("Executor '%s' has been configured as restricted directive and is hence " +
+                                   "unavailable. Please contact your administrator", command));
       }
     }
     return directives;
@@ -137,9 +136,7 @@ public class SimpleTextParser implements RecipeParser {
       if (!optional) {
         String usage = usageRegistry.getUsage(directive);
         throw new DirectiveParseException(
-          String.format("Missing field '%s' at line number %d for directive <%s> (usage: %s)",
-                        field, lineno, directive, usage)
-        );
+          directive, String.format("Missing field '%s' at line number %d (usage: %s)", field, lineno, usage));
       }
     }
     return value;

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/RecordConvertor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/RecordConvertor.java
@@ -230,7 +230,7 @@ public final class RecordConvertor implements Serializable {
         } else {
           throw new RecordConvertorException(
             String.format("Schema specifies field '%s' is integer, but the value is not a integer or string. " +
-                            "It is of type '%s'", name, object.getClass().getName())
+                            "It is of type '%s'", name, object.getClass().getSimpleName())
           );
         }
       case LONG:
@@ -251,7 +251,7 @@ public final class RecordConvertor implements Serializable {
         } else {
           throw new RecordConvertorException(
             String.format("Schema specifies field '%s' is long, but the value is nor a string or long. " +
-                            "It is of type '%s'", name, object.getClass().getName())
+                            "It is of type '%s'", name, object.getClass().getSimpleName())
           );
         }
       case FLOAT:
@@ -274,7 +274,7 @@ public final class RecordConvertor implements Serializable {
         } else {
           throw new RecordConvertorException(
             String.format("Schema specifies field '%s' is float, but the value is nor a string or float. " +
-                            "It is of type '%s'", name, object.getClass().getName())
+                            "It is of type '%s'", name, object.getClass().getSimpleName())
           );
         }
       case DOUBLE:
@@ -301,7 +301,7 @@ public final class RecordConvertor implements Serializable {
         } else {
           throw new RecordConvertorException(
             String.format("Schema specifies field '%s' is double, but the value is nor a string or double. " +
-                            "It is of type '%s'", name, object.getClass().getName())
+                            "It is of type '%s'", name, object.getClass().getSimpleName())
           );
         }
       case BOOLEAN:
@@ -318,7 +318,7 @@ public final class RecordConvertor implements Serializable {
         } else {
           throw new RecordConvertorException(
             String.format("Schema specifies field '%s' is double, but the value is nor a string or boolean. " +
-                            "It is of type '%s'", name, object.getClass().getName())
+                            "It is of type '%s'", name, object.getClass().getSimpleName())
           );
         }
 

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
@@ -678,10 +678,8 @@ public class DirectivesHandler extends AbstractWranglerHandler {
         sb.append(directives).append(";");
         return sb.toString();
       }
-    } catch (CompileException e) {
+    } catch (CompileException | DirectiveParseException e) {
       throw new IllegalArgumentException(e.getMessage(), e);
-    } catch (DirectiveParseException e) {
-      throw new IllegalArgumentException(e.getMessage());
     }
     return null;
   }
@@ -1117,8 +1115,8 @@ public class DirectivesHandler extends AbstractWranglerHandler {
         String migrate = migrator.migrate();
         RecipeParser recipe = new GrammarBasedParser(id.getNamespace().getName(), migrate, composite);
         recipe.initialize(new ConfigDirectiveContext(configStore.getConfig()));
-        executor.initialize(recipe, context);
         try {
+          executor.initialize(recipe, context);
           rows = executor.execute(sample.apply(rows));
         } catch (RecipeException e) {
           throw new BadRequestException(e.getMessage(), e);


### PR DESCRIPTION
**Summary**
* Removed usage of toString() from error messages
* Made error messages consistent for Directive's `initialize()` and `execute()` methods
* Using `JexlException#getInfo()` method to construct error message. This is to avoid having classname that threw exception in the error message, i.e. `io.cdap.wrangler.expression.EL`
* Also did some code cleanup and error message cleanup in directives

![image](https://user-images.githubusercontent.com/14131070/64146101-774df480-cdd0-11e9-9873-256eec47eeb6.png)

![image](https://user-images.githubusercontent.com/14131070/64146112-859c1080-cdd0-11e9-88db-6a5ad5e42c5b.png)

Custom Transforms:
![image](https://user-images.githubusercontent.com/14131070/64149770-afa70000-cddb-11e9-8a3b-6d48a2db1caa.png)
