### PR TITLE
Let the db connection use old way to generate schema and spec

### DIFF
--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/database/DatabaseHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/database/DatabaseHandler.java
@@ -50,7 +50,6 @@ import io.cdap.wrangler.proto.db.DBSpec;
 import io.cdap.wrangler.proto.db.JDBCDriverInfo;
 import io.cdap.wrangler.service.common.AbstractWranglerHandler;
 import io.cdap.wrangler.service.macro.ServiceMacroEvaluator;
-import io.cdap.wrangler.service.s3.S3Configuration;
 import io.cdap.wrangler.utils.ObjectSerDe;
 import io.cdap.wrangler.utils.ReferenceNames;
 import org.apache.commons.lang3.text.StrLookup;
@@ -498,21 +497,25 @@ public class DatabaseHandler extends AbstractWranglerHandler {
     respond(request, responder, namespace, ns -> {
       Connection conn = getConnection(new NamespacedId(ns, id));
 
-      Map<String, String> properties = new HashMap<>();
-      properties.put("connectionString", conn.getProperties().get("url"));
-      properties.put("referenceName", ReferenceNames.cleanseReferenceName(table));
-      properties.put("user", conn.getProperties().get("username"));
-      properties.put("password", conn.getProperties().get("password"));
-      properties.put("importQuery", String.format("SELECT * FROM %s WHERE $CONDITIONS", table));
-      properties.put("numSplits", "1");
-      properties.put("jdbcPluginName", conn.getProperties().get("name"));
-      properties.put("jdbcPluginType", conn.getProperties().get("type"));
-
-      PluginSpec pluginSpec = new PluginSpec(String.format("Database - %s", table), "source", properties);
+      PluginSpec pluginSpec = new PluginSpec(String.format("Database - %s", table), "source",
+                                             getSpecification(conn, table));
       DBSpec spec = new DBSpec(pluginSpec);
 
       return new ServiceResponse<>(spec);
     });
+  }
+
+  public static Map<String, String> getSpecification(Connection conn, String table) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("connectionString", conn.getProperties().get("url"));
+    properties.put("referenceName", ReferenceNames.cleanseReferenceName(table));
+    properties.put("user", conn.getProperties().get("username"));
+    properties.put("password", conn.getProperties().get("password"));
+    properties.put("importQuery", String.format("SELECT * FROM %s WHERE $CONDITIONS", table));
+    properties.put("numSplits", "1");
+    properties.put("jdbcPluginName", conn.getProperties().get("name"));
+    properties.put("jdbcPluginType", conn.getProperties().get("type"));
+    return properties;
   }
 
   public static Map<String, String> getConnectorProperties(Map<String, String> config) {
@@ -526,9 +529,10 @@ public class DatabaseHandler extends AbstractWranglerHandler {
   }
 
   // TODO: this path will not work with current db connector if the database type supports schema,
-  //  but it should still give back the related source information.
+  //  but it should still give back the related source information. Passing a root path so it will not interact with
+  //  the actual database due to messed schema/table name
   public static String getPath(Workspace workspace) {
-    return workspace.getProperties().get(PropertyIds.NAME);
+    return "/";
   }
 
   /**

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/AbstractDirectiveHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/AbstractDirectiveHandler.java
@@ -261,7 +261,7 @@ public class AbstractDirectiveHandler extends AbstractWranglerHandler {
    * @param rows list of all rows.
    * @return A single record will rows merged across all columns.
    */
-  protected static Row createUberRecord(List<Row> rows) {
+  public static Row createUberRecord(List<Row> rows) {
     Row uber = new Row();
     for (Row row : rows) {
       for (int i = 0; i < row.width(); ++i) {

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ConnectionUpgrader.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ConnectionUpgrader.java
@@ -74,10 +74,6 @@ public class ConnectionUpgrader {
                             connection -> connection.getCreated() < upgradeBeforeTsSecs);
     });
 
-    if (connections.isEmpty()) {
-      return;
-    }
-
     for (Connection connection : connections) {
       // do not upgrade pre configured connection
       if (connection.isPreconfigured()) {


### PR DESCRIPTION
This change is needed because the upgraded db workspaces will have different behavior depending on whether the database type supports schema:
1. For mysql, it will work and source schema is generated since it does not have schema, so the given path with just a table in that will generate the schema
2. For SQLServer, it will not generate the source schema, and getSpec call might fail because the path we give is a table name, and db connector will consider it as schema. 

To avoid such confusion, for db types, we use old ways to generate the spec.