### PR TITLE
CDAP-16316 fix case insensitive find

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/Row.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/Row.java
@@ -154,7 +154,7 @@ public final class Row implements Serializable {
   }
 
   /**
-   * Finds a column index based on the name of the column.
+   * Finds a column index based on the name of the column. The col name is case insensitive.
    *
    * @param col to be searched within the row.
    * @return null if not present, else the index at which the column is found.

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/ColumnConverter.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/ColumnConverter.java
@@ -28,26 +28,33 @@ public final class ColumnConverter {
   }
 
   /**
-   * Renames a column.
+   * Renames a column. The renamed column must not exist in the row. The comparision is case insensitive.
    *
    * @param row source record to be modified.
    * @param column name of the column within source record.
    * @param toName the target name of the column.
-   * @throws DirectiveExecutionException when a column matching the target name already exists.
+   * @throws DirectiveExecutionException when a column matching the target name already exists or the given column
+   * does not exist
    */
   public static void rename(String directiveName, Row row, String column, String toName)
     throws DirectiveExecutionException {
     int idx = row.find(column);
     int existingColumn = row.find(toName);
-    if (idx != -1) {
-      if (existingColumn == -1) {
-        row.setColumn(idx, toName);
-      } else {
-        throw new DirectiveExecutionException(
-          directiveName, String.format("Column '%s' already exists. Apply the 'drop %s' directive before " +
-                                         "renaming '%s' to '%s'.",
-                                       toName, toName, column, toName));
-      }
+    if (idx == -1) {
+      throw new DirectiveExecutionException(
+        directiveName, String.format("Column '%s' does not exist. Please add the column '%s' before " +
+                                       "renaming '%s' to '%s'.",
+                                     column, column, column, toName));
+    }
+
+    // if the idx are the same, this means the renamed column is same with the original column except the casing
+    if (existingColumn == -1 || idx == existingColumn) {
+      row.setColumn(idx, toName);
+    } else {
+      throw new DirectiveExecutionException(
+        directiveName, String.format("Column '%s' already exists. Apply the 'drop %s' directive before " +
+                                       "renaming '%s' to '%s'.",
+                                     toName, toName, column, toName));
     }
   }
 

--- a/wrangler-core/src/test/java/io/cdap/directives/column/RenameTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/RenameTest.java
@@ -19,6 +19,7 @@ package io.cdap.directives.column;
 import io.cdap.wrangler.TestingRig;
 import io.cdap.wrangler.api.RecipeException;
 import io.cdap.wrangler.api.Row;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -40,5 +41,40 @@ public class RenameTest {
     );
 
     TestingRig.execute(directives, rows);
+  }
+
+  @Test (expected = RecipeException.class)
+  public void testRenameCaseSensitiveFailure() throws Exception {
+    String[] directives = new String[] {
+      "rename C1 c4",
+    };
+
+    List<Row> rows = Arrays.asList(
+      new Row("C1", "A").add("C2", "B").add("C3", "C").add("C4", "D").add("C5", "E")
+    );
+
+    TestingRig.execute(directives, rows);
+  }
+
+  @Test
+  public void testRenameCaseSensitiveSuccess() throws Exception {
+    String[] directives = new String[] {
+      "rename C1 c1",
+    };
+
+    List<Row> rows = Arrays.asList(
+      new Row("C1", "A").add("C2", "B").add("C3", "C").add("C4", "D").add("C5", "E")
+    );
+
+    rows = TestingRig.execute(directives, rows);
+    Assert.assertEquals(1, rows.size());
+    Row row = rows.get(0);
+    // here compare the exact string since row is case insensitive
+    Assert.assertEquals("c1", row.getFields().get(0).getFirst());
+    Assert.assertEquals("A", row.getValue("c1"));
+    Assert.assertEquals("B", row.getValue("C2"));
+    Assert.assertEquals("C", row.getValue("C3"));
+    Assert.assertEquals("D", row.getValue("C4"));
+    Assert.assertEquals("E", row.getValue("C5"));
   }
 }


### PR DESCRIPTION
This is pretty risky and backward incompatible changes. 
But it is in need IMO because:
1. Our CDAP schema is case sensitive, so the row should be consistent with it

Therefore, it is good we make this change to make everything consistent. 
