### PR TITLE
Treat JsonNull as null value in FillNullOrEmpty directive

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/FillNullOrEmpty.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/FillNullOrEmpty.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.transformation;
 
+import com.google.gson.JsonNull;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -91,6 +92,8 @@ public class FillNullOrEmpty implements Directive, Lineage {
           if (JSONObject.NULL.equals(object)) {
             row.setValue(idx, value);
           }
+        } else if (object instanceof JsonNull) {
+          row.setValue(idx, value);
         }
       }
     }

--- a/wrangler-core/src/test/java/io/cdap/directives/transformation/FillNullOrEmptyTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/transformation/FillNullOrEmptyTest.java
@@ -124,4 +124,21 @@ public class FillNullOrEmptyTest {
     Assert.assertEquals("Not Available", rows.get(1).getValue("value"));
     Assert.assertEquals("Should be fine", rows.get(2).getValue("value"));
   }
+
+  @Test
+  public void testGsonNull() throws Exception {
+    String[] directives = new String[]{
+      "parse-as-json :body",
+      "fill-null-or-empty :body_value 'Not Available'"
+    };
+
+    List<Row> rows = Arrays.asList(
+      new Row("body", "{\"value\": null }")
+    );
+
+    rows = TestingRig.execute(directives, rows);
+
+    Assert.assertTrue(rows.size() == 1);
+    Assert.assertEquals("Not Available", rows.get(0).getValue("body_value"));
+  }
 }


### PR DESCRIPTION
I noticed that using the parse-as-json directive can result in cells with JsonNull values that cannot be altered through the fill-null-or-empty directive. This change checks for JsonNull objects and treats them as a null value.