### PR TITLE
CDAP-16146 fix file extension logic to be case insensitive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.cdap.wrangler</groupId>
   <artifactId>wrangler</artifactId>
-  <version>4.1.2</version>
+  <version>4.1.3</version>
   <name>Wrangler</name>
   <packaging>pom</packaging>
   <description>An interactive tool for data cleansing and transformation.</description>

--- a/wrangler-api/pom.xml
+++ b/wrangler-api/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-proto/pom.xml
+++ b/wrangler-proto/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/FileTypeDetector.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/FileTypeDetector.java
@@ -95,6 +95,7 @@ public class FileTypeDetector {
   public String detectFileType(String location) {
     // We first attempt to detect the type of file based on extension.
     String extension = FilenameUtils.getExtension(location);
+    extension = extension == null ? null : extension.toLowerCase();
     if (extensions.containsKey(extension)) {
       return extensions.get(extension);
     } else {

--- a/wrangler-storage/pom.xml
+++ b/wrangler-storage/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-test/pom.xml
+++ b/wrangler-test/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-transform/pom.xml
+++ b/wrangler-transform/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Fix the logic that uses the file extension to guess a content
type to be case insensitive for the extension. This means an
extension like .xml will be treated the same as .XML