### PR TITLE
[PLUGIN-386] Displaying BigQuery MaterializedViews in Wrangler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,11 +93,11 @@
     <commons-lang3.version>3.5</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <geogson.version>1.1.97</geogson.version>
-    <google.cloud.bigquery.version>1.75.0</google.cloud.bigquery.version>
-    <google.cloud.core.version>1.75.0</google.cloud.core.version>
+    <google.cloud.bigquery.version>1.110.1</google.cloud.bigquery.version>
+    <google.cloud.core.version>1.93.4</google.cloud.core.version>
     <google.findbugs.version>2.0.1</google.findbugs.version>
     <google.http.client.version>1.22.0</google.http.client.version>
-    <google.storage.version>1.75.0</google.storage.version>
+    <google.storage.version>1.106.0</google.storage.version>
     <gson.version>2.6.2</gson.version>
     <guava.retrying.version>2.0.0</guava.retrying.version>
     <guava.version>20.0</guava.version>
@@ -116,7 +116,7 @@
     <netty.version>4.1.16.Final</netty.version>
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
     <poi.version>3.16</poi.version>
-    <protobuf.version>3.4.0</protobuf.version>
+    <protobuf.version>3.11.3</protobuf.version>
     <reflections.version>0.9.9</reflections.version>
     <simmetrics.version>4.1.1</simmetrics.version>
     <simplemagic.version>1.11</simplemagic.version>
@@ -146,6 +146,16 @@
       </snapshots>
     </repository>
   </repositories>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -29,7 +29,7 @@
     <app.main.class>io.cdap.wrangler.DataPrep</app.main.class>
     <tika.version>1.14</tika.version>
     <hadoop.version>2.3.0</hadoop.version>
-    <google.cloud.spanner.version>1.20.0</google.cloud.spanner.version>
+    <google.cloud.spanner.version>1.51.0</google.cloud.spanner.version>
   </properties>
 
   <dependencies>

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/bigquery/BigQueryHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/bigquery/BigQueryHandler.java
@@ -32,6 +32,7 @@ import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.annotations.VisibleForTesting;
@@ -101,6 +102,7 @@ public class BigQueryHandler extends AbstractWranglerHandler {
   private static final String TABLE_ID = "id";
   private static final String SCHEMA = "schema";
   private static final String BUCKET = "bucket";
+  private static final String VIEW = "view";
 
   @POST
   @Path("/contexts/{context}/connections/bigquery/test")
@@ -230,6 +232,7 @@ public class BigQueryHandler extends AbstractWranglerHandler {
       properties.put(GCPUtils.SERVICE_ACCOUNT_KEYFILE, path);
       properties.put(SCHEMA, tableData.getSecond().toString());
       properties.put(BUCKET, bucket);
+      properties.put(VIEW, ConnectionType.BIGQUERY.)
 
       WorkspaceMeta workspaceMeta = WorkspaceMeta.builder(tableId)
         .setScope(scope)
@@ -297,7 +300,6 @@ public class BigQueryHandler extends AbstractWranglerHandler {
     QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query).build();
     JobId jobId = JobId.of(UUID.randomUUID().toString());
     Job queryJob = bigQuery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
-
     // Wait for the job to finish
     queryJob = queryJob.waitFor();
 


### PR DESCRIPTION
Wrangler was unable to load BigQuery datasets that contained MaterializedViews. This was caused by a bug in the BigQuery java library which was fixed in March 2020. This PR updates the Google dependencies to resolve this bug and ensure there are no version conflicts.