### PR TITLE
CDAP-17732-Use UUID.randomUUID() for generating UUID

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/GenerateUUID.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/GenerateUUID.java
@@ -70,7 +70,7 @@ public class GenerateUUID implements Directive, Lineage {
   public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
     for (Row row : rows) {
       int idx = row.find(column);
-      UUID uuid = new UUID(random.nextLong(), random.nextLong());
+      UUID uuid = UUID.randomUUID();
       if (idx != -1) {
         row.setValue(idx, uuid.toString());
       } else {


### PR DESCRIPTION
Fix for [CDAP-17732](https://cdap.atlassian.net/browse/CDAP-17732) Use UUID.randomUUID() for generating UUID