### PR TITLE
CDAP-16724 fix bad sampling in GCS handler

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/Row.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/Row.java
@@ -57,6 +57,7 @@ public final class Row implements Serializable {
    */
   public Row(List<String> columns) {
     this.columns = new ArrayList<>(columns);
+    this.values = new ArrayList<>(columns.size());
   }
 
   /**
@@ -66,8 +67,8 @@ public final class Row implements Serializable {
    * @param value for the column defined above.
    */
   public Row(String name, Object value) {
-    this.columns = new ArrayList<>();
-    this.values = new ArrayList<>();
+    this.columns = new ArrayList<>(1);
+    this.values = new ArrayList<>(1);
     this.columns.add(name);
     this.values.add(value);
   }


### PR DESCRIPTION
Fixed the GCS handler to create less duplicate data. Instead of
copying data multiple times, try to go through the file contents
once and just maintain a single list of Rows.

Also limited the number of rows in the sample to 5000. This is
because the Row class uses a lot of memory, so the handler was
going out of memory reading just 10mb of an input file, where that
10mb contained a million rows.

Also fixed a bug in Row that made one of the constructors useless
and changed another constructor to set the initial the array size
to reduce memory usage.