### PR TITLE
CDAP-18238 fix sample upgrade issue

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/Row.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/Row.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 @PublicEvolving
 public final class Row implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(Row.class);
+  private static final long serialVersionUID = -7505703059736709602L;
 
   // Name of the columns held by the row.
   private List<String> columns = new ArrayList<>();


### PR DESCRIPTION
Row is serializable but it does not have a serial id, so when we changed the content, the serial does not match before and after upgrade, add the serial id before upgrade to fix the issue