### PR TITLE
Workaround for wrangler

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/Directive.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/Directive.java
@@ -16,6 +16,7 @@
 
 package io.cdap.wrangler.api;
 
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 
 import java.util.List;
@@ -115,4 +116,13 @@ public interface Directive extends Executor<List<Row>, List<Row>> {
    * @see io.cdap.wrangler.api.parser.TokenType
    */
   UsageDefinition define();
+
+  /**
+   * Get the field operations related to get this directive.
+   *
+   * @return a list of field operations about this directive
+   */
+  default List<FieldTransformOperation> getFieldOperation() {
+    throw new UnsupportedOperationException("This directive does not support field level lineage.");
+  }
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/RecipeParser.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/RecipeParser.java
@@ -20,7 +20,6 @@ import io.cdap.wrangler.api.annotations.PublicEvolving;
 
 import java.io.Serializable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * A specification for how {@link RecipePipeline} will process.
@@ -32,13 +31,12 @@ public interface RecipeParser extends Serializable {
    *
    * @return List of {@link Executor}.
    */
-  List<Executor> parse() throws DirectiveLoadException, DirectiveNotFoundException, DirectiveParseException;
+  List<Directive> parse() throws DirectiveLoadException, DirectiveNotFoundException, DirectiveParseException;
 
   /**
    * Initialises the directive with a {@link DirectiveContext}.
    *
    * @param context instance of context object or null.
    */
-  @Nullable
   void initialize(DirectiveContext context);
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/Drop.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/Drop.java
@@ -19,6 +19,7 @@ package io.cdap.directives.column;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -30,6 +31,7 @@ import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -51,6 +53,13 @@ public class Drop implements Directive {
     UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
     builder.define("column", TokenType.COLUMN_NAME_LIST);
     return builder.build();
+  }
+
+  @Override
+  public List<FieldTransformOperation> getFieldOperation() {
+    return Collections.singletonList(
+      new FieldTransformOperation(String.format("Drop columns %s", columns),
+                                  String.format("Drop the columns: %s", columns), columns));
   }
 
   @Override

--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -31,6 +32,7 @@ import io.cdap.wrangler.api.parser.Identifier;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -52,6 +54,14 @@ public final class SetType implements Directive {
     builder.define("column", TokenType.COLUMN_NAME);
     builder.define("type", TokenType.IDENTIFIER);
     return builder.build();
+  }
+
+  @Override
+  public List<FieldTransformOperation> getFieldOperation() {
+    return Collections.singletonList(new FieldTransformOperation(String.format("Set type for column %s", col),
+                                                                 String.format("Set type for column %s with" +
+                                                                                 " value %s", col, type),
+                                                                 Collections.singletonList(col), col));
   }
 
   @Override

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
@@ -19,6 +19,8 @@ package io.cdap.directives.row;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -36,7 +38,10 @@ import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * A Wrangle step for filtering rows based on the condition.
@@ -82,6 +87,15 @@ public class RecordConditionFilter implements Directive {
   @Override
   public void destroy() {
     // no-op
+  }
+
+  @Override
+  public List<FieldTransformOperation> getFieldOperation() {
+    return el.variables().stream().map(
+      variable -> new FieldTransformOperation(String.format("Record condition filter for column %s", variable),
+                                              String.format("Filter based on column %s", variable),
+                                              Collections.singletonList(variable), variable))
+             .collect(Collectors.toList());
   }
 
   @Override

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordRegexFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordRegexFilter.java
@@ -19,6 +19,7 @@ package io.cdap.directives.row;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -34,6 +35,7 @@ import io.cdap.wrangler.api.parser.UsageDefinition;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -59,6 +61,17 @@ public class RecordRegexFilter implements Directive {
     builder.define("column", TokenType.COLUMN_NAME);
     builder.define("regex", TokenType.TEXT);
     return builder.build();
+  }
+
+  @Override
+  public List<FieldTransformOperation> getFieldOperation() {
+    return Collections.singletonList(new FieldTransformOperation(String.format("Record regex filter for column %s",
+                                                                               column),
+                                                                 String.format("Filter column %s if %s regex %s",
+                                                                               column,
+                                                                               matched ? "matched" : "not matched",
+                                                                               pattern),
+                                                                 Collections.singletonList(column), column));
   }
 
   @Override

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
@@ -19,6 +19,8 @@ package io.cdap.directives.row;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -39,7 +41,9 @@ import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A directive for erroring the record if
@@ -68,6 +72,15 @@ public class SendToError implements Directive {
     builder.define("metric", TokenType.IDENTIFIER, Optional.TRUE);
     builder.define("message", TokenType.TEXT, Optional.TRUE);
     return builder.build();
+  }
+
+  @Override
+  public List<FieldTransformOperation> getFieldOperation() {
+    return el.variables().stream().map(
+      variable -> new FieldTransformOperation(String.format("Send to error for column %s", variable),
+                                              String.format("Send to error based on column %s", variable),
+                                              Collections.singletonList(variable), variable))
+             .collect(Collectors.toList());
   }
 
   @Override

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
@@ -19,6 +19,7 @@ package io.cdap.directives.transformation;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -35,6 +36,7 @@ import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +73,14 @@ public class ColumnExpression implements Directive {
     builder.define("column", TokenType.COLUMN_NAME);
     builder.define("expression", TokenType.EXPRESSION);
     return builder.build();
+  }
+
+  @Override
+  public List<FieldTransformOperation> getFieldOperation() {
+    return Collections.singletonList(
+      new FieldTransformOperation(String.format("Set column %s", column),
+                                  String.format("Set the column %s with expression %s", column, expression),
+                                  Collections.emptyList(), column));
   }
 
   @Override

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/FillNullOrEmpty.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/FillNullOrEmpty.java
@@ -19,6 +19,7 @@ package io.cdap.directives.transformation;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -32,6 +33,7 @@ import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 import org.json.JSONObject;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -45,6 +47,15 @@ public class FillNullOrEmpty implements Directive {
   public static final String NAME = "fill-null-or-empty";
   private String column;
   private String value;
+
+  @Override
+  public List<FieldTransformOperation> getFieldOperation() {
+    return Collections.singletonList(new FieldTransformOperation(String.format("Fill null or emptry for column %s",
+                                                                               column),
+                                                                 String.format("Fill null or empty for column %s with" +
+                                                                                 " value %s", column, value),
+                                                                 Collections.singletonList(column), column));
+  }
 
   @Override
   public UsageDefinition define() {

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/MaskShuffle.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/MaskShuffle.java
@@ -19,6 +19,7 @@ package io.cdap.directives.transformation;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -31,6 +32,7 @@ import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -62,6 +64,13 @@ public class MaskShuffle implements Directive {
     UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
     builder.define("column", TokenType.COLUMN_NAME);
     return builder.build();
+  }
+
+  @Override
+  public List<FieldTransformOperation> getFieldOperation() {
+    return Collections.singletonList(new FieldTransformOperation(String.format("Mask shuffle on column %s", column),
+                                                                 String.format("Mask shuffle on column %s", column),
+                                                                 Collections.singletonList(column), column));
   }
 
   @Override

--- a/wrangler-core/src/main/java/io/cdap/wrangler/executor/RecipePipelineExecutor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/executor/RecipePipelineExecutor.java
@@ -19,6 +19,7 @@ package io.cdap.wrangler.executor;
 import com.google.common.collect.Lists;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveLoadException;
 import io.cdap.wrangler.api.DirectiveNotFoundException;
@@ -48,7 +49,7 @@ public final class RecipePipelineExecutor implements RecipePipeline<Row, Structu
 
   private static final Logger LOG = LoggerFactory.getLogger(RecipePipelineExecutor.class);
   private ExecutorContext context;
-  private List<Executor> directives;
+  private List<Directive> directives;
   private final ErrorRecordCollector collector = new ErrorRecordCollector();
   private RecordConvertor convertor = new RecordConvertor();
 

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/GrammarBasedParser.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/GrammarBasedParser.java
@@ -38,7 +38,6 @@ import io.cdap.wrangler.registry.DirectiveRegistry;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * This class <code>GrammarBasedParser</code> is an implementation of <code>RecipeParser</code>.
@@ -51,7 +50,7 @@ public class GrammarBasedParser implements RecipeParser {
   private final Compiler compiler = new RecipeCompiler();
   private final DirectiveRegistry registry;
   private final String recipe;
-  private final List<Executor> directives;
+  private final List<Directive> directives;
   private DirectiveContext context;
 
   public GrammarBasedParser(String namespace, String[] directives, DirectiveRegistry registry) {
@@ -72,7 +71,7 @@ public class GrammarBasedParser implements RecipeParser {
    * @return List of {@link Executor}.
    */
   @Override
-  public List<Executor> parse()
+  public List<Directive> parse()
     throws DirectiveLoadException, DirectiveNotFoundException, DirectiveParseException {
     try {
       CompileStatus status = compiler.compile(recipe);
@@ -132,7 +131,6 @@ public class GrammarBasedParser implements RecipeParser {
    *
    * @param context
    */
-  @Nullable
   @Override
   public void initialize(DirectiveContext context) {
     if (context == null) {

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/SimpleTextParser.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/SimpleTextParser.java
@@ -16,6 +16,7 @@
 
 package io.cdap.wrangler.parser;
 
+import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveContext;
 import io.cdap.wrangler.api.DirectiveParseException;
 import io.cdap.wrangler.api.Executor;
@@ -28,7 +29,6 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
-import javax.annotation.Nullable;
 
 /**
  * Parses the DSL into specification containing stepRegistry for wrangling.
@@ -71,8 +71,8 @@ public class SimpleTextParser implements RecipeParser {
    * @throws ParseException
    */
   @Override
-  public List<Executor> parse() throws DirectiveParseException {
-    List<Executor> directives = new ArrayList<>();
+  public List<Directive> parse() throws DirectiveParseException {
+    List<Directive> directives = new ArrayList<>();
 
     // Split directive by EOL
     int lineno = 1;
@@ -147,7 +147,6 @@ public class SimpleTextParser implements RecipeParser {
    *
    * @param context
    */
-  @Nullable
   @Override
   public void initialize(DirectiveContext context) {
     if (context == null) {

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/ConfigDirectiveContextTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/ConfigDirectiveContextTest.java
@@ -17,6 +17,7 @@
 package io.cdap.wrangler.parser;
 
 import com.google.gson.Gson;
+import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveConfig;
 import io.cdap.wrangler.api.DirectiveNotFoundException;
 import io.cdap.wrangler.api.DirectiveParseException;
@@ -98,7 +99,7 @@ public class ConfigDirectiveContextTest {
     );
     directives.initialize(new ConfigDirectiveContext(config));
 
-    List<Executor> steps = directives.parse();
+    List<Directive> steps = directives.parse();
     Assert.assertEquals(1, steps.size());
   }
 
@@ -116,7 +117,7 @@ public class ConfigDirectiveContextTest {
     );
     directives.initialize(new ConfigDirectiveContext(config));
 
-    List<Executor> steps = directives.parse();
+    List<Directive> steps = directives.parse();
     Assert.assertEquals(1, steps.size());
   }
 
@@ -134,7 +135,7 @@ public class ConfigDirectiveContextTest {
     );
     directives.initialize(new ConfigDirectiveContext(config));
 
-    List<Executor> steps = directives.parse();
+    List<Directive> steps = directives.parse();
     Assert.assertEquals(1, steps.size());
   }
 

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/GrammarBasedParserTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/GrammarBasedParserTest.java
@@ -19,7 +19,7 @@ package io.cdap.wrangler.parser;
 import io.cdap.wrangler.TestingRig;
 import io.cdap.wrangler.api.CompileStatus;
 import io.cdap.wrangler.api.Compiler;
-import io.cdap.wrangler.api.Executor;
+import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.RecipeParser;
 import org.junit.Assert;
 import org.junit.Test;
@@ -44,7 +44,7 @@ public class GrammarBasedParserTest {
 
     RecipeParser parser = TestingRig.parse(recipe);
     parser.initialize(null);
-    List<Executor> directives = parser.parse();
+    List<Directive> directives = parser.parse();
     Assert.assertEquals(2, directives.size());
   }
 
@@ -73,7 +73,7 @@ public class GrammarBasedParserTest {
 
     RecipeParser parser = TestingRig.parse(recipe);
     parser.initialize(null);
-    List<Executor> directives = parser.parse();
+    List<Directive> directives = parser.parse();
     Assert.assertEquals(0, directives.size());
   }
 

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/NoOpDirectiveContextTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/NoOpDirectiveContextTest.java
@@ -17,7 +17,7 @@
 package io.cdap.wrangler.parser;
 
 import io.cdap.wrangler.TestingRig;
-import io.cdap.wrangler.api.Executor;
+import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.RecipeParser;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,7 +41,7 @@ public class NoOpDirectiveContextTest {
     };
 
     RecipeParser parse = TestingRig.parse(recipe);
-    List<Executor> directives = parse.parse();
+    List<Directive> directives = parse.parse();
     Assert.assertEquals(6, directives.size());
   }
 


### PR DESCRIPTION
This is a workaround for wrangler FLL. Currently applied to the following directives: Delete a Column, Set a Column, Send to Error, Mask, Filter, Fill-Null-Or-Empty
Change Data Type