### PR TITLE
CDAP-15993 cleanse parse-as-csv column names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.cdap.wrangler</groupId>
   <artifactId>wrangler</artifactId>
-  <version>4.1.0</version>
+  <version>4.1.1</version>
   <name>Wrangler</name>
   <packaging>pom</packaging>
   <description>An interactive tool for data cleansing and transformation.</description>

--- a/wrangler-api/pom.xml
+++ b/wrangler-api/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/CsvParser.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/CsvParser.java
@@ -143,7 +143,7 @@ public class CsvParser implements Directive {
         for (CSVRecord csvRecord : csvRecords) {
           if (!checkedHeader && hasHeader && isHeader(csvRecord)) {
             for (int i = 0; i < csvRecord.size(); i++) {
-              headers.add(csvRecord.get(i).trim());
+              headers.add(csvRecord.get(i).trim().replaceAll("\\s+", "_"));
             }
             if (rows.size() > 0) {
               return new ArrayList<>();

--- a/wrangler-core/src/test/java/io/cdap/directives/parser/CsvParserTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/parser/CsvParserTest.java
@@ -49,7 +49,22 @@ public class CsvParserTest {
     );
 
     rows = TestingRig.execute(directives, rows);
-    Assert.assertTrue(rows.size() == 2);
+    Assert.assertEquals(2, rows.size());
     Assert.assertEquals("07/29/2013", rows.get(0).getValue("date"));
+  }
+
+  @Test
+  public void testHeaders() throws Exception {
+    String[] directives = new String[] { "parse-as-csv body , true" };
+
+    List<Row> rows = Arrays.asList(
+      new Row("body", "first name, last  \t  name"),
+      new Row("body", "alice,zed")
+    );
+
+    rows = TestingRig.execute(directives, rows);
+    Assert.assertEquals(1, rows.size());
+    Assert.assertEquals("alice", rows.get(0).getValue("first_name"));
+    Assert.assertEquals("zed", rows.get(0).getValue("last_name"));
   }
 }

--- a/wrangler-proto/pom.xml
+++ b/wrangler-proto/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-storage/pom.xml
+++ b/wrangler-storage/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-test/pom.xml
+++ b/wrangler-test/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-transform/pom.xml
+++ b/wrangler-transform/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
replaces whitespace with underscores in column names generated
from headers by parse-as-csv. This is because whitespace basically
makes future directives behave very strangely without errors.