### PR TITLE
CDAP-17995 change wrangler on error default

### DIFF
--- a/wrangler-transform/widgets/Wrangler-transform.json
+++ b/wrangler-transform/widgets/Wrangler-transform.json
@@ -55,7 +55,7 @@
           "widget-type": "radio-group",
           "widget-attributes": {
             "layout": "block",
-            "default": "skip-error",
+            "default": "fail-pipeline",
             "options": [
               {
                 "id": "skip-error",


### PR DESCRIPTION
Change the wrangler default back to fail pipeline. Make backend and UI defaults to the same.
Adds a hidden flag to preserve 6.3 compatibility in case any customer wants to keep 6.3 defaults, this flag will be hidden in UI.

Tried to add a unit test https://github.com/data-integrations/wrangler/blob/CDAP-17995-change-wrangler-defaults/wrangler-transform/src/test/java/io/cdap/wrangler/WranglerTest.java.
But due to https://cdap.atlassian.net/browse/CDAP-11465, wrangler uses guava 20.0, which is a higher version than the platform, the unit test cannot work.