### PR TITLE
Support datetime datatype and datetime directives in Wrangler

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/ErrorRowException.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/ErrorRowException.java
@@ -29,6 +29,11 @@ public class ErrorRowException extends Exception {
   private boolean showInWrangler;
 
   public ErrorRowException(String message, int code, boolean showInWrangler) {
+    this(message, code, showInWrangler, null);
+  }
+
+  public ErrorRowException(String message, int code, boolean showInWrangler, Throwable cause) {
+    super(message, cause);
     this.message = message;
     this.code = code;
     this.showInWrangler = showInWrangler;
@@ -39,7 +44,11 @@ public class ErrorRowException extends Exception {
   }
 
   public ErrorRowException(String directiveName, String errorMessage, int code) {
-    this(String.format("%s (ecode: %d, directive: %s)", errorMessage, code, directiveName), code);
+    this(directiveName, errorMessage, code, null);
+  }
+
+  public ErrorRowException(String directiveName, String errorMessage, int code, Throwable cause) {
+    this(String.format("%s (ecode: %d, directive: %s)", errorMessage, code, directiveName), code, false, cause);
   }
 
   /**

--- a/wrangler-core/src/main/java/io/cdap/directives/datetime/CurrentDateTime.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/datetime/CurrentDateTime.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.datetime;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Optional;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.lineage.Lineage;
+import io.cdap.wrangler.api.lineage.Mutation;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.zone.ZoneRulesException;
+import java.util.List;
+
+/**
+ * Directive for generating current datetime with the specified zone
+ */
+@Plugin(type = Directive.TYPE)
+@Name("current-datetime")
+@Categories(categories = {"datetime"})
+@Description("Generates current datetime using the given zone")
+public class CurrentDateTime implements Directive, Lineage {
+
+  public static final String NAME = "current-datetime";
+  private static final String COLUMN = "column";
+  private static final String ZONE = "timezone";
+  private static final String UTC = "UTC";
+  private String column;
+  private String zone;
+  private ZoneId zoneId;
+
+  @Override
+  public UsageDefinition define() {
+    UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+    builder.define(COLUMN, TokenType.COLUMN_NAME);
+    builder.define(ZONE, TokenType.TEXT, Optional.TRUE);
+    return builder.build();
+  }
+
+  @Override
+  public void initialize(Arguments args) throws DirectiveParseException {
+    this.column = ((ColumnName) args.value(COLUMN)).value();
+    if (args.value(ZONE) == null) {
+      this.zone = UTC;
+      this.zoneId = ZoneId.of(UTC);
+      return;
+    }
+
+    this.zone = args.value(ZONE).value().toString();
+    try {
+      this.zoneId = ZoneId.of(this.zone);
+    } catch (IllegalArgumentException | ZoneRulesException exception) {
+      throw new DirectiveParseException(NAME, String.format("Zone '%s' is invalid.", this.zone), exception);
+    }
+  }
+
+  @Override
+  public List<Row> execute(List<Row> rows, ExecutorContext context) {
+    for (Row row : rows) {
+      row.addOrSet(column, LocalDateTime.now(zoneId));
+    }
+    return rows;
+  }
+
+  @Override
+  public void destroy() {
+    //no op
+  }
+
+  @Override
+  public Mutation lineage() {
+    return Mutation.builder()
+      .readable("Generated current datetime for column '%s' with zone '%s'", column, zone)
+      .relation(column, column)
+      .build();
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/datetime/DateTimeToTimeStamp.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/datetime/DateTimeToTimeStamp.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.datetime;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ErrorRowException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Optional;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.lineage.Lineage;
+import io.cdap.wrangler.api.lineage.Mutation;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.zone.ZoneRulesException;
+import java.util.List;
+
+/**
+ * Directive for converting a datetime column to timestamp with the specified zone
+ */
+@Plugin(type = Directive.TYPE)
+@Name("datetime-to-timestamp")
+@Categories(categories = {"datetime"})
+@Description("Converts a datetime column to timestamp")
+public class DateTimeToTimeStamp implements Directive, Lineage {
+
+  public static final String NAME = "datetime-to-timestamp";
+  private static final String COLUMN = "column";
+  private static final String ZONE = "timezone";
+  private String column;
+  private String zone;
+  private ZoneId zoneId;
+
+  @Override
+  public UsageDefinition define() {
+    UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+    builder.define(COLUMN, TokenType.COLUMN_NAME);
+    builder.define(ZONE, TokenType.TEXT, Optional.TRUE);
+    return builder.build();
+  }
+
+  @Override
+  public void initialize(Arguments args) throws DirectiveParseException {
+    this.column = ((ColumnName) args.value(COLUMN)).value();
+    if (args.value(ZONE) == null) {
+      this.zoneId = ZoneId.of("UTC");
+      this.zone = this.zoneId.toString();
+      return;
+    }
+    this.zone = args.value(ZONE).value().toString();
+    try {
+      this.zoneId = ZoneId.of(this.zone);
+    } catch (IllegalArgumentException | ZoneRulesException exception) {
+      throw new DirectiveParseException(NAME, String.format("Zone '%s' is invalid.", this.zone), exception);
+    }
+  }
+
+  @Override
+  public List<Row> execute(List<Row> rows, ExecutorContext context) throws ErrorRowException {
+    for (Row row : rows) {
+      int idx = row.find(column);
+      if (idx == -1) {
+        continue;
+      }
+      Object value = row.getValue(idx);
+      // If the data in the cell is null, then skip this row.
+      if (value == null) {
+        continue;
+      }
+
+      if (!(value instanceof LocalDateTime)) {
+        throw new ErrorRowException(NAME, String.format("Value %s for column %s expected to be datetime but found %s",
+                                                        value.toString(), column, value.getClass().getSimpleName()), 2);
+      }
+
+      ZonedDateTime zonedDateTime = ZonedDateTime.of((LocalDateTime) value, zoneId);
+      row.setValue(idx, zonedDateTime);
+    }
+    return rows;
+  }
+
+  @Override
+  public void destroy() {
+    //no op
+  }
+
+  @Override
+  public Mutation lineage() {
+    return Mutation.builder()
+      .readable("Datetime column '%s' converted to timestamp with zone '%s'", column, zone)
+      .relation(column, column)
+      .build();
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/datetime/FormatDateTime.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/datetime/FormatDateTime.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.datetime;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ErrorRowException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Optional;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.lineage.Lineage;
+import io.cdap.wrangler.api.lineage.Mutation;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Directive to format a datetime column as a string in the specified format
+ */
+@Plugin(type = Directive.TYPE)
+@Name("format-datetime")
+@Categories(categories = {"format", "datetime"})
+@Description("Formats a datetime value to a string using the given format")
+public class FormatDateTime implements Directive, Lineage {
+
+  public static final String NAME = "format-datetime";
+  private static final String COLUMN = "column";
+  private static final String FORMAT = "format";
+  private String column;
+  private String format;
+  private DateTimeFormatter formatter;
+
+  @Override
+  public UsageDefinition define() {
+    UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+    builder.define(COLUMN, TokenType.COLUMN_NAME);
+    builder.define(FORMAT, TokenType.TEXT, Optional.FALSE);
+    return builder.build();
+  }
+
+  @Override
+  public void initialize(Arguments args) throws DirectiveParseException {
+    this.column = ((ColumnName) args.value(COLUMN)).value();
+    this.format = args.value(FORMAT).value().toString();
+    try {
+      this.formatter = DateTimeFormatter.ofPattern(this.format);
+    } catch (IllegalArgumentException exception) {
+      throw new DirectiveParseException(NAME, String.format("Datetime format '%s' is invalid.", this.format),
+                                        exception);
+    }
+  }
+
+  @Override
+  public List<Row> execute(List<Row> rows, ExecutorContext context) throws ErrorRowException {
+    for (Row row : rows) {
+      int idx = row.find(column);
+      if (idx == -1) {
+        continue;
+      }
+      Object value = row.getValue(idx);
+      // If the data in the cell is null, then skip this row.
+      if (value == null) {
+        continue;
+      }
+
+      if (!(value instanceof LocalDateTime)) {
+        throw new ErrorRowException(NAME, String.format("Value %s for column %s expected to be datetime but found %s",
+                                                        value.toString(), column, value.getClass().getSimpleName()), 2);
+      }
+
+      try {
+        LocalDateTime localDateTime = (LocalDateTime) value;
+        row.setValue(idx, localDateTime.format(formatter));
+      } catch (DateTimeException exception) {
+        throw new ErrorRowException(NAME, String.format("Error converting datetime %s to string with format %s",
+                                                        value.toString(), format), 2, exception);
+      }
+    }
+    return rows;
+  }
+
+  @Override
+  public void destroy() {
+    //no op
+  }
+
+  @Override
+  public Mutation lineage() {
+    return Mutation.builder()
+      .readable("Datetime column '%s' converted to string with format '%s'", column, format)
+      .relation(column, column)
+      .build();
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/datetime/TimestampToDateTime.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/datetime/TimestampToDateTime.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.datetime;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.ErrorRowException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.lineage.Lineage;
+import io.cdap.wrangler.api.lineage.Mutation;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * Directive for parsing a timestamp column as DateTime
+ */
+@Plugin(type = Directive.TYPE)
+@Name("timestamp-to-datetime")
+@Categories(categories = {"datetime"})
+@Description("Convert a timestamp column to datetime")
+public class TimestampToDateTime implements Directive, Lineage {
+
+  public static final String NAME = "timestamp-to-datetime";
+  private static final String COLUMN = "column";
+  private String column;
+
+  @Override
+  public UsageDefinition define() {
+    UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+    builder.define(COLUMN, TokenType.COLUMN_NAME);
+    return builder.build();
+  }
+
+  @Override
+  public void initialize(Arguments args) {
+    this.column = ((ColumnName) args.value(COLUMN)).value();
+  }
+
+  @Override
+  public List<Row> execute(List<Row> rows, ExecutorContext context) throws ErrorRowException {
+    for (Row row : rows) {
+      int idx = row.find(column);
+      if (idx == -1) {
+        continue;
+      }
+      Object value = row.getValue(idx);
+      // If the data in the cell is null or is already Datetime , then skip this row.
+      if (value == null || value instanceof LocalDateTime) {
+        continue;
+      }
+
+      if (!(value instanceof ZonedDateTime)) {
+        throw new ErrorRowException(NAME, String.format("Value %s for column %s expected to be timestamp but found %s",
+                                                        value.toString(), column, value.getClass().getSimpleName()), 2);
+      }
+
+      ZonedDateTime timestamp = (ZonedDateTime) value;
+      row.setValue(idx, timestamp.toLocalDateTime());
+    }
+    return rows;
+  }
+
+  @Override
+  public void destroy() {
+    //no op
+  }
+
+  @Override
+  public Mutation lineage() {
+    return Mutation.builder()
+      .readable("Converted column '%s' from timestamp to datetime", column)
+      .relation(column, column)
+      .build();
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/ParseDateTime.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/ParseDateTime.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.parser;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ErrorRowException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Optional;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.lineage.Lineage;
+import io.cdap.wrangler.api.lineage.Mutation;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+/**
+ * Directive for parsing a string in the specified format to DateTime.
+ */
+@Plugin(type = Directive.TYPE)
+@Name("parse-as-datetime")
+@Categories(categories = {"parser", "datetime"})
+@Description("Parse a column value as datetime using the given format")
+public class ParseDateTime implements Directive, Lineage {
+
+  public static final String NAME = "parse-as-datetime";
+  private static final String COLUMN = "column";
+  private static final String FORMAT = "format";
+  private String column;
+  private String format;
+  private DateTimeFormatter formatter;
+
+  @Override
+  public UsageDefinition define() {
+    UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+    builder.define(COLUMN, TokenType.COLUMN_NAME);
+    builder.define(FORMAT, TokenType.TEXT, Optional.FALSE);
+    return builder.build();
+  }
+
+  @Override
+  public void initialize(Arguments args) throws DirectiveParseException {
+    this.column = ((ColumnName) args.value(COLUMN)).value();
+    this.format = args.value(FORMAT).value().toString();
+    try {
+      this.formatter = DateTimeFormatter.ofPattern(this.format);
+    } catch (IllegalArgumentException exception) {
+      throw new DirectiveParseException(NAME, String.format("'%s' is an invalid datetime format.", this.format),
+                                        exception);
+    }
+  }
+
+  @Override
+  public List<Row> execute(List<Row> rows, ExecutorContext context) throws ErrorRowException {
+    for (Row row : rows) {
+      int idx = row.find(column);
+      if (idx == -1) {
+        continue;
+      }
+      Object value = row.getValue(idx);
+      // If the data in the cell is null or is already Datetime , then skip this row.
+      if (value == null || value instanceof LocalDateTime) {
+        continue;
+      }
+
+      try {
+        LocalDateTime localDateTime = LocalDateTime.parse(value.toString(), formatter);
+        row.setValue(idx, localDateTime);
+      } catch (DateTimeParseException exception) {
+        throw new ErrorRowException(NAME, String.format("Value %s for column %s is not in expected format %s",
+                                                        value.toString(), column, format), 2, exception);
+      }
+    }
+    return rows;
+  }
+
+  @Override
+  public void destroy() {
+    //no op
+  }
+
+  @Override
+  public Mutation lineage() {
+    return Mutation.builder()
+      .readable("Parsed column '%s' in format '%s' as datetime", column, format)
+      .relation(column, column)
+      .build();
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/executor/RecipePipelineExecutor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/executor/RecipePipelineExecutor.java
@@ -141,6 +141,7 @@ public final class RecipePipelineExecutor implements RecipePipeline<Row, Structu
           }
           results.addAll(cumulativeRows);
         } catch (ErrorRowException e) {
+          LOG.debug("Error while applying directives", e);
           messages.add(String.format("%s", e.getMessage()));
           collector
             .add(new ErrorRecord(rows.subList(i, i + 1).get(0), String.join(",", messages), e.getCode(),

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/Json2Schema.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/Json2Schema.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.Schema.LogicalType;
 import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
 import io.cdap.cdap.internal.guava.reflect.TypeToken;
 import io.cdap.cdap.internal.io.AbstractSchemaGenerator;
@@ -35,6 +36,7 @@ import java.nio.ByteBuffer;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -116,6 +118,10 @@ public final class Json2Schema {
 
     if (value instanceof ZonedDateTime) {
       return Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS));
+    }
+
+    if (value instanceof LocalDateTime) {
+      return Schema.nullableOf(Schema.of(LogicalType.DATETIME));
     }
 
     // TODO - remove all the instaces of java.util.Date once all the directives support LogicalType.

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/RecordConvertor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/RecordConvertor.java
@@ -32,6 +32,7 @@ import io.cdap.wrangler.api.Row;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -91,6 +92,8 @@ public final class RecordConvertor implements Serializable {
           builder.setTimestamp(name, (ZonedDateTime) decodedObj);
         } else if (decodedObj instanceof BigDecimal) {
           builder.setDecimal(name, (BigDecimal) decodedObj);
+        } else if (decodedObj instanceof LocalDateTime) {
+          builder.setDateTime(name, (LocalDateTime) decodedObj);
         } else {
           builder.set(name, decodedObj);
         }
@@ -119,6 +122,7 @@ public final class RecordConvertor implements Serializable {
         case TIMESTAMP_MILLIS:
         case TIMESTAMP_MICROS:
         case DECIMAL:
+        case DATETIME:
           return object;
         default:
           throw new UnexpectedFormatException("field type " + logicalType + " is not supported.");

--- a/wrangler-core/src/test/java/io/cdap/directives/datetime/CurrentDateTimeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/datetime/CurrentDateTimeTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.datetime;
+
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.RecipeException;
+import io.cdap.wrangler.api.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class CurrentDateTimeTest {
+
+  @Test
+  public void testDefaultZone() throws Exception {
+    String colName = "col1";
+    String[] directives = new String[]{
+      String.format("%s :%s", CurrentDateTime.NAME, colName)
+    };
+    Row row1 = new Row();
+    row1.add(colName, null);
+    List<Row> result = TestingRig.execute(directives, Collections.singletonList(row1));
+    Assert.assertTrue(result.get(0).getValue(colName) instanceof LocalDateTime);
+  }
+
+  @Test
+  public void testAddColumn() throws Exception {
+    String colName = "col1";
+    String[] directives = new String[]{
+      String.format("%s :%s", CurrentDateTime.NAME, colName)
+    };
+    //Skip column - it should be automatically added
+    Row row1 = new Row();
+    Row row2 = new Row();
+    List<Row> result = TestingRig.execute(directives, Arrays.asList(row1, row2));
+    Row resultRow1 = result.get(0);
+    Assert.assertEquals(1, resultRow1.width());
+    Assert.assertTrue(resultRow1.getValue(colName) instanceof LocalDateTime);
+    Row resultRow2 = result.get(1);
+    Assert.assertEquals(1, resultRow2.width());
+    Assert.assertTrue(resultRow2.getValue(colName) instanceof LocalDateTime);
+  }
+
+  @Test(expected = RecipeException.class)
+  public void testInvalidZone() throws Exception {
+    String zone = "abcd";
+    String colName = "col1";
+    String[] directives = new String[]{String.format("%s :%s '%s'", CurrentDateTime.NAME, colName, zone)};
+    Row row1 = new Row();
+    row1.add(colName, null);
+    TestingRig.execute(directives, Collections.singletonList(row1));
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/datetime/DateTimeToTimestampTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/datetime/DateTimeToTimestampTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.datetime;
+
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.RecipeException;
+import io.cdap.wrangler.api.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+
+public class DateTimeToTimestampTest {
+
+  @Test
+  public void testZones() throws Exception {
+    String[] testZones = new String[]{"UTC", "GMT", "Australia/Sydney", "America/Los_Angeles"};
+    String[] colNames = new String[]{"col1", "col2", "col3", "col4"};
+    LocalDateTime localDateTime = LocalDateTime.of(2000, 8, 22, 20, 36, 45, 1234);
+    String[] directives = new String[testZones.length];
+    Row row = new Row();
+    for (int i = 0; i < testZones.length; i++) {
+      directives[i] = String.format("%s :%s \"%s\"", DateTimeToTimeStamp.NAME, colNames[i], testZones[i]);
+      row.add(colNames[i], localDateTime);
+    }
+    List<Row> rows = TestingRig.execute(directives, Collections.singletonList(row));
+
+    Assert.assertEquals(1, rows.size());
+
+    for (Row resultRow : rows) {
+      for (int i = 0; i < testZones.length; i++) {
+        Assert.assertEquals(ZonedDateTime.of(localDateTime, ZoneId.of(testZones[i])),
+                            rows.get(0).getValue(colNames[i]));
+      }
+    }
+  }
+
+  @Test
+  public void testDefaultZone() throws Exception {
+    String colName = "col1";
+    String[] directives = new String[]{String.format("%s :%s", DateTimeToTimeStamp.NAME, colName)};
+    Row row1 = new Row();
+    LocalDateTime now = LocalDateTime.now();
+    row1.add(colName, now);
+    List<Row> result = TestingRig.execute(directives, Collections.singletonList(row1));
+    Assert.assertEquals(ZonedDateTime.of(now, ZoneId.of("UTC")),
+                        result.get(0).getValue(colName));
+  }
+
+  @Test(expected = RecipeException.class)
+  public void testInvalidZone() throws Exception {
+    String zone = "abcd";
+    String colName = "col1";
+    String[] directives = new String[]{String.format("%s :%s '%s'", DateTimeToTimeStamp.NAME, colName, zone)};
+    Row row1 = new Row();
+    row1.add(colName, LocalDateTime.now());
+    TestingRig.execute(directives, Collections.singletonList(row1));
+  }
+
+  @Test
+  public void testInvalidObject() throws Exception {
+    String colName = "col1";
+    String[] directives = new String[]{String.format("%s :%s", DateTimeToTimeStamp.NAME, colName)};
+    Row row1 = new Row();
+    row1.add(colName, LocalDateTime.now().toString());
+    final List<Row> results = TestingRig.execute(directives, Collections.singletonList(row1));
+    //should be error collected
+    Assert.assertTrue(results.isEmpty());
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/datetime/FormatDateTimeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/datetime/FormatDateTimeTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.datetime;
+
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.RecipeException;
+import io.cdap.wrangler.api.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+public class FormatDateTimeTest {
+
+  @Test
+  public void testDateTimeFormats() throws Exception {
+    String[] testPatterns = new String[]{"MM/dd/yyyy HH:mm", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss[xxx]",
+      "yyyyMMdd h:mm a"};
+    String[] colNames = new String[]{"col1", "col2", "col3", "col4", "col5"};
+    LocalDateTime localDateTime = LocalDateTime.of(2000, 8, 22, 20, 36, 45, 1234);
+    String[] dateTimes = new String[]{"08/22/2000 20:36", "2000-08-22T20:36:45", "2000-08-22T20:36:45",
+      "20000822 8:36 PM"};
+    String[] directives = new String[testPatterns.length];
+    Row row = new Row();
+    for (int i = 0; i < testPatterns.length; i++) {
+      directives[i] = String.format("%s :%s \"%s\"", FormatDateTime.NAME, colNames[i], testPatterns[i]);
+      row.add(colNames[i], localDateTime);
+    }
+    List<Row> rows = TestingRig.execute(directives, Collections.singletonList(row));
+
+    Assert.assertEquals(1, rows.size());
+    for (Row resultRow : rows) {
+      for (int i = 0; i < testPatterns.length; i++) {
+        Assert.assertEquals(dateTimes[i], rows.get(0).getValue(colNames[i]));
+      }
+    }
+  }
+
+  @Test(expected = RecipeException.class)
+  public void testInvalidFormat() throws Exception {
+    String pattern = "abcd";
+    String colName = "col1";
+    String[] directives = new String[]{String.format("format-datetime :%s '%s'", colName, pattern)};
+    Row row1 = new Row();
+    row1.add(colName, LocalDateTime.now());
+    TestingRig.execute(directives, Collections.singletonList(row1));
+  }
+
+  @Test
+  public void testInvalidObject() throws Exception {
+    String pattern = "MM/dd/yyyy HH:mm";
+    String colName = "col1";
+    String datetime1 = "12/10/2016";
+    String[] directives = new String[]{String.format("format-datetime :%s '%s'", colName, pattern)};
+    Row row1 = new Row();
+    row1.add(colName, datetime1);
+
+    final List<Row> results = TestingRig.execute(directives, Collections.singletonList(row1));
+    //should be error collected
+    Assert.assertTrue(results.isEmpty());
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/datetime/TimestampToDateTimeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/datetime/TimestampToDateTimeTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.datetime;
+
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+
+public class TimestampToDateTimeTest {
+
+  @Test
+  public void testConversion() throws Exception {
+    String colName = "col1";
+    ZonedDateTime zonedDateTime = ZonedDateTime.now();
+    Row row = new Row();
+    String[] directives = new String[]{String.format("%s :%s", TimestampToDateTime.NAME, colName)};
+    row.add(colName, zonedDateTime);
+    List<Row> rows = TestingRig.execute(directives, Collections.singletonList(row));
+
+    Assert.assertEquals(1, rows.size());
+    Assert.assertEquals(zonedDateTime.toLocalDateTime(), rows.get(0).getValue(colName));
+  }
+
+  @Test
+  public void testInvalidObject() throws Exception {
+    String colName = "col1";
+    String[] directives = new String[]{String.format("%s :%s", TimestampToDateTime.NAME, colName)};
+    Row row1 = new Row();
+    row1.add(colName, LocalDateTime.now().toString());
+    final List<Row> results = TestingRig.execute(directives, Collections.singletonList(row1));
+    //should be error collected
+    Assert.assertTrue(results.isEmpty());
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/parser/ParseDateTimeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/parser/ParseDateTimeTest.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright © 2021 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.parser;
+
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.RecipeException;
+import io.cdap.wrangler.api.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class ParseDateTimeTest {
+
+  @Test
+  public void testDateTimeFormats() throws Exception {
+    String[] testPatterns = new String[]{"MM/dd/yyyy HH:mm", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss[xxx]",
+      "yyyy-MM-dd'T'HH:mm:ss[xxx]'['VV']'", "yyyyMMdd h:mm a"};
+    String[] colNames = new String[]{"col1", "col2", "col3", "col4", "col5"};
+    String[] dateTimes = new String[]{"03/30/2010 01:05", "2020-01-28T04:50:12", "2011-12-03T10:15:30+01:00",
+      "2011-12-03T10:15:30+01:00[Europe/Paris]", "19901212 10:12 AM"};
+    String[] directives = new String[testPatterns.length];
+    Row row = new Row();
+    for (int i = 0; i < testPatterns.length; i++) {
+      directives[i] = String
+        .format("%s :%s \"%s\"", ParseDateTime.NAME, colNames[i], testPatterns[i]);
+      row.add(colNames[i], dateTimes[i]);
+    }
+    List<Row> rows = TestingRig.execute(directives, Collections.singletonList(row));
+
+    Assert.assertEquals(1, rows.size());
+
+    for (Row resultRow : rows) {
+      for (int i = 0; i < testPatterns.length; i++) {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(testPatterns[i]);
+        Assert.assertEquals(LocalDateTime.parse(dateTimes[i], dateTimeFormatter),
+                            rows.get(0).getValue(colNames[i]));
+      }
+    }
+  }
+
+  @Test
+  public void testDateTimeMultipleRows() throws Exception {
+    String pattern = "MM/dd/yyyy HH:mm";
+    String colName = "col1";
+    String datetime1 = "12/10/2016 07:45";
+    String datetime2 = "02/01/1990 12:01";
+    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(pattern);
+    String[] directives = new String[]{
+      String.format("%s :%s '%s'", ParseDateTime.NAME, colName, pattern)
+    };
+    Row row1 = new Row();
+    row1.add(colName, datetime1);
+    Row row2 = new Row();
+    row2.add(colName, datetime2);
+    List<Row> rows = TestingRig.execute(directives, Arrays.asList(row1, row2));
+
+    Assert.assertEquals(2, rows.size());
+    Assert.assertEquals(LocalDateTime.parse(datetime1, dateTimeFormatter),
+                        rows.get(0).getValue(colName));
+    Assert.assertEquals(LocalDateTime.parse(datetime2, dateTimeFormatter),
+                        rows.get(1).getValue(colName));
+  }
+
+  @Test(expected = RecipeException.class)
+  public void testInvalidFormat() throws Exception {
+    String pattern = "abcd";
+    String colName = "col1";
+    String datetime1 = "12/10/2016 07:45";
+    String[] directives = new String[]{
+      String.format("parse-datetime :%s '%s'", colName, pattern)
+    };
+    Row row1 = new Row();
+    row1.add(colName, datetime1);
+    TestingRig.execute(directives, Collections.singletonList(row1));
+  }
+
+  @Test
+  public void testInvalidData() throws Exception {
+    String pattern = "MM/dd/yyyy HH:mm";
+    String colName = "col1";
+    String datetime1 = "12/10/2016";
+    String[] directives = new String[]{
+      String.format("%s :%s '%s'", ParseDateTime.NAME, colName, pattern)
+    };
+    Row row1 = new Row();
+    row1.add(colName, datetime1);
+    final List<Row> results = TestingRig.execute(directives, Collections.singletonList(row1));
+    //should be error collected
+    Assert.assertTrue(results.isEmpty());
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/registry/CompositeDirectiveRegistryTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/registry/CompositeDirectiveRegistryTest.java
@@ -112,7 +112,7 @@ public class CompositeDirectiveRegistryTest {
       iterator.next();
       count++;
     }
-    Assert.assertEquals(78, count);
+    Assert.assertEquals(83, count);
 
     registry.reload("");
 
@@ -122,7 +122,7 @@ public class CompositeDirectiveRegistryTest {
       iterator.next();
       count++;
     }
-    Assert.assertEquals(78, count);
+    Assert.assertEquals(83, count);
 
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/wrangler/utils/Json2SchemaTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/utils/Json2SchemaTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -98,6 +99,7 @@ public class Json2SchemaTest {
     testRow.add("time", LocalTime.of(11, 11, 11));
     testRow.add("timestamp", ZonedDateTime.of(2018, 11 , 11 , 11, 11, 11, 0, ZoneId.of("UTC")));
     testRow.add("d", new BigDecimal(new BigInteger("123456"), 5));
+    testRow.add("datetime", LocalDateTime.now());
 
     Json2Schema json2Schema = new Json2Schema();
     Schema actual = json2Schema.toSchema("testRecord", testRow);
@@ -110,7 +112,9 @@ public class Json2SchemaTest {
                                         Schema.of(Schema.LogicalType.TIME_MICROS))),
                                       Schema.Field.of("timestamp", Schema.nullableOf(
                                         Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))),
-                                      Schema.Field.of("d", Schema.nullableOf(Schema.decimalOf(38, 5))));
+                                      Schema.Field.of("d", Schema.nullableOf(Schema.decimalOf(38, 5))),
+                                      Schema.Field
+                                        .of("datetime", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME))));
 
     Assert.assertEquals(expected, actual);
   }

--- a/wrangler-core/src/test/java/io/cdap/wrangler/utils/RecordConvertorTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/utils/RecordConvertorTest.java
@@ -19,15 +19,18 @@ package io.cdap.wrangler.utils;
 import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.Schema.LogicalType;
 import io.cdap.wrangler.TestingRig;
 import io.cdap.wrangler.api.ErrorRecord;
 import io.cdap.wrangler.api.RecipeException;
 import io.cdap.wrangler.api.RecipePipeline;
 import io.cdap.wrangler.api.Row;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -337,5 +340,17 @@ public class RecordConvertorTest {
     List<Row> records = Collections.singletonList(row);
     List<StructuredRecord> results = pipeline.execute(records, expectedSchema);
     Assert.assertEquals(expectedSchema, results.get(0).getSchema());
+  }
+
+  @Test
+  public void testDateTimeConversion() throws RecordConvertorException {
+    String fieldName = "field";
+    LocalDateTime value = LocalDateTime.now();
+    Schema schema = Schema.recordOf("test",
+        Schema.Field.of(fieldName, Schema.nullableOf(Schema.of(LogicalType.DATETIME))));
+    Row row = new Row();
+    row.add(fieldName, value);
+    StructuredRecord structuredRecord = new RecordConvertor().decodeRecord(row, schema);
+    Assert.assertEquals(value, structuredRecord.getDateTime(fieldName));
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/bigquery/BigQueryHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/bigquery/BigQueryHandler.java
@@ -70,6 +70,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -376,6 +377,8 @@ public class BigQueryHandler extends AbstractWranglerHandler {
           schemaType = Schema.of(Schema.Type.LONG);
           break;
         case DATETIME:
+          schemaType = Schema.of(Schema.LogicalType.DATETIME);
+          break;
         case STRING:
           schemaType = Schema.of(Schema.Type.STRING);
           break;
@@ -425,6 +428,7 @@ public class BigQueryHandler extends AbstractWranglerHandler {
         return decimal;
 
       case DATETIME:
+        return LocalDateTime.parse(fieldValue.getStringValue());
       case STRING:
         return fieldValue.getStringValue();
       case BOOL:

--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -453,6 +453,8 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> {
           return input.getTimestamp(fieldName);
         case DECIMAL:
           return input.getDecimal(fieldName);
+        case DATETIME:
+          return input.getDateTime(fieldName);
         default:
           throw new UnexpectedFormatException("Field type " + logicalType + " is not supported.");
       }


### PR DESCRIPTION
- Changes for supporting datetime datatype in Wrangler
New directives
1. parse-as-datetime  - Parses string as datetime with given format
2. format-datetime - Formats datetime to a string of given format
3. current-datetime - Generates current datetime with given zone
4. timestamp-to-datetime - Converts a timestamp to datetime
5. timestamp - Creates a timestamp from datetime and given zone