### PR TITLE
Document that Row#find returns -1 not null

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/Row.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/Row.java
@@ -158,7 +158,7 @@ public final class Row implements Serializable {
    * Finds a column index based on the name of the column. The col name is case insensitive.
    *
    * @param col to be searched within the row.
-   * @return null if not present, else the index at which the column is found.
+   * @return -1 if not present, else the index at which the column is found.
    */
   public int find(String col) {
     int idx = 0;


### PR DESCRIPTION
When Row#find cannot find a column, it returns -1, not null. Since it returns an int, it cannot return null.

This doc caused me a little confusion until I looked at the code, so I went ahead and updated it.