### PR TITLE
Add new handler and deprecate all the old one

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/DirectiveConfig.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/DirectiveConfig.java
@@ -45,6 +45,7 @@ import java.util.Set;
  *   }
  *  }
  */
+@Deprecated
 public final class DirectiveConfig {
   public static final DirectiveConfig EMPTY = new DirectiveConfig();
   // RecipeParser to be excluded or made non-accessible.

--- a/wrangler-core/src/main/java/io/cdap/wrangler/registry/CompositeDirectiveRegistry.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/registry/CompositeDirectiveRegistry.java
@@ -17,6 +17,7 @@
 package io.cdap.wrangler.registry;
 
 import com.google.common.collect.Iterables;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.wrangler.api.DirectiveLoadException;
 
 import java.io.IOException;
@@ -66,6 +67,24 @@ public final class CompositeDirectiveRegistry implements DirectiveRegistry {
     for (int idx = 0; idx < registries.length; ++idx) {
       registries[idx].reload(namespace);
     }
+  }
+
+  @Nullable
+  @Override
+  public ArtifactSummary getLatestWranglerArtifact() {
+    ArtifactSummary latestArtifact = null;
+    for (DirectiveRegistry registry : registries) {
+      ArtifactSummary artifact = registry.getLatestWranglerArtifact();
+      if (artifact == null) {
+        continue;
+      }
+      if (latestArtifact == null) {
+        latestArtifact = artifact;
+      } else {
+        latestArtifact = DirectiveRegistry.pickLatest(latestArtifact, artifact);
+      }
+    }
+    return latestArtifact;
   }
 
   /**

--- a/wrangler-core/src/main/java/io/cdap/wrangler/registry/DirectiveRegistry.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/registry/DirectiveRegistry.java
@@ -16,6 +16,10 @@
 
 package io.cdap.wrangler.registry;
 
+import com.google.common.annotations.VisibleForTesting;
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.wrangler.api.DirectiveLoadException;
 
 import java.io.Closeable;
@@ -61,4 +65,28 @@ public interface DirectiveRegistry extends Closeable {
    */
   void reload(String namespace) throws DirectiveLoadException;
 
+  /**
+   * Retrieve latest Wrangler transform artifact information
+   */
+  @Nullable
+  ArtifactSummary getLatestWranglerArtifact();
+
+  /**
+   * Pick up the latest artifact, this method assumes the name of the artifact is same
+   */
+  @VisibleForTesting
+  static ArtifactSummary pickLatest(ArtifactSummary artifact1, ArtifactSummary artifact2) {
+    // first compare the artifact
+    int cmp = new ArtifactVersion(artifact1.getVersion()).compareTo(new ArtifactVersion(artifact2.getVersion()));
+    if (cmp > 0) {
+      return artifact1;
+    }
+
+    if (cmp < 0) {
+      return artifact2;
+    }
+
+    // if scope is differnt, whoever has user scope is latest
+    return artifact1.getScope().equals(ArtifactScope.USER) ? artifact1 : artifact2;
+  }
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/registry/SystemDirectiveRegistry.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/registry/SystemDirectiveRegistry.java
@@ -16,6 +16,7 @@
 
 package io.cdap.wrangler.registry;
 
+import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveLoadException;
 import org.reflections.Reflections;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListMap;
+import javax.annotation.Nullable;
 
 /**
  * This class is implementation of {@link DirectiveRegistry} for maintaining a registry
@@ -91,6 +93,12 @@ public final class SystemDirectiveRegistry implements DirectiveRegistry {
   @Override
   public void reload(String namespace) {
     // No-op.
+  }
+
+  @Nullable
+  @Override
+  public ArtifactSummary getLatestWranglerArtifact() {
+    return null;
   }
 
   /**

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/ProjectInfo.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/ProjectInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Wrangler project info
+ */
+public class ProjectInfo {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProjectInfo.class);
+  private static final String RESOURCE_NAME = "/.properties";
+  private static final String PLUGIN_VERSION = "plugin.version";
+  private static final Map<String, String> PROPERTIES;
+
+  // Initialize project properties from .properties file.
+  static {
+    Properties props = new Properties();
+    try (InputStream resourceStream = ProjectInfo.class.getResourceAsStream(RESOURCE_NAME)) {
+      props.load(resourceStream);
+    } catch (Exception e) {
+      LOG.warn("Unable to load the project properties {} ", e.getMessage(), e);
+    }
+
+    Map<String, String> properties = new HashMap<>();
+    for (String key : props.stringPropertyNames()) {
+      properties.put(key, props.getProperty(key));
+    }
+    PROPERTIES = properties;
+  }
+
+  /**
+   * @return the project properties.
+   */
+  public static Map<String, String> getProperties() {
+    return PROPERTIES;
+  }
+
+  /**
+   * @return the project version.
+   */
+  public static String getVersion() {
+    return PROPERTIES.get(PLUGIN_VERSION);
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/StructuredToRowTransformer.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/StructuredToRowTransformer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.utils;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.format.UnexpectedFormatException;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.wrangler.api.Row;
+
+/**
+ * Transformer to transform {@link StructuredRecord} to {@link Row}
+ */
+public class StructuredToRowTransformer {
+  private StructuredToRowTransformer() {
+  }
+
+  /**
+   * Get the row from the given transform.
+   *
+   * @param record the record to transform
+   * @return the row corresponding to the record
+   */
+  public static Row transform(StructuredRecord record) {
+    Row row = new Row();
+    for (Schema.Field field : record.getSchema().getFields()) {
+      row.add(field.getName(), getValue(record, field.getName()));
+    }
+    return row;
+  }
+
+  /**
+   * Get the field value from the given record
+   *
+   * @param input input record
+   * @param fieldName field name to get value from
+   * @return the value of the field in the row
+   */
+  public static Object getValue(StructuredRecord input, String fieldName) {
+    Schema fieldSchema = input.getSchema().getField(fieldName).getSchema();
+    fieldSchema = fieldSchema.isNullable() ? fieldSchema.getNonNullable() : fieldSchema;
+    Schema.LogicalType logicalType = fieldSchema.getLogicalType();
+
+    if (logicalType != null) {
+      switch (logicalType) {
+        case DATE:
+          return input.getDate(fieldName);
+        case TIME_MILLIS:
+        case TIME_MICROS:
+          return input.getTime(fieldName);
+        case TIMESTAMP_MILLIS:
+        case TIMESTAMP_MICROS:
+          return input.getTimestamp(fieldName);
+        case DECIMAL:
+          return input.getDecimal(fieldName);
+        case DATETIME:
+          return input.getDateTime(fieldName);
+        default:
+          throw new UnexpectedFormatException("Field type " + logicalType + " is not supported.");
+      }
+    }
+
+    // If the logical type is present in complex types, it will be retrieved as corresponding
+    // simple type (int/long).
+    return input.get(fieldName);
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/registry/CompositeDirectiveRegistryTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/registry/CompositeDirectiveRegistryTest.java
@@ -19,6 +19,7 @@ package io.cdap.wrangler.registry;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.ExecutorContext;
@@ -91,6 +92,12 @@ public class CompositeDirectiveRegistryTest {
     @Override
     public void reload(String namespace) {
       // no-op
+    }
+
+    @Nullable
+    @Override
+    public ArtifactSummary getLatestWranglerArtifact() {
+      return null;
     }
 
     @Override

--- a/wrangler-core/src/test/java/io/cdap/wrangler/registry/DirectiveRegistryTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/registry/DirectiveRegistryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.registry;
+
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for directive registry
+ */
+public class DirectiveRegistryTest {
+
+  @Test
+  public void testArtifactCompare() throws Exception {
+    ArtifactSummary summary1 = new ArtifactSummary("wrangler-transform", "1.0.0", ArtifactScope.USER);
+    ArtifactSummary summary2 = new ArtifactSummary("wrangler-transform", "1.0.1", ArtifactScope.SYSTEM);
+    Assert.assertEquals(summary2, DirectiveRegistry.pickLatest(summary1, summary2));
+
+    summary2 = new ArtifactSummary("wrangler-transform", "1.0.0", ArtifactScope.SYSTEM);
+    Assert.assertEquals(summary1, DirectiveRegistry.pickLatest(summary1, summary2));
+
+    summary1 = new ArtifactSummary("wrangler-transform", "2.0.0", ArtifactScope.SYSTEM);
+    Assert.assertEquals(summary1, DirectiveRegistry.pickLatest(summary1, summary2));
+  }
+}

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/Artifact.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/Artifact.java
@@ -18,32 +18,35 @@
 package io.cdap.wrangler.proto.workspace.v2;
 
 import java.util.Objects;
-import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
- * Spec for the workspace sample
+ * An artifact.
  */
-public class SampleSpec {
-  private final String connectionName;
-  private final String path;
-  private final Set<StageSpec> relatedPlugins;
+public class Artifact {
+  private final String name;
+  private final String version;
+  private final String scope;
 
-  public SampleSpec(String connectionName, String path, Set<StageSpec> relatedPlugins) {
-    this.connectionName = connectionName;
-    this.path = path;
-    this.relatedPlugins = relatedPlugins;
+  public Artifact(String name, String version, String scope) {
+    this.name = name;
+    this.version = version;
+    this.scope = scope;
   }
 
-  public String getConnectionName() {
-    return connectionName;
+  @Nullable
+  public String getName() {
+    return name;
   }
 
-  public String getPath() {
-    return path;
+  @Nullable
+  public String getVersion() {
+    return version;
   }
 
-  public Set<StageSpec> getRelatedPlugins() {
-    return relatedPlugins;
+  @Nullable
+  public String getScope() {
+    return scope;
   }
 
   @Override
@@ -51,19 +54,17 @@ public class SampleSpec {
     if (this == o) {
       return true;
     }
-
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
-    SampleSpec that = (SampleSpec) o;
-    return Objects.equals(connectionName, that.connectionName) &&
-             Objects.equals(path, that.path) &&
-             Objects.equals(relatedPlugins, that.relatedPlugins);
+    Artifact artifact = (Artifact) o;
+    return Objects.equals(name, artifact.name) &&
+             Objects.equals(version, artifact.version) &&
+             Objects.equals(scope, artifact.scope);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(connectionName, path, relatedPlugins);
+    return Objects.hash(name, version, scope);
   }
 }

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/DirectiveExecutionRequest.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/DirectiveExecutionRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.proto.workspace.v2;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Directive execution request for v2 endpoint
+ */
+public class DirectiveExecutionRequest {
+  private final List<String> directives;
+  private final int limit;
+
+  public DirectiveExecutionRequest(List<String> directives, int limit) {
+    this.directives = directives;
+    this.limit = limit;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public List<String> getDirectives() {
+    return directives == null ? Collections.emptyList() : directives;
+  }
+}

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/DirectiveExecutionResponse.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/DirectiveExecutionResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.proto.workspace.v2;
+
+import io.cdap.wrangler.proto.workspace.WorkspaceValidationResult;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * V2 version of execution response
+ */
+public class DirectiveExecutionResponse extends ServiceResponse<Map<String, Object>> {
+  private final Set<String> headers;
+  private final Map<String, String> types;
+  private final WorkspaceValidationResult summary;
+
+  public DirectiveExecutionResponse(List<Map<String, Object>> values, Set<String> headers, Map<String, String> types,
+                                    WorkspaceValidationResult summary) {
+    super(values);
+    this.headers = headers;
+    this.types = types;
+    this.summary = summary;
+  }
+
+  public Set<String> getHeaders() {
+    return headers;
+  }
+
+  public Map<String, String> getTypes() {
+    return types;
+  }
+
+  public WorkspaceValidationResult getSummary() {
+    return summary;
+  }
+}

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/DirectiveUsage.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/DirectiveUsage.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.proto.workspace.v2;
+
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+/**
+ * V2 version for directives
+ */
+public class DirectiveUsage {
+  private final String directive;
+  private final String usage;
+  private final String description;
+  private final String scope;
+  private final UsageDefinition arguments;
+  private final String[] categories;
+
+  public DirectiveUsage(String directive, String usage, String description, String scope,
+                        UsageDefinition arguments, String[] categories) {
+    this.directive = directive;
+    this.usage = usage;
+    this.description = description;
+    this.scope = scope;
+    this.arguments = arguments;
+    this.categories = categories;
+  }
+
+  public String getDirective() {
+    return directive;
+  }
+
+  public String getUsage() {
+    return usage;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public UsageDefinition getArguments() {
+    return arguments;
+  }
+
+  public String[] getCategories() {
+    return categories;
+  }
+}

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/Plugin.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/Plugin.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.proto.workspace.v2;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Plugin information
+ */
+public class Plugin {
+  private final String name;
+  private final String type;
+  private final Map<String, String> properties;
+  private final Artifact artifact;
+
+  public Plugin(String name, String type, Map<String, String> properties, Artifact artifact) {
+    this.name = name;
+    this.type = type;
+    this.properties = properties;
+    this.artifact = artifact;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public Artifact getArtifact() {
+    return artifact;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Plugin that = (Plugin) o;
+    return Objects.equals(name, that.name) &&
+             Objects.equals(type, that.type) &&
+             Objects.equals(properties, that.properties) &&
+             Objects.equals(artifact, that.artifact);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, properties, artifact);
+  }
+}

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/ServiceResponse.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/ServiceResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -12,15 +12,16 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 
-package io.cdap.wrangler.proto;
+package io.cdap.wrangler.proto.workspace.v2;
 
 import java.util.Collection;
 import java.util.Collections;
 
 /**
- * Service response.
+ * Service response for v2 endpoints.
  *
  * @param <T> type of value returned by the response
  */
@@ -28,14 +29,11 @@ public class ServiceResponse<T> {
   private final String message;
   private final Integer count;
   private final Collection<T> values;
-  // TODO: (CDAP-14652) see if this is used by UI. It should be a boolean and not a string...
-  private final String truncated;
 
   public ServiceResponse(String message) {
     this.message = message;
     this.count = null;
     this.values = Collections.emptyList();
-    this.truncated = null;
   }
 
   public ServiceResponse(T value) {
@@ -43,18 +41,13 @@ public class ServiceResponse<T> {
   }
 
   public ServiceResponse(Collection<T> values) {
-    this(values, false);
+    this(values, "Success");
   }
 
-  public ServiceResponse(Collection<T> values, boolean truncated) {
-    this(values, truncated, "Success");
-  }
-
-  public ServiceResponse(Collection<T> values, boolean truncated, String message) {
+  public ServiceResponse(Collection<T> values, String message) {
     this.message = message;
     this.count = values.size();
     this.values = values;
-    this.truncated = Boolean.toString(truncated);
   }
 
   public String getMessage() {
@@ -69,3 +62,4 @@ public class ServiceResponse<T> {
     return values;
   }
 }
+

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/StageSpec.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/StageSpec.java
@@ -17,33 +17,30 @@
 
 package io.cdap.wrangler.proto.workspace.v2;
 
+import io.cdap.cdap.api.data.schema.Schema;
+
 import java.util.Objects;
-import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
- * Spec for the workspace sample
+ * Stage spec for a plugin
  */
-public class SampleSpec {
-  private final String connectionName;
-  private final String path;
-  private final Set<StageSpec> relatedPlugins;
+public class StageSpec {
+  private final Schema schema;
+  private final Plugin plugin;
 
-  public SampleSpec(String connectionName, String path, Set<StageSpec> relatedPlugins) {
-    this.connectionName = connectionName;
-    this.path = path;
-    this.relatedPlugins = relatedPlugins;
+  public StageSpec(@Nullable Schema schema, Plugin plugin) {
+    this.schema = schema;
+    this.plugin = plugin;
   }
 
-  public String getConnectionName() {
-    return connectionName;
+  @Nullable
+  public Schema getSchema() {
+    return schema;
   }
 
-  public String getPath() {
-    return path;
-  }
-
-  public Set<StageSpec> getRelatedPlugins() {
-    return relatedPlugins;
+  public Plugin getPlugin() {
+    return plugin;
   }
 
   @Override
@@ -56,14 +53,13 @@ public class SampleSpec {
       return false;
     }
 
-    SampleSpec that = (SampleSpec) o;
-    return Objects.equals(connectionName, that.connectionName) &&
-             Objects.equals(path, that.path) &&
-             Objects.equals(relatedPlugins, that.relatedPlugins);
+    StageSpec stageSpec = (StageSpec) o;
+    return Objects.equals(schema, stageSpec.schema) &&
+             Objects.equals(plugin, stageSpec.plugin);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(connectionName, path, relatedPlugins);
+    return Objects.hash(schema, plugin);
   }
 }

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/WorkspaceCreationRequest.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/WorkspaceCreationRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.proto.workspace.v2;
+
+import io.cdap.cdap.etl.api.connector.SampleRequest;
+
+/**
+ * Creation request for a workspace
+ */
+public class WorkspaceCreationRequest {
+  private final String connection;
+  private final SampleRequest sampleRequest;
+
+  public WorkspaceCreationRequest(String connection, SampleRequest sampleRequest) {
+    this.connection = connection;
+    this.sampleRequest = sampleRequest;
+  }
+
+  public String getConnection() {
+    return connection;
+  }
+
+  public SampleRequest getSampleRequest() {
+    return sampleRequest;
+  }
+}

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/WorkspaceSpec.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/WorkspaceSpec.java
@@ -19,31 +19,27 @@ package io.cdap.wrangler.proto.workspace.v2;
 
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
- * Spec for the workspace sample
+ * Workspace specification
  */
-public class SampleSpec {
-  private final String connectionName;
-  private final String path;
-  private final Set<StageSpec> relatedPlugins;
+public class WorkspaceSpec {
+  private final Set<StageSpec> sources;
+  private final StageSpec wrangler;
 
-  public SampleSpec(String connectionName, String path, Set<StageSpec> relatedPlugins) {
-    this.connectionName = connectionName;
-    this.path = path;
-    this.relatedPlugins = relatedPlugins;
+  public WorkspaceSpec(Set<StageSpec> sources, StageSpec wrangler) {
+    this.sources = sources;
+    this.wrangler = wrangler;
   }
 
-  public String getConnectionName() {
-    return connectionName;
+  @Nullable
+  public Set<StageSpec> getSources() {
+    return sources;
   }
 
-  public String getPath() {
-    return path;
-  }
-
-  public Set<StageSpec> getRelatedPlugins() {
-    return relatedPlugins;
+  public StageSpec getWrangler() {
+    return wrangler;
   }
 
   @Override
@@ -56,14 +52,13 @@ public class SampleSpec {
       return false;
     }
 
-    SampleSpec that = (SampleSpec) o;
-    return Objects.equals(connectionName, that.connectionName) &&
-             Objects.equals(path, that.path) &&
-             Objects.equals(relatedPlugins, that.relatedPlugins);
+    WorkspaceSpec that = (WorkspaceSpec) o;
+    return Objects.equals(sources, that.sources) &&
+             Objects.equals(wrangler, that.wrangler);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(connectionName, path, relatedPlugins);
+    return Objects.hash(sources, wrangler);
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/DataPrepService.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/DataPrepService.java
@@ -27,6 +27,7 @@ import io.cdap.wrangler.service.connections.ConnectionHandler;
 import io.cdap.wrangler.service.connections.ConnectionTypeConfig;
 import io.cdap.wrangler.service.database.DatabaseHandler;
 import io.cdap.wrangler.service.directive.DirectivesHandler;
+import io.cdap.wrangler.service.directive.WorkspaceHandler;
 import io.cdap.wrangler.service.explorer.FilesystemExplorer;
 import io.cdap.wrangler.service.gcs.GCSHandler;
 import io.cdap.wrangler.service.kafka.KafkaHandler;
@@ -69,5 +70,6 @@ public class DataPrepService extends AbstractSystemService {
     addHandler(new BigQueryHandler());
     addHandler(new SpannerHandler());
     addHandler(new DataModelHandler());
+    addHandler(new WorkspaceHandler());
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/adls/ADLSHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/adls/ADLSHandler.java
@@ -81,6 +81,7 @@ import javax.ws.rs.QueryParam;
 /**
  * Service to explore ADLS Gen1 filesystem.
  */
+@Deprecated
 public class ADLSHandler extends AbstractWranglerHandler {
   private static final String COLUMN_NAME = "body";
   private static final int FILE_SIZE = 10 * 1024 * 1024;

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/bigquery/BigQueryHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/bigquery/BigQueryHandler.java
@@ -97,6 +97,7 @@ import javax.ws.rs.QueryParam;
 /**
  * Service for testing, browsing, and reading using a BigQuery connection.
  */
+@Deprecated
 public class BigQueryHandler extends AbstractWranglerHandler {
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryHandler.class);
   private static final String DATASET_ID = "datasetId";

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/common/AbstractWranglerHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/common/AbstractWranglerHandler.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
@@ -162,6 +161,58 @@ public class AbstractWranglerHandler extends AbstractSystemHttpServiceHandler {
 
   /**
    * Utility method for executing an endpoint with common error handling and namespace checks built in.
+   *
+   * If the callable throws a {@link StatusCodeException}, the exception's status code and message will be used
+   * to create the response.
+   * If a {@link JsonSyntaxException} is thrown, a 400 response will be sent.
+   * If anything else if thrown, a 500 response will be sent.
+   * If nothing is thrown, the result of the callable will be sent as json.
+   *
+   * @param responder the http responder
+   * @param namespace the namespace to check for
+   * @param runnable the endpoint logic to run
+   */
+  protected void respond(HttpServiceResponder responder, String namespace,
+                         NamespacedResponderRunnable runnable) {
+    // system namespace does not officially exist, so don't check existence for system namespace.
+    NamespaceSummary namespaceSummary;
+    if (Contexts.SYSTEM.equals(namespace)) {
+      namespaceSummary = new NamespaceSummary(Contexts.SYSTEM, "", 0L);
+    } else {
+      try {
+        namespaceSummary = getContext().getAdmin().getNamespaceSummary(namespace);
+        if (namespaceSummary == null) {
+          responder.sendJson(HttpURLConnection.HTTP_NOT_FOUND,
+                             new io.cdap.wrangler.proto.workspace.v2.ServiceResponse<>(
+                               String.format("Namespace '%s' does not exist", namespace)));
+          return;
+        }
+      } catch (IOException e) {
+        responder.sendJson(HttpURLConnection.HTTP_INTERNAL_ERROR,
+                           new io.cdap.wrangler.proto.workspace.v2.ServiceResponse<>(e.getMessage()));
+        return;
+      }
+    }
+
+    try {
+      runnable.respond(namespaceSummary);
+    } catch (StatusCodeException e) {
+      responder.sendJson(e.getCode(), new io.cdap.wrangler.proto.workspace.v2.ServiceResponse<>(e.getMessage()));
+    } catch (ErrorRecordsException e) {
+      responder.sendJson(HttpURLConnection.HTTP_BAD_REQUEST,
+                         new io.cdap.wrangler.proto.workspace.v2.ServiceResponse<>(e.getErrorRecords(),
+                                                                                   e.getMessage()));
+    } catch (JsonSyntaxException e) {
+      responder.sendJson(HttpURLConnection.HTTP_BAD_REQUEST,
+                         new io.cdap.wrangler.proto.workspace.v2.ServiceResponse<>(e.getMessage()));
+    } catch (Throwable t) {
+      responder.sendJson(HttpURLConnection.HTTP_INTERNAL_ERROR,
+                         new io.cdap.wrangler.proto.workspace.v2.ServiceResponse<>((t.getMessage())));
+    }
+  }
+
+  /**
+   * Utility method for executing an endpoint with common error handling and namespace checks built in.
    * A response will always be sent after this method is called so the http responder should not be used after this.
    * The endpoint logic should also not use the responder in any way.
    *
@@ -219,5 +270,12 @@ public class AbstractWranglerHandler extends AbstractSystemHttpServiceHandler {
    */
   protected interface NamespacedResponder<T> {
     T respond(Namespace namespace) throws Exception;
+  }
+
+  /**
+   * Responds to a request within a namespace.
+   */
+  protected interface NamespacedResponderRunnable {
+    void respond(NamespaceSummary namespace) throws Exception;
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/connections/ConnectionHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/connections/ConnectionHandler.java
@@ -58,6 +58,7 @@ import javax.ws.rs.QueryParam;
 /**
  * This service exposes REST APIs for managing the lifecycle of a connection in the connection store.
  */
+@Deprecated
 public class ConnectionHandler extends AbstractWranglerHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionHandler.class);
   private static final String CONNECTION_TYPE_CONFIG = "connectionTypeConfig";

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/database/DatabaseHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/database/DatabaseHandler.java
@@ -92,6 +92,7 @@ import javax.ws.rs.QueryParam;
 /**
  * Class description here.
  */
+@Deprecated
 public class DatabaseHandler extends AbstractWranglerHandler {
   private static final Logger LOG = LoggerFactory.getLogger(DatabaseHandler.class);
   private static final List<String> MACRO_FIELDS = ImmutableList.of("username", "password");

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/AbstractDirectiveHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/AbstractDirectiveHandler.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.service.directive;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
+import io.cdap.directives.aggregates.DefaultTransientStore;
+import io.cdap.wrangler.api.DirectiveConfig;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ErrorRecordBase;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.GrammarMigrator;
+import io.cdap.wrangler.api.Pair;
+import io.cdap.wrangler.api.RecipeException;
+import io.cdap.wrangler.api.RecipeParser;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.TransientStore;
+import io.cdap.wrangler.executor.RecipePipelineExecutor;
+import io.cdap.wrangler.parser.ConfigDirectiveContext;
+import io.cdap.wrangler.parser.GrammarBasedParser;
+import io.cdap.wrangler.parser.MigrateToV2;
+import io.cdap.wrangler.proto.BadRequestException;
+import io.cdap.wrangler.proto.ErrorRecordsException;
+import io.cdap.wrangler.proto.workspace.ColumnStatistics;
+import io.cdap.wrangler.proto.workspace.ColumnValidationResult;
+import io.cdap.wrangler.proto.workspace.WorkspaceValidationResult;
+import io.cdap.wrangler.proto.workspace.v2.DirectiveExecutionResponse;
+import io.cdap.wrangler.registry.CompositeDirectiveRegistry;
+import io.cdap.wrangler.registry.DirectiveRegistry;
+import io.cdap.wrangler.registry.SystemDirectiveRegistry;
+import io.cdap.wrangler.registry.UserDirectiveRegistry;
+import io.cdap.wrangler.service.common.AbstractWranglerHandler;
+import io.cdap.wrangler.statistics.BasicStatistics;
+import io.cdap.wrangler.statistics.Statistics;
+import io.cdap.wrangler.utils.SchemaConverter;
+import io.cdap.wrangler.validator.ColumnNameValidator;
+import io.cdap.wrangler.validator.Validator;
+import io.cdap.wrangler.validator.ValidatorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract handler which contains common logic for v1 and v2 endpoints
+ *
+ * TODO: CDAP-18015 Refactor and add unit test for methods in this class
+ */
+public class AbstractDirectiveHandler extends AbstractWranglerHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractDirectiveHandler.class);
+
+  protected static final String COLUMN_NAME = "body";
+  protected static final String RECORD_DELIMITER_HEADER = "recorddelimiter";
+  protected static final String DELIMITER_HEADER = "delimiter";
+
+  protected DirectiveRegistry composite;
+
+  @Override
+  public void initialize(SystemHttpServiceContext context) throws Exception {
+    super.initialize(context);
+    composite = new CompositeDirectiveRegistry(
+      new SystemDirectiveRegistry(),
+      new UserDirectiveRegistry(context)
+    );
+  }
+
+  /**
+   * Closes the resources help by the composite registry.
+   */
+  @Override
+  public void destroy() {
+    super.destroy();
+    try {
+      composite.close();
+    } catch (IOException e) {
+      // If something bad happens here, you might see a a lot of open file handles.
+      LOG.warn("Unable to close the directive registry. You might see increasing number of open file handle.",
+               e.getMessage());
+    }
+  }
+
+  protected List<Row> executeDirectives(String namespace, List<String> directives,
+                                        List<Row> sample) throws DirectiveParseException {
+    TransientStore store = new DefaultTransientStore();
+    // Execute the pipeline.
+    ExecutorContext context = new ServicePipelineContext(namespace,
+                                                         ExecutorContext.Environment.SERVICE, getContext(), store);
+    RecipePipelineExecutor executor = new RecipePipelineExecutor();
+    if (!directives.isEmpty()) {
+      GrammarMigrator migrator = new MigrateToV2(directives);
+      String migrate = migrator.migrate();
+      RecipeParser recipe = new GrammarBasedParser(namespace, migrate, composite);
+      recipe.initialize(new ConfigDirectiveContext(DirectiveConfig.EMPTY));
+      try {
+        executor.initialize(recipe, context);
+        sample = executor.execute(sample);
+      } catch (RecipeException e) {
+        throw new BadRequestException(e.getMessage(), e);
+      }
+
+      List<ErrorRecordBase> errors = executor.errors()
+                                       .stream()
+                                       .filter(ErrorRecordBase::isShownInWrangler)
+                                       .collect(Collectors.toList());
+      if (errors.size() > 0) {
+        throw new ErrorRecordsException(errors);
+      }
+
+      executor.destroy();
+    }
+    return sample;
+  }
+
+  /**
+   * Transform the rows to response that is user friendly. Also generates the summary from the rows.
+   */
+  protected DirectiveExecutionResponse generateExecutionResponse(
+    List<Row> rows, int limit) throws Exception {
+    List<Map<String, Object>> values = new ArrayList<>(rows.size());
+    Map<String, String> types = new HashMap<>();
+    Set<String> headers = new LinkedHashSet<>();
+    SchemaConverter convertor = new SchemaConverter();
+
+    // Iterate through all the new rows.
+    for (Row row : rows) {
+      // If output array has more than return result values, we terminate.
+      if (values.size() >= limit) {
+        break;
+      }
+
+      Map<String, Object> value = new HashMap<>(row.width());
+
+      // Iterate through all the fields of the row.
+      for (Pair<String, Object> field : row.getFields()) {
+        String fieldName = field.getFirst();
+        headers.add(fieldName);
+        Object object = field.getSecond();
+
+        if (object != null) {
+          Schema schema = convertor.getSchema(object, fieldName);
+          String type = object.getClass().getSimpleName();
+          if (schema != null) {
+            schema = schema.isNullable() ? schema.getNonNullable() : schema;
+            type = schema.getLogicalType() == null ? schema.getType().name() : schema.getLogicalType().name();
+            // for backward compatibility, make the characters except the first one to lower case
+            type = type.substring(0, 1).toUpperCase() + type.substring(1).toLowerCase();
+          }
+          types.put(fieldName, type);
+          if ((object.getClass().getMethod("toString").getDeclaringClass() != Object.class)) {
+            value.put(fieldName, object.toString());
+          } else {
+            value.put(fieldName, "Non-displayable object");
+          }
+        } else {
+          value.put(fieldName, null);
+        }
+      }
+      values.add(value);
+    }
+    return new DirectiveExecutionResponse(values, headers, types, getWorkspaceSummary(rows));
+  }
+
+  /**
+   * Get the summary for the workspace rows
+   */
+  protected WorkspaceValidationResult getWorkspaceSummary(List<Row> rows) throws Exception {
+    // Validate Column names.
+    Validator<String> validator = new ColumnNameValidator();
+    validator.initialize();
+
+    // Iterate through columns to value a set
+    Set<String> uniqueColumns = new HashSet<>();
+    for (Row row : rows) {
+      for (int i = 0; i < row.width(); ++i) {
+        uniqueColumns.add(row.getColumn(i));
+      }
+    }
+
+    Map<String, ColumnValidationResult> columnValidationResults = new HashMap<>();
+    for (String name : uniqueColumns) {
+      try {
+        validator.validate(name);
+        columnValidationResults.put(name, new ColumnValidationResult(null));
+      } catch (ValidatorException e) {
+        columnValidationResults.put(name, new ColumnValidationResult(e.getMessage()));
+      }
+    }
+
+    // Generate General and Type related Statistics for each column.
+    Statistics statsGenerator = new BasicStatistics();
+    Row summary = statsGenerator.aggregate(rows);
+
+    Row stats = (Row) summary.getValue("stats");
+    Row types = (Row) summary.getValue("types");
+
+    List<Pair<String, Object>> fields = stats.getFields();
+    Map<String, ColumnStatistics> statistics = new HashMap<>();
+    for (Pair<String, Object> field : fields) {
+      List<Pair<String, Double>> values = (List<Pair<String, Double>>) field.getSecond();
+      Map<String, Float> generalStats = new HashMap<>();
+      for (Pair<String, Double> value : values) {
+        generalStats.put(value.getFirst(), value.getSecond().floatValue() * 100);
+      }
+      ColumnStatistics columnStatistics = new ColumnStatistics(generalStats, null);
+      statistics.put(field.getFirst(), columnStatistics);
+    }
+
+    fields = types.getFields();
+    for (Pair<String, Object> field : fields) {
+      List<Pair<String, Double>> values = (List<Pair<String, Double>>) field.getSecond();
+      Map<String, Float> typeStats = new HashMap<>();
+      for (Pair<String, Double> value : values) {
+        typeStats.put(value.getFirst(), value.getSecond().floatValue() * 100);
+      }
+      ColumnStatistics existingStats = statistics.get(field.getFirst());
+      Map<String, Float> generalStats = existingStats == null ? null : existingStats.getGeneral();
+      statistics.put(field.getFirst(), new ColumnStatistics(generalStats, typeStats));
+    }
+
+    return new WorkspaceValidationResult(columnValidationResults, statistics);
+  }
+
+  /**
+   * Creates a uber record after iterating through all rows.
+   *
+   * @param rows list of all rows.
+   * @return A single record will rows merged across all columns.
+   */
+  protected static Row createUberRecord(List<Row> rows) {
+    Row uber = new Row();
+    for (Row row : rows) {
+      for (int i = 0; i < row.width(); ++i) {
+        Object o = row.getValue(i);
+        if (o != null) {
+          int idx = uber.find(row.getColumn(i));
+          if (idx == -1) {
+            uber.add(row.getColumn(i), o);
+          }
+        }
+      }
+    }
+    return uber;
+  }
+
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ConnectionDiscoverer.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ConnectionDiscoverer.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.service.directive;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.CharStreams;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.ServiceDiscoverer;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.proto.connection.SampleResponse;
+import io.cdap.cdap.etl.proto.connection.SampleResponseCodec;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.wrangler.proto.BadRequestException;
+import io.cdap.wrangler.proto.NotFoundException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Discover for connection related operations
+ */
+public class ConnectionDiscoverer {
+  private static final Gson GSON =
+    new GsonBuilder()
+      .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+      .registerTypeAdapter(SampleResponse.class, new SampleResponseCodec()).create();
+
+  private static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+  private static final long RETRY_BASE_DELAY_MILLIS = 200L;
+  private static final long RETRY_MAX_DELAY_MILLIS = TimeUnit.SECONDS.toMillis(5);
+  private static final double RETRY_DELAY_MULTIPLIER = 1.2d;
+  private static final double RETRY_RANDOMIZE_FACTOR = 0.1d;
+
+  private final ServiceDiscoverer serviceDiscoverer;
+
+  public ConnectionDiscoverer(ServiceDiscoverer serviceDiscoverer) {
+    this.serviceDiscoverer = serviceDiscoverer;
+  }
+
+  public SampleResponse retrieveSample(String namespace, String connectionName,
+                                       SampleRequest sampleRequest) throws IOException, InterruptedException {
+    String url = String.format("v1/contexts/%s/connections/%s/sample", namespace, connectionName);
+    return execute(namespace, connectionName, url, urlConn -> {
+      urlConn.setRequestMethod("POST");
+      urlConn.setDoOutput(true);
+      try (OutputStream os = urlConn.getOutputStream();
+           OutputStreamWriter writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)) {
+        writer.write(GSON.toJson(sampleRequest));
+        writer.flush();
+      }
+    }, SampleResponse.class);
+  }
+
+  /**
+   * Execute the url provided, and return the response based on given type.
+   */
+  private <T> T execute(String namespace, String connectionName, String url,
+                        URLConfigurer configurer, Class<T> type) throws IOException, InterruptedException {
+    // Make call with exponential delay on failure retry.
+    long delay = RETRY_BASE_DELAY_MILLIS;
+    double minMultiplier = RETRY_DELAY_MULTIPLIER - RETRY_DELAY_MULTIPLIER * RETRY_RANDOMIZE_FACTOR;
+    double maxMultiplier = RETRY_DELAY_MULTIPLIER + RETRY_DELAY_MULTIPLIER * RETRY_RANDOMIZE_FACTOR;
+    Stopwatch stopWatch = Stopwatch.createStarted();
+
+    // remember the latest retryable exception;
+    RetryableException latest = null;
+    while (stopWatch.elapsed(TimeUnit.MILLISECONDS) < TIMEOUT_MILLIS) {
+      try {
+        HttpURLConnection urlConn = retrieveConnectionUrl(url);
+        configurer.configure(urlConn);
+        return retrieveResult(urlConn, type);
+      } catch (RetryableException e) {
+        latest = e;
+        TimeUnit.MILLISECONDS.sleep(delay);
+        delay = (long) (delay * (minMultiplier + Math.random() * (maxMultiplier - minMultiplier + 1)));
+        delay = Math.min(delay, RETRY_MAX_DELAY_MILLIS);
+      } catch (IOException e) {
+        throw new IOException(String.format("Failed to retrieve sample for connection '%s' in namespace '%s'.",
+                                            connectionName, namespace), e);
+      }
+    }
+
+    if (latest != null) {
+      throw new IOException(String.format("Timed out when trying to retrieve sample for " +
+                                            "connection '%s' in namespace '%s'.", connectionName, namespace), latest);
+    }
+
+    // should not get here, the call should either already fail with a non retryable failure or timed out because of
+    // retryable failure
+    throw new IllegalStateException(String.format("Unable to retrieve sample for " +
+                                                    "connection '%s' in namespace '%s'.", connectionName, namespace));
+  }
+
+  private HttpURLConnection retrieveConnectionUrl(String url) throws IOException {
+    HttpURLConnection urlConn = serviceDiscoverer.openConnection(
+      NamespaceId.SYSTEM.getNamespace(), Constants.PIPELINEID, Constants.STUDIO_SERVICE_NAME, url);
+
+    if (urlConn == null) {
+      throw new RetryableException("Connection service is not available");
+    }
+    return urlConn;
+  }
+
+  /**
+   * Retrieve the result from the url conn.
+   *
+   * @param urlConn url connection to get result
+   * @param type the expected return type for this call
+   */
+  private <T> T retrieveResult(HttpURLConnection urlConn, Class<T> type) throws IOException {
+    int responseCode = urlConn.getResponseCode();
+    if (responseCode != HttpURLConnection.HTTP_OK) {
+      switch (responseCode) {
+        case HttpURLConnection.HTTP_BAD_GATEWAY:
+        case HttpURLConnection.HTTP_UNAVAILABLE:
+        case HttpURLConnection.HTTP_GATEWAY_TIMEOUT:
+          throw new RetryableException("Connection service is not available with status " + responseCode);
+        case HttpURLConnection.HTTP_BAD_REQUEST:
+          throw new BadRequestException(getError(urlConn));
+        case HttpURLConnection.HTTP_NOT_FOUND:
+          throw new NotFoundException(getError(urlConn));
+      }
+      throw new IOException("Failed to call connection service with status " + responseCode + ": " +
+                              getError(urlConn));
+    }
+
+    try (Reader reader = new InputStreamReader(urlConn.getInputStream(), StandardCharsets.UTF_8)) {
+      return GSON.fromJson(CharStreams.toString(reader), type);
+    } finally {
+      urlConn.disconnect();
+    }
+  }
+
+  /**
+   * Returns the full content of the error stream for the given {@link HttpURLConnection}.
+   */
+  private String getError(HttpURLConnection urlConn) {
+    try (InputStream is = urlConn.getErrorStream()) {
+      if (is == null) {
+        return "Unknown error";
+      }
+      return new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      return "Unknown error due to failure to read from error output: " + e.getMessage();
+    }
+  }
+
+  /**
+   * Interface for the methods to configure the url conn
+   */
+  private interface URLConfigurer {
+    void configure(HttpURLConnection urlConn) throws IOException;
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
@@ -33,7 +33,6 @@ import io.cdap.cdap.api.service.http.HttpServiceResponder;
 import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
-import io.cdap.directives.aggregates.DefaultTransientStore;
 import io.cdap.wrangler.PropertyIds;
 import io.cdap.wrangler.RequestExtractor;
 import io.cdap.wrangler.SamplingMethod;
@@ -45,16 +44,9 @@ import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveConfig;
 import io.cdap.wrangler.api.DirectiveLoadException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.ErrorRecordBase;
-import io.cdap.wrangler.api.ExecutorContext;
-import io.cdap.wrangler.api.GrammarMigrator;
-import io.cdap.wrangler.api.Pair;
-import io.cdap.wrangler.api.RecipeException;
-import io.cdap.wrangler.api.RecipeParser;
 import io.cdap.wrangler.api.RecipeSymbol;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.TokenGroup;
-import io.cdap.wrangler.api.TransientStore;
 import io.cdap.wrangler.api.parser.Token;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.datamodel.DataModelGlossary;
@@ -63,22 +55,16 @@ import io.cdap.wrangler.dataset.workspace.DataType;
 import io.cdap.wrangler.dataset.workspace.Workspace;
 import io.cdap.wrangler.dataset.workspace.WorkspaceDataset;
 import io.cdap.wrangler.dataset.workspace.WorkspaceMeta;
-import io.cdap.wrangler.executor.RecipePipelineExecutor;
-import io.cdap.wrangler.parser.ConfigDirectiveContext;
-import io.cdap.wrangler.parser.GrammarBasedParser;
 import io.cdap.wrangler.parser.MigrateToV2;
 import io.cdap.wrangler.parser.RecipeCompiler;
 import io.cdap.wrangler.proto.BadRequestException;
 import io.cdap.wrangler.proto.ConflictException;
-import io.cdap.wrangler.proto.ErrorRecordsException;
 import io.cdap.wrangler.proto.NamespacedId;
 import io.cdap.wrangler.proto.NotFoundException;
 import io.cdap.wrangler.proto.Request;
 import io.cdap.wrangler.proto.ServiceResponse;
 import io.cdap.wrangler.proto.WorkspaceIdentifier;
 import io.cdap.wrangler.proto.connection.ConnectionType;
-import io.cdap.wrangler.proto.workspace.ColumnStatistics;
-import io.cdap.wrangler.proto.workspace.ColumnValidationResult;
 import io.cdap.wrangler.proto.workspace.DataModelInfo;
 import io.cdap.wrangler.proto.workspace.DirectiveArtifact;
 import io.cdap.wrangler.proto.workspace.DirectiveDescriptor;
@@ -87,20 +73,14 @@ import io.cdap.wrangler.proto.workspace.DirectiveUsage;
 import io.cdap.wrangler.proto.workspace.ModelInfo;
 import io.cdap.wrangler.proto.workspace.WorkspaceInfo;
 import io.cdap.wrangler.proto.workspace.WorkspaceSummaryResponse;
-import io.cdap.wrangler.proto.workspace.WorkspaceValidationResult;
 import io.cdap.wrangler.registry.CompositeDirectiveRegistry;
 import io.cdap.wrangler.registry.DirectiveInfo;
 import io.cdap.wrangler.registry.DirectiveRegistry;
 import io.cdap.wrangler.registry.SystemDirectiveRegistry;
 import io.cdap.wrangler.registry.UserDirectiveRegistry;
-import io.cdap.wrangler.service.common.AbstractWranglerHandler;
-import io.cdap.wrangler.statistics.BasicStatistics;
-import io.cdap.wrangler.statistics.Statistics;
 import io.cdap.wrangler.utils.ObjectSerDe;
+import io.cdap.wrangler.utils.ProjectInfo;
 import io.cdap.wrangler.utils.SchemaConverter;
-import io.cdap.wrangler.validator.ColumnNameValidator;
-import io.cdap.wrangler.validator.Validator;
-import io.cdap.wrangler.validator.ValidatorException;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -108,7 +88,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
@@ -116,12 +95,9 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -138,15 +114,12 @@ import javax.ws.rs.QueryParam;
 /**
  * Service for managing workspaces and also application of directives on to the workspace.
  */
-public class DirectivesHandler extends AbstractWranglerHandler {
+@Deprecated
+public class DirectivesHandler extends AbstractDirectiveHandler {
   private static final Logger LOG = LoggerFactory.getLogger(DirectivesHandler.class);
   private static final Gson GSON =
     new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
-  private static final String resourceName = ".properties";
 
-  private static final String COLUMN_NAME = "body";
-  private static final String RECORD_DELIMITER_HEADER = "recorddelimiter";
-  private static final String DELIMITER_HEADER = "delimiter";
   private static final String DATA_MODEL_PROPERTY = "dataModel";
   private static final String DATA_MODEL_REVISION_PROPERTY = "dataModelRevision";
   private static final String DATA_MODEL_MODEL_PROPERTY = "dataModelModel";
@@ -604,47 +577,8 @@ public class DirectivesHandler extends AbstractWranglerHandler {
           return records.subList(0, min);
         });
 
-        List<Map<String, Object>> values = new ArrayList<>(rows.size());
-        Map<String, String> types = new HashMap<>();
-        Set<String> headers = new LinkedHashSet<>();
-        SchemaConverter convertor = new SchemaConverter();
-
-        // Iterate through all the new rows.
-        for (Row row : rows) {
-          // If output array has more than return result values, we terminate.
-          if (values.size() >= directiveRequest.getWorkspace().getResults()) {
-            break;
-          }
-
-          Map<String, Object> value = new HashMap<>(row.width());
-
-          // Iterate through all the fields of the row.
-          for (Pair<String, Object> field : row.getFields()) {
-            String fieldName = field.getFirst();
-            headers.add(fieldName);
-            Object object = field.getSecond();
-
-            if (object != null) {
-              Schema schema = convertor.getSchema(object, fieldName);
-              String type = object.getClass().getSimpleName();
-              if (schema != null) {
-                schema = schema.isNullable() ? schema.getNonNullable() : schema;
-                type = schema.getLogicalType() == null ? schema.getType().name() : schema.getLogicalType().name();
-                // for backward compatibility, make the characters except the first one to lower case
-                type = type.substring(0, 1).toUpperCase() + type.substring(1).toLowerCase();
-              }
-              types.put(fieldName, type);
-              if ((object.getClass().getMethod("toString").getDeclaringClass() != Object.class)) {
-                value.put(fieldName, object.toString());
-              } else {
-                value.put(fieldName, "Non-displayable object");
-              }
-            } else {
-              value.put(fieldName, null);
-            }
-          }
-          values.add(value);
-        }
+        io.cdap.wrangler.proto.workspace.v2.DirectiveExecutionResponse response =
+          generateExecutionResponse(rows, directiveRequest.getWorkspace().getResults());
 
         // Save the recipes being executed.
         TransactionRunners.run(getContext(), context -> {
@@ -652,7 +586,8 @@ public class DirectivesHandler extends AbstractWranglerHandler {
           ws.updateWorkspaceRequest(namespacedId, directiveRequest);
         });
 
-        return new DirectiveExecutionResponse(values, headers, types, directiveRequest.getRecipe().getDirectives());
+        return new DirectiveExecutionResponse(response.getValues(), response.getHeaders(), response.getTypes(),
+                                              directiveRequest.getRecipe().getDirectives());
       } catch (JsonParseException e) {
         throw new BadRequestException(e.getMessage(), e);
       }
@@ -738,61 +673,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
           return records.subList(0, min);
         });
 
-        // Validate Column names.
-        Validator<String> validator = new ColumnNameValidator();
-        validator.initialize();
-
-        // Iterate through columns to value a set
-        Set<String> uniqueColumns = new HashSet<>();
-        for (Row row : rows) {
-          for (int i = 0; i < row.width(); ++i) {
-            uniqueColumns.add(row.getColumn(i));
-          }
-        }
-
-        Map<String, ColumnValidationResult> columnValidationResults = new HashMap<>();
-        for (String name : uniqueColumns) {
-          try {
-            validator.validate(name);
-            columnValidationResults.put(name, new ColumnValidationResult(null));
-          } catch (ValidatorException e) {
-            columnValidationResults.put(name, new ColumnValidationResult(e.getMessage()));
-          }
-        }
-
-        // Generate General and Type related Statistics for each column.
-        Statistics statsGenerator = new BasicStatistics();
-        Row summary = statsGenerator.aggregate(rows);
-
-        Row stats = (Row) summary.getValue("stats");
-        Row types = (Row) summary.getValue("types");
-
-        List<Pair<String, Object>> fields = stats.getFields();
-        Map<String, ColumnStatistics> statistics = new HashMap<>();
-        for (Pair<String, Object> field : fields) {
-          List<Pair<String, Double>> values = (List<Pair<String, Double>>) field.getSecond();
-          Map<String, Float> generalStats = new HashMap<>();
-          for (Pair<String, Double> value : values) {
-            generalStats.put(value.getFirst(), value.getSecond().floatValue() * 100);
-          }
-          ColumnStatistics columnStatistics = new ColumnStatistics(generalStats, null);
-          statistics.put(field.getFirst(), columnStatistics);
-        }
-
-        fields = types.getFields();
-        for (Pair<String, Object> field : fields) {
-          List<Pair<String, Double>> values = (List<Pair<String, Double>>) field.getSecond();
-          Map<String, Float> typeStats = new HashMap<>();
-          for (Pair<String, Double> value : values) {
-            typeStats.put(value.getFirst(), value.getSecond().floatValue() * 100);
-          }
-          ColumnStatistics existingStats = statistics.get(field.getFirst());
-          Map<String, Float> generalStats = existingStats == null ? null : existingStats.getGeneral();
-          statistics.put(field.getFirst(), new ColumnStatistics(generalStats, typeStats));
-        }
-
-        WorkspaceValidationResult validationResult = new WorkspaceValidationResult(columnValidationResults, statistics);
-        return new WorkspaceSummaryResponse(validationResult);
+        return new WorkspaceSummaryResponse(getWorkspaceSummary(rows));
       } catch (JsonParseException | DirectiveParseException e) {
         throw new BadRequestException(e.getMessage(), e);
       }
@@ -1014,20 +895,7 @@ public class DirectivesHandler extends AbstractWranglerHandler {
   @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void capabilities(HttpServiceRequest request, HttpServiceResponder responder) {
     respond(request, responder, () -> {
-      ClassLoader loader = Thread.currentThread().getContextClassLoader();
-      Properties props = new Properties();
-      try (InputStream resourceStream = loader.getResourceAsStream(resourceName)) {
-        props.load(resourceStream);
-      } catch (IOException e) {
-        throw new IOException("There was problem reading the capability matrix. " +
-          "Please check the environment to ensure you have right verions of jar." + e.getMessage(), e);
-      }
-
-      Map<String, String> value = new HashMap<>();
-      for (String key : props.stringPropertyNames()) {
-        value.put(key, props.getProperty(key));
-      }
-      return new ServiceResponse<>(value);
+      return new ServiceResponse<>(ProjectInfo.getProperties());
     });
   }
 
@@ -1216,28 +1084,6 @@ public class DirectivesHandler extends AbstractWranglerHandler {
   }
 
   /**
-   * Creates a uber record after iterating through all rows.
-   *
-   * @param rows list of all rows.
-   * @return A single record will rows merged across all columns.
-   */
-  private static Row createUberRecord(List<Row> rows) {
-    Row uber = new Row();
-    for (Row row : rows) {
-      for (int i = 0; i < row.width(); ++i) {
-        Object o = row.getValue(i);
-        if (o != null) {
-          int idx = uber.find(row.getColumn(i));
-          if (idx == -1) {
-            uber.add(row.getColumn(i), o);
-          }
-        }
-      }
-    }
-    return uber;
-  }
-
-  /**
    * Converts the data in workspace into records.
    *
    * @param workspace the workspace to get records from
@@ -1290,41 +1136,13 @@ public class DirectivesHandler extends AbstractWranglerHandler {
       throw new BadRequestException("Request is empty. Please check if the request is sent as HTTP POST body.");
     }
 
-    TransientStore store = new DefaultTransientStore();
     return TransactionRunners.run(getContext(), ctx -> {
       WorkspaceDataset ws = WorkspaceDataset.get(ctx);
 
       Workspace workspace = ws.getWorkspace(id);
       // Extract rows from the workspace.
       List<Row> rows = fromWorkspace(workspace);
-      // Execute the pipeline.
-      ExecutorContext context = new ServicePipelineContext(id.getNamespace().getName(),
-                                                           ExecutorContext.Environment.SERVICE, getContext(), store);
-      RecipePipelineExecutor executor = new RecipePipelineExecutor();
-      if (user.getRecipe().getDirectives().size() > 0) {
-        ConfigStore configStore = ConfigStore.get(ctx);
-        GrammarMigrator migrator = new MigrateToV2(user.getRecipe().getDirectives());
-        String migrate = migrator.migrate();
-        RecipeParser recipe = new GrammarBasedParser(id.getNamespace().getName(), migrate, composite);
-        recipe.initialize(new ConfigDirectiveContext(configStore.getConfig()));
-        try {
-          executor.initialize(recipe, context);
-          rows = executor.execute(sample.apply(rows));
-        } catch (RecipeException e) {
-          throw new BadRequestException(e.getMessage(), e);
-        }
-
-        List<ErrorRecordBase> errors = executor.errors()
-          .stream()
-          .filter(ErrorRecordBase::isShownInWrangler)
-          .collect(Collectors.toList());
-        if (errors.size() > 0) {
-          throw new ErrorRecordsException(errors);
-        }
-
-        executor.destroy();
-      }
-      return rows;
+      return executeDirectives(id.getNamespace().getName(), user.getRecipe().getDirectives(), sample.apply(rows));
     });
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceHandler.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.service.directive;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.service.http.HttpServiceRequest;
+import io.cdap.cdap.api.service.http.HttpServiceResponder;
+import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
+import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
+import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
+import io.cdap.cdap.etl.proto.connection.SampleResponse;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.wrangler.PropertyIds;
+import io.cdap.wrangler.RequestExtractor;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.proto.BadRequestException;
+import io.cdap.wrangler.proto.workspace.v2.Artifact;
+import io.cdap.wrangler.proto.workspace.v2.DirectiveExecutionRequest;
+import io.cdap.wrangler.proto.workspace.v2.DirectiveExecutionResponse;
+import io.cdap.wrangler.proto.workspace.v2.DirectiveUsage;
+import io.cdap.wrangler.proto.workspace.v2.Plugin;
+import io.cdap.wrangler.proto.workspace.v2.SampleSpec;
+import io.cdap.wrangler.proto.workspace.v2.ServiceResponse;
+import io.cdap.wrangler.proto.workspace.v2.StageSpec;
+import io.cdap.wrangler.proto.workspace.v2.Workspace;
+import io.cdap.wrangler.proto.workspace.v2.WorkspaceCreationRequest;
+import io.cdap.wrangler.proto.workspace.v2.WorkspaceDetail;
+import io.cdap.wrangler.proto.workspace.v2.WorkspaceId;
+import io.cdap.wrangler.proto.workspace.v2.WorkspaceSpec;
+import io.cdap.wrangler.registry.DirectiveInfo;
+import io.cdap.wrangler.store.workspace.WorkspaceStore;
+import io.cdap.wrangler.utils.SchemaConverter;
+import io.cdap.wrangler.utils.StructuredToRowTransformer;
+import org.apache.commons.lang3.StringEscapeUtils;
+
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * V2 endpoints for workspace
+ */
+public class WorkspaceHandler extends AbstractDirectiveHandler {
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
+  private WorkspaceStore store;
+  private ConnectionDiscoverer discoverer;
+
+  @Override
+  public void initialize(SystemHttpServiceContext context) throws Exception {
+    super.initialize(context);
+    store = new WorkspaceStore(context);
+    discoverer = new ConnectionDiscoverer(context);
+  }
+
+  @POST
+  @Path("v2/contexts/{context}/workspaces")
+  public void createWorkspace(HttpServiceRequest request, HttpServiceResponder responder,
+                              @PathParam("context") String namespace) {
+    respond(responder, namespace, ns -> {
+      if (ns.getName().equalsIgnoreCase(NamespaceId.SYSTEM.getNamespace())) {
+        throw new BadRequestException("Creating workspace in system namespace is currently not supported");
+      }
+
+      WorkspaceCreationRequest creationRequest =
+        GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(), WorkspaceCreationRequest.class);
+
+      if (creationRequest.getConnection() == null) {
+        throw new BadRequestException("Connection name has to be provided to create a workspace");
+      }
+
+      SampleRequest sampleRequest = creationRequest.getSampleRequest();
+      if (sampleRequest == null) {
+        throw new BadRequestException("Sample request has to be provided to create a workspace");
+      }
+
+      SampleResponse sampleResponse = discoverer.retrieveSample(namespace, creationRequest.getConnection(),
+                                                                sampleRequest);
+      List<Row> rows = new ArrayList<>();
+      if (!sampleResponse.getSample().isEmpty()) {
+        for (StructuredRecord record : sampleResponse.getSample()) {
+          rows.add(StructuredToRowTransformer.transform(record));
+        }
+      }
+
+      ConnectorDetail detail = sampleResponse.getDetail();
+      SampleSpec spec = new SampleSpec(
+        creationRequest.getConnection(), sampleRequest.getPath(),
+        detail.getRelatedPlugins().stream().map(plugin -> {
+          ArtifactSelectorConfig artifact = plugin.getArtifact();
+          Plugin pluginSpec = new Plugin(
+            plugin.getName(), plugin.getType(), plugin.getProperties(),
+            new Artifact(artifact.getName(), artifact.getVersion(), artifact.getScope()));
+          return new StageSpec(plugin.getSchema(), pluginSpec);
+        }).collect(Collectors.toSet()));
+
+      WorkspaceId wsId = new WorkspaceId(ns);
+      long now = System.currentTimeMillis();
+      Workspace workspace = Workspace.builder(generateWorkspaceName(wsId, creationRequest.getSampleRequest().getPath()),
+                                              wsId.getWorkspaceId())
+                              .setCreatedTimeMillis(now).setUpdatedTimeMillis(now).setSampleSpec(spec).build();
+      store.saveWorkspace(wsId, new WorkspaceDetail(workspace, rows));
+      responder.sendJson(wsId.getWorkspaceId());
+    });
+  }
+
+  @GET
+  @Path("v2/contexts/{context}/workspaces")
+  public void listWorkspaces(HttpServiceRequest request, HttpServiceResponder responder,
+                             @PathParam("context") String namespace) {
+    respond(responder, namespace, ns -> {
+      if (ns.getName().equalsIgnoreCase(NamespaceId.SYSTEM.getNamespace())) {
+        throw new BadRequestException("Listing workspaces in system namespace is currently not supported");
+      }
+      responder.sendString(GSON.toJson(new ServiceResponse<>(store.listWorkspaces(ns))));
+    });
+  }
+
+  @GET
+  @Path("v2/contexts/{context}/workspaces/{id}")
+  public void getWorkspace(HttpServiceRequest request, HttpServiceResponder responder,
+                           @PathParam("context") String namespace,
+                           @PathParam("id") String workspaceId) {
+    respond(responder, namespace, ns -> {
+      if (ns.getName().equalsIgnoreCase(NamespaceId.SYSTEM.getNamespace())) {
+        throw new BadRequestException("Getting workspace in system namespace is currently not supported");
+      }
+      responder.sendString(GSON.toJson(store.getWorkspace(new WorkspaceId(ns, workspaceId))));
+    });
+  }
+
+  @DELETE
+  @Path("v2/contexts/{context}/workspaces/{id}")
+  public void deleteWorkspace(HttpServiceRequest request, HttpServiceResponder responder,
+                              @PathParam("context") String namespace,
+                              @PathParam("id") String workspaceId) {
+    respond(responder, namespace, ns -> {
+      if (ns.getName().equalsIgnoreCase(NamespaceId.SYSTEM.getNamespace())) {
+        throw new BadRequestException("Deleting workspace in system namespace is currently not supported");
+      }
+      store.deleteWorkspace(new WorkspaceId(ns, workspaceId));
+      responder.sendStatus(HttpURLConnection.HTTP_OK);
+    });
+  }
+
+  /**
+   * Upload data to the workspace, the workspace is created automatically on fly.
+   */
+  @POST
+  @Path("v2/contexts/{context}/workspaces/upload")
+  public void upload(HttpServiceRequest request, HttpServiceResponder responder,
+                     @PathParam("context") String namespace) {
+    respond(responder, namespace, ns -> {
+      if (ns.getName().equalsIgnoreCase(NamespaceId.SYSTEM.getNamespace())) {
+        throw new BadRequestException("Uploading data in system namespace is currently not supported");
+      }
+
+      String name = request.getHeader(PropertyIds.FILE_NAME);
+      if (name == null) {
+        throw new BadRequestException("Name must be provided in the 'file' header");
+      }
+
+      RequestExtractor handler = new RequestExtractor(request);
+
+      // For back-ward compatibility, we check if there is delimiter specified
+      // using 'recorddelimiter' or 'delimiter'
+      String delimiter = handler.getHeader(RECORD_DELIMITER_HEADER, "\\u001A");
+      delimiter = handler.getHeader(DELIMITER_HEADER, delimiter);
+      String content = handler.getContent(StandardCharsets.UTF_8);
+      if (content == null) {
+        throw new BadRequestException(
+          "Body not present, please post the file containing the records to create a workspace.");
+      }
+
+      delimiter = StringEscapeUtils.unescapeJava(delimiter);
+      List<Row> sample = new ArrayList<>();
+      for (String line : content.split(delimiter)) {
+        sample.add(new Row(COLUMN_NAME, line));
+      }
+
+      WorkspaceId id = new WorkspaceId(ns);
+      long now = System.currentTimeMillis();
+      Workspace workspace = Workspace.builder(name, id.getWorkspaceId())
+                              .setCreatedTimeMillis(now).setUpdatedTimeMillis(now).build();
+      store.saveWorkspace(id, new WorkspaceDetail(workspace, sample));
+      responder.sendJson(id.getWorkspaceId());
+    });
+  }
+
+  /**
+   * Executes the directives on the record.
+   */
+  @POST
+  @Path("v2/contexts/{context}/workspaces/{id}/execute")
+  public void execute(HttpServiceRequest request, HttpServiceResponder responder,
+                      @PathParam("context") String namespace,
+                      @PathParam("id") String workspaceId) {
+    respond(responder, namespace, ns -> {
+      if (ns.getName().equalsIgnoreCase(NamespaceId.SYSTEM.getNamespace())) {
+        throw new BadRequestException("Executing directives in system namespace is currently not supported");
+      }
+      // load the udd
+      composite.reload(namespace);
+
+      DirectiveExecutionRequest executionRequest =
+        GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(), DirectiveExecutionRequest.class);
+      WorkspaceId wsId = new WorkspaceId(ns, workspaceId);
+      WorkspaceDetail detail = store.getWorkspaceDetail(wsId);
+      List<Row> result = executeDirectives(ns.getName(), executionRequest.getDirectives(), detail.getSample());
+      DirectiveExecutionResponse response = generateExecutionResponse(result, executionRequest.getLimit());
+
+      Workspace newWorkspace = Workspace.builder(detail.getWorkspace())
+                                 .setDirectives(executionRequest.getDirectives())
+                                 .setUpdatedTimeMillis(System.currentTimeMillis()).build();
+      store.saveWorkspace(wsId, new WorkspaceDetail(newWorkspace, detail.getSample()));
+      responder.sendJson(response);
+    });
+  }
+
+  /**
+   * Retrieve the directives available in the namespace
+   */
+  @GET
+  @Path("v2/contexts/{context}/directives")
+  public void getDirectives(HttpServiceRequest request, HttpServiceResponder responder,
+                            @PathParam("context") String namespace) {
+    respond(responder, namespace, ns -> {
+      // CDAP-15397 - reload must be called before it can be safely used
+      composite.reload(namespace);
+      List<DirectiveUsage> directives = new ArrayList<>();
+      for (DirectiveInfo directive : composite.list(namespace)) {
+        DirectiveUsage directiveUsage = new DirectiveUsage(directive.name(), directive.usage(),
+                                                           directive.description(), directive.scope().name(),
+                                                           directive.definition(), directive.categories());
+        directives.add(directiveUsage);
+      }
+      responder.sendJson(new ServiceResponse<>(directives));
+    });
+  }
+
+  /**
+   * Get the specification for the workspace
+   */
+  @GET
+  @Path("v2/contexts/{context}/workspaces/{id}/specification")
+  public void specification(HttpServiceRequest request, HttpServiceResponder responder,
+                            @PathParam("context") String namespace,
+                            @PathParam("id") String workspaceId) {
+    respond(responder, namespace, ns -> {
+      if (ns.getName().equalsIgnoreCase(NamespaceId.SYSTEM.getNamespace())) {
+        throw new BadRequestException("Getting specification in system namespace is currently not supported");
+      }
+      // reload to retrieve the wrangler transform
+      composite.reload(namespace);
+
+      WorkspaceId wsId = new WorkspaceId(ns, workspaceId);
+      WorkspaceDetail detail = store.getWorkspaceDetail(wsId);
+      List<String> directives = detail.getWorkspace().getDirectives();
+      List<Row> result = executeDirectives(ns.getName(), directives, detail.getSample());
+
+      SchemaConverter schemaConvertor = new SchemaConverter();
+      Schema schema = schemaConvertor.toSchema("record", createUberRecord(result));
+      Map<String, String> properties = ImmutableMap.of("directives", String.join("\n", directives));
+
+      Set<StageSpec> srcSpecs = getSourceSpecs(detail, directives);
+
+      ArtifactSummary wrangler = composite.getLatestWranglerArtifact();
+      responder.sendString(GSON.toJson(new WorkspaceSpec(
+        srcSpecs, new StageSpec(
+          schema, new Plugin("Wrangler", "transform", properties,
+                             wrangler == null ? null :
+                               new Artifact(wrangler.getName(), wrangler.getVersion(),
+                                            wrangler.getScope().name().toLowerCase()))))));
+    });
+  }
+
+  /**
+   * Get source specs, contains some hacky way on dealing with the csv parser
+   */
+  private Set<StageSpec> getSourceSpecs(WorkspaceDetail detail, List<String> directives) {
+    SampleSpec sampleSpec = detail.getWorkspace().getSampleSpec();
+    Set<StageSpec> srcSpecs = sampleSpec == null ? Collections.emptySet() : sampleSpec.getRelatedPlugins();
+
+    // really hacky way for the parse-as-csv directive, should get removed once we have support to provide the
+    // format properties when doing sampling
+    boolean shouldCopyHeader =
+      directives.stream()
+        .map(String::trim)
+        .anyMatch(directive -> directive.startsWith("parse-as-csv") && directive.endsWith("true"));
+    if (shouldCopyHeader && !srcSpecs.isEmpty()) {
+      srcSpecs = srcSpecs.stream().map(stageSpec -> {
+        Plugin plugin = stageSpec.getPlugin();
+        Map<String, String> srcProperties = new HashMap<>(plugin.getProperties());
+        srcProperties.put("copyHeader", "true");
+        return new StageSpec(stageSpec.getSchema(), new Plugin(plugin.getName(), plugin.getType(),
+                                                               srcProperties, plugin.getArtifact()));
+      }).collect(Collectors.toSet());
+    }
+    return srcSpecs;
+  }
+
+  /**
+   * Get the workspace name, the generation rule is like:
+   * 1. If the path is not null or empty, the name will be last portion of path starting from "/".
+   * If "/" does not exist, the name will be the path itself.
+   * 2. If path is null or empty or equal to "/", the name will be the uuid for the workspace
+   */
+  private String generateWorkspaceName(WorkspaceId id, @Nullable String path) {
+    if (Strings.isNullOrEmpty(path)) {
+      return id.getWorkspaceId();
+    }
+
+    // remove trailing "/"
+    path = path.replaceAll("/+$", "");
+
+    int last = path.lastIndexOf('/');
+    // if found an "/", take the rest as name
+    if (last >= 0) {
+      return path.substring(last + 1);
+    }
+    // if not, check if path is empty or not
+    return path.isEmpty() ? id.getWorkspaceId() : path;
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/explorer/FilesystemExplorer.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/explorer/FilesystemExplorer.java
@@ -67,6 +67,7 @@ import javax.ws.rs.QueryParam;
  * A {@link FilesystemExplorer} is a HTTP Service handler for exploring the filesystem.
  * It provides capabilities for listing file(s) and directories. It also provides metadata.
  */
+@Deprecated
 public class FilesystemExplorer extends AbstractWranglerHandler {
   private Explorer explorer;
   private static final String COLUMN_NAME = "body";

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/gcs/GCSHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/gcs/GCSHandler.java
@@ -88,6 +88,7 @@ import javax.ws.rs.QueryParam;
 /**
  * Service to explore <code>GCS</code> filesystem
  */
+@Deprecated
 public class GCSHandler extends AbstractWranglerHandler {
   private static final Logger LOG = LoggerFactory.getLogger(GCSHandler.class);
   private static final String MAX_SAMPLE_ROWS = "wrangler.gcs.sampling.max.rows";

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/kafka/KafkaHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/kafka/KafkaHandler.java
@@ -61,6 +61,7 @@ import javax.ws.rs.QueryParam;
 /**
  * Service for handling Kafka connections.
  */
+@Deprecated
 public final class KafkaHandler extends AbstractWranglerHandler {
 
   @POST

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/s3/S3Handler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/s3/S3Handler.java
@@ -83,6 +83,7 @@ import javax.ws.rs.QueryParam;
 /**
  * Service to explore S3 filesystem.
  */
+@Deprecated
 public class S3Handler extends AbstractWranglerHandler {
   private static final String COLUMN_NAME = "body";
   private static final int FILE_SIZE = 10 * 1024 * 1024;

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/spanner/SpannerHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/spanner/SpannerHandler.java
@@ -77,6 +77,7 @@ import javax.ws.rs.QueryParam;
 /**
  * Spanner data prep connection service
  */
+@Deprecated
 public class SpannerHandler extends AbstractWranglerHandler {
   private static final String TABLE_NAME = "TableName";
   // Spanner queries for listing tables and listing schema of table are documented at

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/connections/ConnectionStore.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/connections/ConnectionStore.java
@@ -55,6 +55,7 @@ import javax.annotation.Nullable;
  * The store is backed by a table with namespace, id, type, name, description, properties, created, and updated columns.
  * The primary key is the namespace and id.
  */
+@Deprecated
 public class ConnectionStore {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/ConfigStore.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/ConfigStore.java
@@ -42,6 +42,7 @@ import java.util.Optional;
  * TODO: (CDAP-14619) check if the DirectiveConfig is used by anything/anyone. If so, see if it can be moved to app
  *   configuration instead of stored in a one row table.
  */
+@Deprecated
 public class ConfigStore {
   private static final Gson GSON = new Gson();
   private static final String KEY_COL = "key";

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/WorkspaceDataset.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/WorkspaceDataset.java
@@ -61,6 +61,7 @@ import javax.annotation.Nullable;
  *
  * namespace, id, name, type, scope, created, updated, properties, data, and request
  */
+@Deprecated
 public class WorkspaceDataset {
   private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final Gson GSON = new GsonBuilder()

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/store/workspace/WorkspaceStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/store/workspace/WorkspaceStoreTest.java
@@ -20,7 +20,6 @@ package io.cdap.wrangler.store.workspace;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.NamespaceSummary;
-import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.test.SystemAppTestBase;
 import io.cdap.cdap.test.TestConfiguration;
@@ -78,9 +77,7 @@ public class WorkspaceStoreTest extends SystemAppTestBase {
   public void testCRUD() {
     NamespaceSummary ns1 = new NamespaceSummary("n1", "", 10L);
     NamespaceSummary ns2 = new NamespaceSummary("n2", "", 10L);
-    SampleSpec dummySpec = new SampleSpec(
-      "conn", "/tmp", Schema.recordOf("test", Schema.Field.of("name", Schema.of(Schema.Type.STRING))),
-      Collections.emptyMap());
+    SampleSpec dummySpec = new SampleSpec("conn", "/tmp", ImmutableSet.of());
 
     // test writes
     WorkspaceId id1 = new WorkspaceId(ns1);


### PR DESCRIPTION
This is depending on #499 and https://github.com/cdapio/cdap/pull/13430

This pr has quite a lot of changes but lots of code cannot be unit tested due to https://cdap.atlassian.net/browse/CDAP-11465.

Basically it has following major changes:
1. Deprecated most of the unused endpoints and dataset
2. Introduce a new set of v2 endpoints for workspace to make the code cleaner, for some of the endpoints still preserve the old logic as these logic would need a lot of effort to clean up.

All the changes have been tested manually
