### PR TITLE
CDAP-17904 support connection/workspace upgrade

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/wrangler/registry/CompositeDirectiveRegistry.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/registry/CompositeDirectiveRegistry.java
@@ -19,6 +19,7 @@ package io.cdap.wrangler.registry;
 import com.google.common.collect.Iterables;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.wrangler.api.DirectiveLoadException;
+import io.cdap.wrangler.utils.ArtifactSummaryComparator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -81,7 +82,7 @@ public final class CompositeDirectiveRegistry implements DirectiveRegistry {
       if (latestArtifact == null) {
         latestArtifact = artifact;
       } else {
-        latestArtifact = DirectiveRegistry.pickLatest(latestArtifact, artifact);
+        latestArtifact = ArtifactSummaryComparator.pickLatest(latestArtifact, artifact);
       }
     }
     return latestArtifact;

--- a/wrangler-core/src/main/java/io/cdap/wrangler/registry/DirectiveRegistry.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/registry/DirectiveRegistry.java
@@ -16,10 +16,7 @@
 
 package io.cdap.wrangler.registry;
 
-import com.google.common.annotations.VisibleForTesting;
-import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
-import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.wrangler.api.DirectiveLoadException;
 
 import java.io.Closeable;
@@ -70,23 +67,4 @@ public interface DirectiveRegistry extends Closeable {
    */
   @Nullable
   ArtifactSummary getLatestWranglerArtifact();
-
-  /**
-   * Pick up the latest artifact, this method assumes the name of the artifact is same
-   */
-  @VisibleForTesting
-  static ArtifactSummary pickLatest(ArtifactSummary artifact1, ArtifactSummary artifact2) {
-    // first compare the artifact
-    int cmp = new ArtifactVersion(artifact1.getVersion()).compareTo(new ArtifactVersion(artifact2.getVersion()));
-    if (cmp > 0) {
-      return artifact1;
-    }
-
-    if (cmp < 0) {
-      return artifact2;
-    }
-
-    // if scope is differnt, whoever has user scope is latest
-    return artifact1.getScope().equals(ArtifactScope.USER) ? artifact1 : artifact2;
-  }
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/registry/UserDirectiveRegistry.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/registry/UserDirectiveRegistry.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.etl.api.StageContext;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveLoadException;
+import io.cdap.wrangler.utils.ArtifactSummaryComparator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -196,7 +197,7 @@ public final class UserDirectiveRegistry implements DirectiveRegistry {
                 latestWrangler = artifact;
                 continue;
               }
-              latestWrangler = DirectiveRegistry.pickLatest(latestWrangler, artifact);
+              latestWrangler = ArtifactSummaryComparator.pickLatest(latestWrangler, artifact);
             }
           }
         }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/ArtifactSummaryComparator.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/ArtifactSummaryComparator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.utils;
+
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.artifact.ArtifactVersion;
+
+import java.util.Comparator;
+
+/**
+ * Comparator for artifact summary
+ */
+public class ArtifactSummaryComparator implements Comparator<ArtifactSummary> {
+  private static final ArtifactSummaryComparator COMPARATOR = new ArtifactSummaryComparator();
+
+  @Override
+  public int compare(ArtifactSummary summary1, ArtifactSummary summary2) {
+    // first compare the artifact
+    int cmp = new ArtifactVersion(summary1.getVersion()).compareTo(new ArtifactVersion(summary2.getVersion()));
+    if (cmp > 0) {
+      return 1;
+    }
+
+    if (cmp < 0) {
+      return -1;
+    }
+
+    // if scope is different, whoever has user scope is latest
+    return summary1.getScope().equals(ArtifactScope.USER) ? 1 : -1;
+  }
+
+  /**
+   * Pick up the latest artifact, this method assumes the name of the artifact is same
+   */
+  public static ArtifactSummary pickLatest(ArtifactSummary artifact1, ArtifactSummary artifact2) {
+    return COMPARATOR.compare(artifact1, artifact2) > 0 ? artifact1 : artifact2;
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/utils/ArtifactSummaryComparatorTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/utils/ArtifactSummaryComparatorTest.java
@@ -15,28 +15,25 @@
  *
  */
 
-package io.cdap.wrangler.registry;
+package io.cdap.wrangler.utils;
 
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for directive registry
- */
-public class DirectiveRegistryTest {
+public class ArtifactSummaryComparatorTest {
 
   @Test
   public void testArtifactCompare() throws Exception {
     ArtifactSummary summary1 = new ArtifactSummary("wrangler-transform", "1.0.0", ArtifactScope.USER);
     ArtifactSummary summary2 = new ArtifactSummary("wrangler-transform", "1.0.1", ArtifactScope.SYSTEM);
-    Assert.assertEquals(summary2, DirectiveRegistry.pickLatest(summary1, summary2));
+    Assert.assertEquals(summary2, ArtifactSummaryComparator.pickLatest(summary1, summary2));
 
     summary2 = new ArtifactSummary("wrangler-transform", "1.0.0", ArtifactScope.SYSTEM);
-    Assert.assertEquals(summary1, DirectiveRegistry.pickLatest(summary1, summary2));
+    Assert.assertEquals(summary1, ArtifactSummaryComparator.pickLatest(summary1, summary2));
 
     summary1 = new ArtifactSummary("wrangler-transform", "2.0.0", ArtifactScope.SYSTEM);
-    Assert.assertEquals(summary1, DirectiveRegistry.pickLatest(summary1, summary2));
+    Assert.assertEquals(summary1, ArtifactSummaryComparator.pickLatest(summary1, summary2));
   }
 }

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/connection/ConnectionType.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/connection/ConnectionType.java
@@ -17,6 +17,9 @@
 package io.cdap.wrangler.proto.connection;
 
 
+import java.util.EnumSet;
+import javax.annotation.Nullable;
+
 /**
  * This class {@link ConnectionType} defines different connections from which the data is extracted.
  *
@@ -26,19 +29,32 @@ package io.cdap.wrangler.proto.connection;
 public enum ConnectionType {
   UPLOAD("upload"),
   FILE("file"),
-  DATABASE("database"),
+  DATABASE("database", "Database"),
   TABLE("table"),
-  S3("s3"),
-  GCS("gcs"),
+  S3("s3", "S3"),
+  GCS("gcs", "GCS"),
   ADLS("adls"),
-  BIGQUERY("bigquery"),
-  KAFKA("kafka"),
-  SPANNER("spanner");
+  BIGQUERY("bigquery", "BigQuery"),
+  KAFKA("kafka", "Kafka"),
+  SPANNER("spanner", "Spanner");
 
-  private String type;
+  // file won't be upgraded since file connection type is meant for local file system and not packaged in distributed
+  // cdap
+  public static final EnumSet CONN_UPGRADABLE_TYPES = EnumSet.of(DATABASE, S3, GCS, BIGQUERY, KAFKA, SPANNER);
+  // upload is upgradable and it will get translates to a no-source pipeline in studio
+  public static final EnumSet WORKSPACE_UPGRADABLE_TYPES =
+    EnumSet.of(DATABASE, S3, GCS, BIGQUERY, KAFKA, SPANNER, UPLOAD);
+
+  private final String type;
+  private final String connectorName;
 
   ConnectionType(String type) {
+    this(type, null);
+  }
+
+  ConnectionType(String type, @Nullable String connectorName) {
     this.type = type;
+    this.connectorName = connectorName;
   }
 
   /**
@@ -48,4 +64,8 @@ public enum ConnectionType {
     return type;
   }
 
+  @Nullable
+  public String getConnectorName() {
+    return connectorName;
+  }
 }

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/SampleSpec.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/SampleSpec.java
@@ -19,6 +19,7 @@ package io.cdap.wrangler.proto.workspace.v2;
 
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Spec for the workspace sample
@@ -29,7 +30,8 @@ public class SampleSpec {
   private final String path;
   private final Set<StageSpec> relatedPlugins;
 
-  public SampleSpec(String connectionName, String connectionType, String path, Set<StageSpec> relatedPlugins) {
+  public SampleSpec(String connectionName, String connectionType, @Nullable String path,
+                    Set<StageSpec> relatedPlugins) {
     this.connectionName = connectionName;
     this.connectionType = connectionType;
     this.path = path;
@@ -44,6 +46,8 @@ public class SampleSpec {
     return connectionType;
   }
 
+  // path is not there for an upgraded workspace
+  @Nullable
   public String getPath() {
     return path;
   }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/DataPrepService.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/DataPrepService.java
@@ -17,6 +17,7 @@
 package io.cdap.wrangler.service;
 
 import io.cdap.cdap.api.service.AbstractSystemService;
+import io.cdap.cdap.api.service.SystemServiceContext;
 import io.cdap.wrangler.dataset.connections.ConnectionStore;
 import io.cdap.wrangler.dataset.schema.SchemaRegistry;
 import io.cdap.wrangler.dataset.workspace.ConfigStore;
@@ -26,8 +27,10 @@ import io.cdap.wrangler.service.bigquery.BigQueryHandler;
 import io.cdap.wrangler.service.connections.ConnectionHandler;
 import io.cdap.wrangler.service.connections.ConnectionTypeConfig;
 import io.cdap.wrangler.service.database.DatabaseHandler;
+import io.cdap.wrangler.service.directive.ConnectionUpgrader;
 import io.cdap.wrangler.service.directive.DirectivesHandler;
 import io.cdap.wrangler.service.directive.WorkspaceHandler;
+import io.cdap.wrangler.service.directive.WorkspaceUpgrader;
 import io.cdap.wrangler.service.explorer.FilesystemExplorer;
 import io.cdap.wrangler.service.gcs.GCSHandler;
 import io.cdap.wrangler.service.kafka.KafkaHandler;
@@ -35,12 +38,22 @@ import io.cdap.wrangler.service.s3.S3Handler;
 import io.cdap.wrangler.service.schema.DataModelHandler;
 import io.cdap.wrangler.service.schema.SchemaRegistryHandler;
 import io.cdap.wrangler.service.spanner.SpannerHandler;
+import io.cdap.wrangler.store.upgrade.UpgradeEntityType;
+import io.cdap.wrangler.store.upgrade.UpgradeState;
+import io.cdap.wrangler.store.upgrade.UpgradeStore;
 import io.cdap.wrangler.store.workspace.WorkspaceStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Data prep service.
  */
 public class DataPrepService extends AbstractSystemService {
+  private static final Logger LOG = LoggerFactory.getLogger(DataPrepService.class);
+  private static final UpgradeState PRE_UPGRADE = new UpgradeState(0L);
+
   private final ConnectionTypeConfig config;
 
   public DataPrepService(ConnectionTypeConfig config) {
@@ -57,6 +70,7 @@ public class DataPrepService extends AbstractSystemService {
     createTable(SchemaRegistry.ENTRY_TABLE_SPEC);
     createTable(WorkspaceDataset.TABLE_SPEC);
     createTable(WorkspaceStore.WORKSPACE_TABLE_SPEC);
+    createTable(UpgradeStore.UPGRADE_TABLE_SPEC);
 
     addHandler(new DirectivesHandler());
     addHandler(new SchemaRegistryHandler());
@@ -71,5 +85,54 @@ public class DataPrepService extends AbstractSystemService {
     addHandler(new SpannerHandler());
     addHandler(new DataModelHandler());
     addHandler(new WorkspaceHandler());
+  }
+
+  @Override
+  public void initialize(SystemServiceContext context) {
+    // only do the upgrade on first instance to avoid transaction conflict
+    if (context.getInstanceId() != 0) {
+      return;
+    }
+
+    UpgradeStore upgradeStore = new UpgradeStore(context);
+    WorkspaceStore wsStore = new WorkspaceStore(context);
+    UpgradeState connState = upgradeStore.getEntityUpgradeState(UpgradeEntityType.CONNECTION);
+    UpgradeState wsState = upgradeStore.getEntityUpgradeState(UpgradeEntityType.WORKSPACE);
+    boolean isConnDone = connState != null && connState.getVersion() == 1L;
+    boolean isWsDone = wsState != null && wsState.getVersion() == 1L;
+    if (isConnDone && isWsDone) {
+      return;
+    }
+
+    long timestampNowMillis = System.currentTimeMillis();
+    long upgradeBefore =
+      upgradeStore.initializeAndRetrieveUpgradeTimestampMillis(UpgradeEntityType.CONNECTION, timestampNowMillis,
+                                                               PRE_UPGRADE);
+    upgradeStore.initializeAndRetrieveUpgradeTimestampMillis(UpgradeEntityType.WORKSPACE, timestampNowMillis,
+                                                             PRE_UPGRADE);
+    long upgradeBeforeTsSecs = TimeUnit.MILLISECONDS.toSeconds(upgradeBefore);
+    if (!isConnDone) {
+      try {
+        ConnectionUpgrader connectionUpgrader = new ConnectionUpgrader(upgradeStore, context, upgradeBeforeTsSecs);
+        connectionUpgrader.upgradeConnections();
+      } catch (Exception e) {
+        // check if there is any error upgrading the connections, if true, no point to continue upgrading the workspace
+        // as most connections won't be able to get the spec.
+        // also we don't want the service fail to start due to upgrade failure
+        LOG.error("Failed to upgrade the connections", e);
+        return;
+      }
+    }
+
+    if (!isWsDone) {
+      try {
+        WorkspaceUpgrader workspaceUpgrader =
+          new WorkspaceUpgrader(upgradeStore, context, upgradeBeforeTsSecs, wsStore);
+        workspaceUpgrader.upgradeWorkspaces();
+      } catch (Exception e) {
+        // don't want the service fail to start due to upgrade failure
+        LOG.error("Failed to upgrade the workspaces", e);
+      }
+    }
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/bigquery/BigQueryHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/bigquery/BigQueryHandler.java
@@ -48,6 +48,7 @@ import io.cdap.wrangler.SamplingMethod;
 import io.cdap.wrangler.api.Pair;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.dataset.workspace.DataType;
+import io.cdap.wrangler.dataset.workspace.Workspace;
 import io.cdap.wrangler.dataset.workspace.WorkspaceDataset;
 import io.cdap.wrangler.dataset.workspace.WorkspaceMeta;
 import io.cdap.wrangler.proto.ConnectionSample;
@@ -83,6 +84,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.UUID;
@@ -100,6 +102,7 @@ import javax.ws.rs.QueryParam;
 @Deprecated
 public class BigQueryHandler extends AbstractWranglerHandler {
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryHandler.class);
+  private static final String PATH_FORMAT = "/%s/%s";
   private static final String DATASET_ID = "datasetId";
   private static final String DATASET_PROJECT = "datasetProject";
   private static final String TABLE_ID = "id";
@@ -296,6 +299,21 @@ public class BigQueryHandler extends AbstractWranglerHandler {
 
       return new ServiceResponse<>(spec);
     });
+  }
+
+  public static Map<String, String> getConnectorProperties(Map<String, String> config) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("serviceAccountType", "filePath");
+    properties.put("serviceFilePath", config.get(GCPUtils.SERVICE_ACCOUNT_KEYFILE));
+    properties.put(DATASET_PROJECT, config.get(DATASET_PROJECT));
+    properties.put("project", config.get(GCPUtils.PROJECT_ID));
+    properties.values().removeIf(Objects::isNull);
+    return properties;
+  }
+
+  public static String getPath(Workspace workspace) {
+    Map<String, String> properties = workspace.getProperties();
+    return String.format(PATH_FORMAT, properties.get(DATASET_ID), properties.get(TABLE_ID));
   }
 
   private Pair<List<Row>, Schema> getData(Connection connection, TableId tableId)

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/database/DatabaseHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/database/DatabaseHandler.java
@@ -33,6 +33,7 @@ import io.cdap.wrangler.RequestExtractor;
 import io.cdap.wrangler.SamplingMethod;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.dataset.workspace.DataType;
+import io.cdap.wrangler.dataset.workspace.Workspace;
 import io.cdap.wrangler.dataset.workspace.WorkspaceDataset;
 import io.cdap.wrangler.dataset.workspace.WorkspaceMeta;
 import io.cdap.wrangler.proto.ConnectionSample;
@@ -49,6 +50,7 @@ import io.cdap.wrangler.proto.db.DBSpec;
 import io.cdap.wrangler.proto.db.JDBCDriverInfo;
 import io.cdap.wrangler.service.common.AbstractWranglerHandler;
 import io.cdap.wrangler.service.macro.ServiceMacroEvaluator;
+import io.cdap.wrangler.service.s3.S3Configuration;
 import io.cdap.wrangler.utils.ObjectSerDe;
 import io.cdap.wrangler.utils.ReferenceNames;
 import org.apache.commons.lang3.text.StrLookup;
@@ -511,6 +513,22 @@ public class DatabaseHandler extends AbstractWranglerHandler {
 
       return new ServiceResponse<>(spec);
     });
+  }
+
+  public static Map<String, String> getConnectorProperties(Map<String, String> config) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("connectionString", config.get("url"));
+    properties.put("user", config.get("username"));
+    properties.put("password", config.get("password"));
+    properties.put("jdbcPluginType", config.get("type"));
+    properties.put("jdbcPluginName", config.get("name"));
+    return properties;
+  }
+
+  // TODO: this path will not work with current db connector if the database type supports schema,
+  //  but it should still give back the related source information.
+  public static String getPath(Workspace workspace) {
+    return workspace.getProperties().get(PropertyIds.NAME);
   }
 
   /**

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ConnectionUpgrader.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ConnectionUpgrader.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.service.directive;
+
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.api.service.SystemServiceContext;
+import io.cdap.cdap.etl.proto.connection.ConnectionCreationRequest;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.cdap.wrangler.dataset.connections.ConnectionStore;
+import io.cdap.wrangler.proto.ConflictException;
+import io.cdap.wrangler.proto.Namespace;
+import io.cdap.wrangler.proto.connection.Connection;
+import io.cdap.wrangler.proto.connection.ConnectionType;
+import io.cdap.wrangler.store.upgrade.UpgradeEntityType;
+import io.cdap.wrangler.store.upgrade.UpgradeState;
+import io.cdap.wrangler.store.upgrade.UpgradeStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Upgrader for connections
+ */
+public class ConnectionUpgrader {
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectionUpgrader.class);
+  private static final UpgradeState CONN_COMPLETE_STATE = new UpgradeState(1L);
+
+  private final UpgradeStore upgradeStore;
+  private final SystemServiceContext context;
+  private final long upgradeBeforeTsSecs;
+  private final ConnectorArtifactLoader artifactLoader;
+  private final ConnectionDiscoverer discoverer;
+
+  public ConnectionUpgrader(UpgradeStore upgradeStore, SystemServiceContext context, long upgradeBeforeTsSecs) {
+    this.upgradeStore = upgradeStore;
+    this.context = context;
+    this.upgradeBeforeTsSecs = upgradeBeforeTsSecs;
+    this.artifactLoader = new ConnectorArtifactLoader(context);
+    this.discoverer = new ConnectionDiscoverer(context);
+  }
+
+  public void upgradeConnections() throws Exception {
+    List<NamespaceSummary> namespaces = context.listNamespaces();
+    for (NamespaceSummary ns : namespaces) {
+      UpgradeState state = upgradeStore.getEntityUpgradeState(ns, UpgradeEntityType.CONNECTION);
+      if (state == null || state.getVersion() == 0L) {
+        upgradeConnectionsInNamespace(ns);
+      }
+    }
+    upgradeStore.setEntityUpgradeState(UpgradeEntityType.CONNECTION, CONN_COMPLETE_STATE);
+  }
+
+  private void upgradeConnectionsInNamespace(NamespaceSummary namespace) {
+    List<Connection> connections = TransactionRunners.run(context, ctx -> {
+      ConnectionStore connStore = ConnectionStore.get(ctx);
+      return connStore.list(new Namespace(namespace.getName(), namespace.getGeneration()),
+                            connection -> connection.getCreated() < upgradeBeforeTsSecs);
+    });
+
+    if (connections.isEmpty()) {
+      return;
+    }
+
+    for (Connection connection : connections) {
+      // do not upgrade pre configured connection
+      if (connection.isPreconfigured()) {
+        continue;
+      }
+
+      // if it is not upgradable
+      ConnectionType type = connection.getType();
+      if (!ConnectionType.CONN_UPGRADABLE_TYPES.contains(type)) {
+        continue;
+      }
+
+      PluginInfo pluginInfo = artifactLoader.getPluginInfo(type.getConnectorName());
+      if (pluginInfo == null) {
+        LOG.warn("Unable to find the connector for connection type {} with connection name {}, " +
+                   "upgrade will not be done for it", type.name().toLowerCase(), connection.getName());
+        continue;
+      }
+
+      PluginInfo info = new PluginInfo(
+        pluginInfo.getName(), pluginInfo.getType(), pluginInfo.getCategory(),
+        SpecificationUpgradeUtils.getConnectorProperties(type, connection.getProperties()),
+        pluginInfo.getArtifact());
+      ConnectionCreationRequest request = new ConnectionCreationRequest(connection.getDescription(), info);
+      try {
+        discoverer.addConnection(namespace.getName(), connection.getName(), request);
+      } catch (ConflictException e) {
+        // if there is a conflict exception, it is quite possible this connection is already upgraded before
+        LOG.debug("A connection {} already exists, ignoring the upgrade", connection.getName());
+      } catch (Exception e) {
+        LOG.warn("Failed to upgrade connection {}", connection.getName(), e);
+      }
+    }
+    upgradeStore.setEntityUpgradeState(namespace, UpgradeEntityType.CONNECTION, CONN_COMPLETE_STATE);
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ConnectorArtifactLoader.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ConnectorArtifactLoader.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.service.directive;
+
+import io.cdap.cdap.api.artifact.ArtifactInfo;
+import io.cdap.cdap.api.artifact.ArtifactManager;
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.wrangler.utils.ArtifactSummaryComparator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Connector artifact loader
+ */
+public class ConnectorArtifactLoader {
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectorArtifactLoader.class);
+  private static final Map<String, String> CONNECTORS_PLUGINS_MAP;
+
+  static {
+    Map<String, String> connectors = new HashMap<>();
+    connectors.put("BigQuery", "google-cloud");
+    connectors.put("GCS", "google-cloud");
+    connectors.put("Spanner", "google-cloud");
+    connectors.put("Database", "database-plugins");
+    connectors.put("S3", "amazon-s3-plugins");
+    connectors.put("Kafka", "kafka-plugins");
+    CONNECTORS_PLUGINS_MAP = connectors;
+  }
+
+  private final ArtifactManager artifactManager;
+  // map of connector plugin name -> artifact info
+  private final Map<String, PluginInfo> connectors;
+
+  public ConnectorArtifactLoader(ArtifactManager artifactManager) {
+    this.artifactManager = artifactManager;
+    this.connectors = new HashMap<>();
+    reload();
+  }
+
+  @Nullable
+  public PluginInfo getPluginInfo(String connectorName) {
+    return connectors.get(connectorName);
+  }
+
+  public void reload() {
+    connectors.clear();
+
+    List<ArtifactInfo> artifacts;
+    try {
+      artifacts = artifactManager.listArtifacts();
+    } catch (IOException e) {
+      LOG.error("Failed to load connector artifact.", e);
+      return;
+    }
+
+    ArtifactSummaryComparator comparator = new ArtifactSummaryComparator();
+    Map<String, ArtifactSummary> connectorPlugins = new HashMap<>();
+    for (ArtifactInfo artifact : artifacts) {
+      // for now just support upgrading to system scope artifact to save some logic in finding artifacts in
+      // each namespace of connections
+      if (artifact.getScope().equals(ArtifactScope.USER)) {
+        continue;
+      }
+
+      Set<PluginClass> plugins = artifact.getClasses().getPlugins();
+      for (PluginClass plugin : plugins) {
+        // has to be connector type
+        if (!Connector.PLUGIN_TYPE.equalsIgnoreCase(plugin.getType())) {
+          continue;
+        }
+
+        String name = plugin.getName();
+        // has to be one of the migrating connection types
+        if (!CONNECTORS_PLUGINS_MAP.containsKey(name)) {
+          continue;
+        }
+
+        String expectedArtifact = CONNECTORS_PLUGINS_MAP.get(name);
+        // artifact name has to match
+        if (!expectedArtifact.equals(artifact.getName())) {
+          continue;
+        }
+
+        // if not latest, continue
+        if (connectorPlugins.containsKey(name) && comparator.compare(connectorPlugins.get(name), artifact) > 0) {
+          continue;
+        }
+
+        PluginInfo info = new PluginInfo(name, Connector.PLUGIN_TYPE, plugin.getCategory(), Collections.emptyMap(),
+                                         new ArtifactSelectorConfig(artifact.getScope().name().toLowerCase(),
+                                                                    artifact.getName(), artifact.getVersion()));
+        connectorPlugins.put(name, artifact);
+        connectors.put(name, info);
+      }
+    }
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
@@ -1089,7 +1089,7 @@ public class DirectivesHandler extends AbstractDirectiveHandler {
    * @param workspace the workspace to get records from
    * @return list of records.
    */
-  private List<Row> fromWorkspace(Workspace workspace) throws IOException, ClassNotFoundException {
+  public static List<Row> fromWorkspace(Workspace workspace) throws IOException, ClassNotFoundException {
     DataType type = workspace.getType();
     List<Row> rows = new ArrayList<>();
 

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/SpecificationUpgradeUtils.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/SpecificationUpgradeUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.service.directive;
+
+import io.cdap.wrangler.dataset.workspace.Workspace;
+import io.cdap.wrangler.proto.connection.ConnectionType;
+import io.cdap.wrangler.service.bigquery.BigQueryHandler;
+import io.cdap.wrangler.service.database.DatabaseHandler;
+import io.cdap.wrangler.service.gcs.GCSHandler;
+import io.cdap.wrangler.service.kafka.KafkaHandler;
+import io.cdap.wrangler.service.s3.S3Handler;
+import io.cdap.wrangler.service.spanner.SpannerHandler;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Specification util specifically needed for upgrade. Can be used to generate the spec that is known by the
+ * connector/source or generate path. This class is mostly hardcoding and should be removed once we remove the
+ * deprecated handlers.
+ */
+public class SpecificationUpgradeUtils {
+
+  private SpecificationUpgradeUtils() {
+  }
+
+  /**
+   * Method to retrieve the spec that is known to connector/source, this is needed because the connection type handlers
+   * sometimes use a different config name for property, need to have this method to generate the connector properties
+   * in order for the new connection to use.
+   *
+   * @param connectionType the connection type to check
+   * @param properties properties to retrieve connector/source properties
+   * @return properties that can be used by connector
+   */
+  public static Map<String, String> getConnectorProperties(ConnectionType connectionType,
+                                                           Map<String, String> properties) {
+    if (!ConnectionType.CONN_UPGRADABLE_TYPES.contains(connectionType)) {
+      return properties;
+    }
+
+    switch (connectionType) {
+      case BIGQUERY:
+        return BigQueryHandler.getConnectorProperties(properties);
+      case GCS:
+        return GCSHandler.getConnectorProperties(properties);
+      case SPANNER:
+        return SpannerHandler.getConnectorProperties(properties);
+      case S3:
+        return S3Handler.getConnectorProperties(properties);
+      case DATABASE:
+        return DatabaseHandler.getConnectorProperties(properties);
+      case KAFKA:
+        return KafkaHandler.getConnectorProperties(properties);
+      default:
+        return properties;
+    }
+  }
+
+  /**
+   * Get a connector path from the v1 workspace
+   *
+   * @param connectionType connectionType of the workspace
+   * @param workspace the v1 workspace information
+   * @return a connector path, null if the connection type cannot be upgraded to a new connection
+   */
+  @Nullable
+  public static String getPath(ConnectionType connectionType, Workspace workspace) {
+    if (!ConnectionType.CONN_UPGRADABLE_TYPES.contains(connectionType)) {
+      return null;
+    }
+
+    switch (connectionType) {
+      case BIGQUERY:
+        return BigQueryHandler.getPath(workspace);
+      case GCS:
+        return GCSHandler.getPath(workspace);
+      case SPANNER:
+        return SpannerHandler.getPath(workspace);
+      case S3:
+        return S3Handler.getPath(workspace);
+      case DATABASE:
+        return DatabaseHandler.getPath(workspace);
+      case KAFKA:
+        return KafkaHandler.getPath(workspace);
+      default:
+        return null;
+    }
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceUpgrader.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceUpgrader.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.service.directive;
+
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.api.service.SystemServiceContext;
+import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
+import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
+import io.cdap.cdap.etl.proto.connection.SpecGenerationRequest;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.cdap.wrangler.PropertyIds;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.dataset.workspace.Workspace;
+import io.cdap.wrangler.dataset.workspace.WorkspaceDataset;
+import io.cdap.wrangler.proto.NotFoundException;
+import io.cdap.wrangler.proto.connection.ConnectionType;
+import io.cdap.wrangler.proto.workspace.v2.Artifact;
+import io.cdap.wrangler.proto.workspace.v2.Plugin;
+import io.cdap.wrangler.proto.workspace.v2.SampleSpec;
+import io.cdap.wrangler.proto.workspace.v2.StageSpec;
+import io.cdap.wrangler.proto.workspace.v2.WorkspaceDetail;
+import io.cdap.wrangler.proto.workspace.v2.WorkspaceId;
+import io.cdap.wrangler.store.upgrade.UpgradeEntityType;
+import io.cdap.wrangler.store.upgrade.UpgradeState;
+import io.cdap.wrangler.store.upgrade.UpgradeStore;
+import io.cdap.wrangler.store.workspace.WorkspaceStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Upgrader for workspaces. This upgrade should be run after the {@link ConnectionUpgrader}
+ */
+public class WorkspaceUpgrader {
+  private static final Logger LOG = LoggerFactory.getLogger(WorkspaceUpgrader.class);
+  private static final UpgradeState WS_COMPLETE_STATE = new UpgradeState(1L);
+
+  private final UpgradeStore upgradeStore;
+  private final SystemServiceContext context;
+  private final long upgradeBeforeTsSecs;
+  private final ConnectionDiscoverer discoverer;
+  private final WorkspaceStore wsStore;
+
+  public WorkspaceUpgrader(UpgradeStore upgradeStore, SystemServiceContext context, long upgradeBeforeTsSecs,
+                           WorkspaceStore wsStore) {
+    this.upgradeStore = upgradeStore;
+    this.context = context;
+    this.upgradeBeforeTsSecs = upgradeBeforeTsSecs;
+    this.discoverer = new ConnectionDiscoverer(context);
+    this.wsStore = wsStore;
+  }
+
+  public void upgradeWorkspaces() throws Exception {
+    List<NamespaceSummary> namespaces = context.listNamespaces();
+    for (NamespaceSummary ns : namespaces) {
+      UpgradeState state = upgradeStore.getEntityUpgradeState(ns, UpgradeEntityType.WORKSPACE);
+      if (state == null || state.getVersion() == 0L) {
+        upgradeWorkspacesInConnections(ns);
+      }
+    }
+    upgradeStore.setEntityUpgradeState(UpgradeEntityType.WORKSPACE, WS_COMPLETE_STATE);
+  }
+
+  private void upgradeWorkspacesInConnections(NamespaceSummary namespace) {
+    List<Workspace> workspaces = TransactionRunners.run(context, ctx -> {
+      WorkspaceDataset wsDataset = WorkspaceDataset.get(ctx);
+      return wsDataset.listWorkspaces(namespace, upgradeBeforeTsSecs);
+    });
+
+    for (Workspace workspace : workspaces) {
+      List<Row> sample = Collections.emptyList();
+      try {
+        sample = DirectivesHandler.fromWorkspace(workspace);
+      } catch (Exception e) {
+        // this should not happen, but guard here to avoid failing the entire upgrade process
+        LOG.warn("Could not decode the sample data for workspace {}. This workspace will not be upgraded",
+                 workspace.getName(), e);
+      }
+      List<String> directives = workspace.getRequest() == null ? Collections.emptyList() :
+                                  workspace.getRequest().getRecipe().getDirectives();
+      WorkspaceId workspaceId = new WorkspaceId(namespace, workspace.getNamespacedId().getId());
+
+      long now = System.currentTimeMillis();
+      io.cdap.wrangler.proto.workspace.v2.Workspace.Builder ws =
+        io.cdap.wrangler.proto.workspace.v2.Workspace
+          .builder(workspace.getName(), workspace.getNamespacedId().getId()).setDirectives(directives)
+          .setCreatedTimeMillis(now).setUpdatedTimeMillis(now);
+
+      ConnectionType connectionType =
+        ConnectionType.valueOf(workspace.getProperties().get(PropertyIds.CONNECTION_TYPE).toUpperCase());
+      // if it is not upgradable workspace types, just ignore and continue, i.e, ADLS
+      if (!ConnectionType.WORKSPACE_UPGRADABLE_TYPES.contains(connectionType)) {
+        LOG.debug("Workspace {} of type {} is not upgradable. This workspace will not be upgraded",
+                  workspace.getName(), connectionType);
+        continue;
+      }
+
+      // if this type is not related to any connectors, just save it with empty sample sepc,
+      // so there will be no sources created when converting to pipeline,
+      // for now the only type like this is UPLOAD
+      if (!ConnectionType.CONN_UPGRADABLE_TYPES.contains(connectionType)) {
+        wsStore.saveWorkspace(workspaceId, new WorkspaceDetail(ws.build(), sample));
+        continue;
+      }
+
+      String connectorName = connectionType.getConnectorName();
+      String path = SpecificationUpgradeUtils.getPath(connectionType, workspace);
+
+      String connection = workspace.getProperties().get(PropertyIds.CONNECTION_ID);
+      try {
+        ConnectorDetail detail = discoverer.getSpecification(namespace.getName(), connection,
+                                                             new SpecGenerationRequest(path, Collections.emptyMap()));
+
+        SampleSpec spec = new SampleSpec(
+          connection, connectorName, path,
+          detail.getRelatedPlugins().stream().map(plugin -> {
+            ArtifactSelectorConfig artifact = plugin.getArtifact();
+            Plugin pluginSpec = new Plugin(
+              plugin.getName(), plugin.getType(), plugin.getProperties(),
+              new Artifact(artifact.getName(), artifact.getVersion(), artifact.getScope()));
+            return new StageSpec(plugin.getSchema(), pluginSpec);
+          }).collect(Collectors.toSet()));
+        wsStore.saveWorkspace(workspaceId, new WorkspaceDetail(ws.setSampleSpec(spec).build(), sample));
+      } catch (NotFoundException e) {
+        LOG.warn("Connection {} related to workspace {} does not exist. " +
+                   "The workspace will be upgraded without that information", connection, workspace.getName());
+        wsStore.saveWorkspace(workspaceId, new WorkspaceDetail(ws.build(), sample));
+      } catch (Exception e) {
+        LOG.warn("Unable to get the spec from connection {} for workspace {}. The workspace will not be upgraded.",
+                 connection, workspace.getName());
+      }
+    }
+
+    upgradeStore.setEntityUpgradeState(namespace, UpgradeEntityType.WORKSPACE, WS_COMPLETE_STATE);
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/gcs/GCSHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/gcs/GCSHandler.java
@@ -38,6 +38,7 @@ import io.cdap.wrangler.SamplingMethod;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.dataset.connections.ConnectionStore;
 import io.cdap.wrangler.dataset.workspace.DataType;
+import io.cdap.wrangler.dataset.workspace.Workspace;
 import io.cdap.wrangler.dataset.workspace.WorkspaceDataset;
 import io.cdap.wrangler.dataset.workspace.WorkspaceMeta;
 import io.cdap.wrangler.proto.BadRequestException;
@@ -75,6 +76,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
@@ -406,6 +408,19 @@ public class GCSHandler extends AbstractWranglerHandler {
       });
 
     });
+  }
+
+  public static Map<String, String> getConnectorProperties(Map<String, String> config) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("serviceAccountType", "filePath");
+    properties.put("serviceFilePath", config.get(GCPUtils.SERVICE_ACCOUNT_KEYFILE));
+    properties.put("project", config.get(GCPUtils.PROJECT_ID));
+    properties.values().removeIf(Objects::isNull);
+    return properties;
+  }
+
+  public static String getPath(Workspace workspace) {
+    return workspace.getProperties().get(PropertyIds.URI);
   }
 
   private Set<String> getBucketWhitelist(Connection connection) {

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/kafka/KafkaHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/kafka/KafkaHandler.java
@@ -28,6 +28,7 @@ import io.cdap.wrangler.SamplingMethod;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.dataset.connections.ConnectionStore;
 import io.cdap.wrangler.dataset.workspace.DataType;
+import io.cdap.wrangler.dataset.workspace.Workspace;
 import io.cdap.wrangler.dataset.workspace.WorkspaceDataset;
 import io.cdap.wrangler.dataset.workspace.WorkspaceMeta;
 import io.cdap.wrangler.proto.ConnectionSample;
@@ -210,5 +211,16 @@ public final class KafkaHandler extends AbstractWranglerHandler {
       KafkaSpec kafkaSpec = new KafkaSpec(pluginSpec);
       return new ServiceResponse<>(kafkaSpec);
     });
+  }
+
+  public static Map<String, String> getConnectorProperties(Map<String, String> config) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("brokers", config.get(PropertyIds.BROKER));
+    properties.put("kafkaBrokers", config.get(PropertyIds.BROKER));
+    return properties;
+  }
+
+  public static String getPath(Workspace workspace) {
+    return workspace.getProperties().get(PropertyIds.TOPIC);
   }
 }

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/connections/ConnectionStore.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/connections/ConnectionStore.java
@@ -19,6 +19,7 @@ package io.cdap.wrangler.dataset.connections;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.api.NamespaceSummary;
 import io.cdap.cdap.api.Predicate;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
@@ -205,6 +206,17 @@ public class ConnectionStore {
       }
       return result;
     }
+  }
+
+  /**
+   * Delete all connection with the namespace and generation id
+   */
+  public void deleteAll(NamespaceSummary namespace) throws IOException {
+    List<Field<?>> key = new ArrayList<>(2);
+    key.add(Fields.stringField(NAMESPACE_COL, namespace.getName()));
+    key.add(Fields.longField(GENERATION_COL, namespace.getGeneration()));
+    Range range = Range.singleton(key);
+    table.deleteAll(range);
   }
 
   /**

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/store/upgrade/UpgradeEntityType.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/store/upgrade/UpgradeEntityType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.store.upgrade;
+
+/**
+ * Upgrade entity type
+ */
+public enum UpgradeEntityType {
+  WORKSPACE,
+  CONNECTION
+}

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/store/upgrade/UpgradeState.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/store/upgrade/UpgradeState.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.store.upgrade;
+
+import java.util.Objects;
+
+/**
+ * Upgrade state to store any upgrade related information. Can be extended to contain more information about the
+ * upgrade information
+ */
+public class UpgradeState {
+  // this version is the storage version, if in the future, we want to upgrade the entity type again,
+  // we can use this to check what the previous upgraded version is.
+  private final long version;
+
+  public UpgradeState(long version) {
+    this.version = version;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    UpgradeState that = (UpgradeState) o;
+    return version == that.version;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version);
+  }
+}

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/store/upgrade/UpgradeStore.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/store/upgrade/UpgradeStore.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.store.upgrade;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.spi.data.StructuredRow;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Upgrade store to store upgrade information for each namespace,
+ * Use system namespace to track the overall upgrade status.
+ * This upgrade store can be used as a general purpose for app upgrade:
+ * it has primary key as [namespace][namespace-generation][entity-type] and value [upgrade-ts-millis][upgrade-state]
+ * upgrade state is a serialized string which represents the overall upgrade information and status
+ */
+public class UpgradeStore {
+  private static final NamespaceSummary SYSTEM_NS = new NamespaceSummary("system", "", 0L);
+  private static final StructuredTableId TABLE_ID = new StructuredTableId("app_upgrade");
+  private static final Gson GSON = new Gson();
+
+  private static final String NAMESPACE_COL = "namespace";
+  private static final String GENERATION_COL = "generation";
+  private static final String ENTITY_TYPE_COL = "entity_type";
+  private static final String UPGRADE_STATE_COL = "upgrade_state";
+  private static final String UPGRADE_TIMESTAMP = "upgrade_timestamp";
+
+  public static final StructuredTableSpecification UPGRADE_TABLE_SPEC =
+    new StructuredTableSpecification.Builder()
+      .withId(TABLE_ID)
+      .withFields(Fields.stringType(NAMESPACE_COL),
+                  Fields.longType(GENERATION_COL),
+                  Fields.stringType(ENTITY_TYPE_COL),
+                  Fields.stringType(UPGRADE_STATE_COL),
+                  Fields.longType(UPGRADE_TIMESTAMP))
+      .withPrimaryKeys(NAMESPACE_COL, GENERATION_COL, ENTITY_TYPE_COL)
+      .build();
+
+  private final TransactionRunner transactionRunner;
+
+  public UpgradeStore(TransactionRunner transactionRunner) {
+    this.transactionRunner = transactionRunner;
+  }
+
+  /**
+   * Initialize the upgrade timestamp and state for the given upgrade types if not there and
+   * return the upgrade timestamp. This method should be called before any upgrade starts.
+   * The upgrade will only operate on entities created before this timestamp.
+   *
+   * @param type the upgrade entity type
+   * @param timestampMillis the upgrade timestamp in millis
+   * @param preUpgradeState the state before upgrade
+   * @return the upgrade timestamp
+   */
+  public long initializeAndRetrieveUpgradeTimestampMillis(UpgradeEntityType type, long timestampMillis,
+                                                          UpgradeState preUpgradeState) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      Collection<Field<?>> fields = getPrimaryKeys(SYSTEM_NS, type);
+      Optional<StructuredRow> row = table.read(fields);
+
+      fields.add(Fields.longField(UPGRADE_TIMESTAMP, timestampMillis));
+      fields.add(Fields.stringField(UPGRADE_STATE_COL, GSON.toJson(preUpgradeState)));
+
+      if (!row.isPresent()) {
+        table.upsert(fields);
+        return timestampMillis;
+      }
+
+      // return the upgrade timestamp
+      return row.get().getLong(UPGRADE_TIMESTAMP);
+    });
+  }
+
+  /**
+   * Set the upgrade complete status for the entity type
+   */
+  public void setEntityUpgradeState(UpgradeEntityType type, UpgradeState upgradeState) {
+    TransactionRunners.run(transactionRunner, context -> {
+      setComplete(SYSTEM_NS, context, type, upgradeState);
+    });
+  }
+
+  /**
+   * Set the upgrade complete status for the entity type in a namespace
+   *
+   * @param namespace namespace that completed upgrade
+   */
+  public void setEntityUpgradeState(NamespaceSummary namespace, UpgradeEntityType type, UpgradeState upgradeState) {
+    TransactionRunners.run(transactionRunner, context -> {
+      setComplete(namespace, context, type, upgradeState);
+    });
+  }
+
+  /**
+   * Get the upgrade state
+   */
+  @Nullable
+  public UpgradeState getEntityUpgradeState(UpgradeEntityType type) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getEntityUpgradeState(SYSTEM_NS, context, type);
+    });
+  }
+
+  /**
+   * Checks whether an entity type is upgrade complete in a namespace
+   */
+  public UpgradeState getEntityUpgradeState(NamespaceSummary namespace, UpgradeEntityType type) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getEntityUpgradeState(namespace, context, type);
+    });
+  }
+
+  // visible for testing, storage do not have guava dependency so cannot add annotation
+  void clear() {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      table.deleteAll(Range.all());
+    });
+  }
+
+  private void setComplete(NamespaceSummary namespace, StructuredTableContext context,
+                           UpgradeEntityType type, UpgradeState upgradeState) throws IOException {
+    StructuredTable table = context.getTable(TABLE_ID);
+    Collection<Field<?>> fields = getPrimaryKeys(namespace, type);
+    fields.add(Fields.stringField(UPGRADE_STATE_COL, GSON.toJson(upgradeState)));
+    table.upsert(fields);
+  }
+
+  @Nullable
+  private UpgradeState getEntityUpgradeState(NamespaceSummary namespace, StructuredTableContext context,
+                                             UpgradeEntityType type) throws IOException {
+    StructuredTable table = context.getTable(TABLE_ID);
+    Collection<Field<?>> fields = getPrimaryKeys(namespace, type);
+    Optional<StructuredRow> row = table.read(fields);
+    if (!row.isPresent() || row.get().getString(UPGRADE_STATE_COL) == null) {
+      return null;
+    }
+
+    return GSON.fromJson(row.get().getString(UPGRADE_STATE_COL), UpgradeState.class);
+  }
+
+  private Collection<Field<?>> getPrimaryKeys(NamespaceSummary namespace, UpgradeEntityType entityType) {
+    List<Field<?>> keys = new ArrayList<>(getNamespaceKeys(namespace));
+    keys.add(Fields.stringField(ENTITY_TYPE_COL, entityType.name()));
+    return keys;
+  }
+
+  private Collection<Field<?>> getNamespaceKeys(NamespaceSummary namespace) {
+    List<Field<?>> keys = new ArrayList<>();
+    keys.add(Fields.stringField(NAMESPACE_COL, namespace.getName()));
+    keys.add(Fields.longField(GENERATION_COL, namespace.getGeneration()));
+    return keys;
+  }
+}

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/store/upgrade/UpgradeStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/store/upgrade/UpgradeStoreTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.wrangler.store.upgrade;
+
+import com.google.common.collect.ImmutableList;
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.utils.Tasks;
+import io.cdap.cdap.test.SystemAppTestBase;
+import io.cdap.cdap.test.TestConfiguration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Upgrade store test
+ */
+public class UpgradeStoreTest extends SystemAppTestBase {
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+  private static UpgradeStore store;
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    getStructuredTableAdmin().create(UpgradeStore.UPGRADE_TABLE_SPEC);
+    store = new UpgradeStore(getTransactionRunner());
+  }
+
+  @After
+  public void cleanupTest() throws Exception {
+    store.clear();
+  }
+
+  @Test
+  public void testUpgradeTimestampDoesNotChange() throws Exception {
+    long tsNow = System.currentTimeMillis();
+    long upgradeTs = store.initializeAndRetrieveUpgradeTimestampMillis(
+      UpgradeEntityType.CONNECTION, tsNow, new UpgradeState(0L));
+    Assert.assertTrue(upgradeTs > 0);
+    // wait for time to pass at least 1 milli second
+    Tasks.waitFor(true, () -> System.currentTimeMillis() > upgradeTs, 5, TimeUnit.MILLISECONDS);
+    long actual = store.initializeAndRetrieveUpgradeTimestampMillis(
+      UpgradeEntityType.CONNECTION, System.currentTimeMillis(), new UpgradeState(1L));
+    Assert.assertEquals(upgradeTs, actual);
+    Assert.assertEquals(new UpgradeState(0L), store.getEntityUpgradeState(UpgradeEntityType.CONNECTION));
+  }
+
+  @Test
+  public void testUpgradeStore() throws Exception {
+    List<NamespaceSummary> namespaces = ImmutableList.of(
+      new NamespaceSummary("default", "", 0L),
+      new NamespaceSummary("test1", "", 1L),
+      new NamespaceSummary("test2", "", 0L),
+      new NamespaceSummary("test3", "", 5L));
+
+    Assert.assertNull(store.getEntityUpgradeState(UpgradeEntityType.CONNECTION));
+    Assert.assertNull(store.getEntityUpgradeState(UpgradeEntityType.WORKSPACE));
+
+    UpgradeState preUpgrade = new UpgradeState(0L);
+    store.initializeAndRetrieveUpgradeTimestampMillis(UpgradeEntityType.CONNECTION,
+                                                      System.currentTimeMillis(), preUpgrade);
+    store.initializeAndRetrieveUpgradeTimestampMillis(UpgradeEntityType.WORKSPACE,
+                                                      System.currentTimeMillis(), preUpgrade);
+    Assert.assertEquals(preUpgrade, store.getEntityUpgradeState(UpgradeEntityType.CONNECTION));
+    Assert.assertEquals(preUpgrade, store.getEntityUpgradeState(UpgradeEntityType.WORKSPACE));
+
+    UpgradeState upgraded = new UpgradeState(1L);
+
+    // assert connection upgrade completion
+    namespaces.forEach(ns -> {
+      store.setEntityUpgradeState(ns, UpgradeEntityType.CONNECTION, upgraded);
+      Assert.assertEquals(upgraded, store.getEntityUpgradeState(ns, UpgradeEntityType.CONNECTION));
+      Assert.assertEquals(preUpgrade, store.getEntityUpgradeState(UpgradeEntityType.CONNECTION));
+      Assert.assertEquals(preUpgrade, store.getEntityUpgradeState(UpgradeEntityType.WORKSPACE));
+    });
+
+    // connection upgrade is done
+    store.setEntityUpgradeState(UpgradeEntityType.CONNECTION, upgraded);
+    Assert.assertEquals(upgraded, store.getEntityUpgradeState(UpgradeEntityType.CONNECTION));
+    Assert.assertEquals(preUpgrade, store.getEntityUpgradeState(UpgradeEntityType.WORKSPACE));
+
+    // assert workspace upgrade completion
+    namespaces.forEach(ns -> {
+      store.setEntityUpgradeState(ns, UpgradeEntityType.WORKSPACE, upgraded);
+      Assert.assertEquals(upgraded, store.getEntityUpgradeState(ns, UpgradeEntityType.WORKSPACE));
+      Assert.assertEquals(preUpgrade, store.getEntityUpgradeState(UpgradeEntityType.WORKSPACE));
+      Assert.assertEquals(upgraded, store.getEntityUpgradeState(UpgradeEntityType.CONNECTION));
+    });
+
+    // workspace upgrade is done
+    store.setEntityUpgradeState(UpgradeEntityType.WORKSPACE, upgraded);
+
+    // upgrade is done
+    Assert.assertEquals(upgraded, store.getEntityUpgradeState(UpgradeEntityType.CONNECTION));
+    Assert.assertEquals(upgraded, store.getEntityUpgradeState(UpgradeEntityType.WORKSPACE));
+  }
+}


### PR DESCRIPTION
Contains some unavoided hardcoding to convert the connection type to our connector. 
The upgraded connection and workspaces should just behave the new connections and workspaces, i.e, workspace automatically fill out spec, plugin info and use connection in source when transforming into studio page.
For connections and workspaces that are unsupported for upgrade, i.e, ADLS, or connections already get deleted, transforming it to studio will only have the wrangler stage. 
For database connections and workspaces, it is possible that we are not able to get schema due to incompatibility of jdbc url string. The rest should look like the same