### PR TITLE
PLUGIN-464 fix flatten to be a no-op on empty lists

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/directives/row/Flatten.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/Flatten.java
@@ -46,7 +46,7 @@ import java.util.List;
 @Plugin(type = Directive.TYPE)
 @Name(Flatten.NAME)
 @Categories(categories = { "row"})
-@Description("Separates array elements of one or more columns into indvidual records, copying the other columns.")
+@Description("Separates array elements of one or more columns into individual records, copying the other columns.")
 public class Flatten implements Directive, Lineage {
   public static final String NAME = "flatten";
   // Column within the input row that needs to be parsed as Json
@@ -107,6 +107,11 @@ public class Flatten implements Directive, Lineage {
             max = m;
           }
         }
+      }
+
+      if (max == 0) {
+        results.add(new Row(row));
+        continue;
       }
 
       // We iterate through the arrays and populate all the columns.

--- a/wrangler-core/src/test/java/io/cdap/directives/row/FlattenTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/row/FlattenTest.java
@@ -26,12 +26,27 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * Tests {@link Flatten}
  */
 public class FlattenTest {
+
+  @Test
+  public void testEmptyList() throws Exception {
+    String[] directives = new String[] {
+      "flatten x"
+    };
+
+    Row row = new Row("x", new ArrayList<>()).add("y", "y");
+    List<Row> output = TestingRig.execute(directives, Collections.singletonList(row));
+
+    Assert.assertEquals(1, output.size());
+    Assert.assertEquals("y", output.get(0).getValue("y"));
+    Assert.assertEquals(0, ((List) output.get(0).getValue("x")).size());
+  }
 
   /**
    * { col1, col2, col3}


### PR DESCRIPTION
Fixed a bug where input rows with an empty list would get
filtered out by the flatten directive.