### PR TITLE
Expand Calculate Options

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/ArithmeticOperations.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/ArithmeticOperations.java
@@ -24,380 +24,483 @@ import java.math.RoundingMode;
  * Cross-column operations for arithmetic
  */
 public class ArithmeticOperations {
-  /**
-   * Arithmetic operation - Add two columns.
-   */
-  public static Integer add(Integer x, Integer y) {
-    if (x == null || y == null) {
-      return null;
+  // The Number types upon which arithmetic operations can be performed, in order of increasing generality
+  private enum NumberType {
+    SHORT(0),
+    INTEGER(1),
+    LONG(2),
+    FLOAT(3),
+    DOUBLE(4),
+    BIGDECIMAL(5);
+
+    private final int priority;
+
+    NumberType(int priority) {
+      this.priority = priority;
     }
-    return x + y;
+
+    public int getPriority() {
+      return priority;
+    }
   }
 
   /**
-   * Arithmetic operation - Add two columns.
+   * Return the "largest" (e.g. most general) type of the given numbers.
+   * Used for operations applied to columns of multiple types, in order to determine the type of the output column.
+   * The order of increasing generality is Short < Integer < Long < Float < Double < BigDecimal.
+   * Returns null if any input is null.
+   * Throws an error if any input of type Byte is given (this is not currently supported for arithmetic ops).
    */
-  public static Double add(Double x, Double y) {
-    if (x == null || y == null) {
-      return null;
+  private static NumberType getOutputType(Number... nums) throws DirectiveExecutionException {
+    NumberType outputType = NumberType.SHORT;
+    for (Number num : nums) {
+      if (num instanceof Byte) {
+        throw new DirectiveExecutionException("Input cannot be of type 'Byte'.");
+      } else if (num == null) {
+        return null;
+      } else if (num instanceof Integer && NumberType.INTEGER.getPriority() > outputType.getPriority()) {
+        outputType = NumberType.INTEGER;
+      } else if (num instanceof Long && NumberType.LONG.getPriority() > outputType.getPriority()) {
+        outputType = NumberType.LONG;
+      } else if (num instanceof Float && NumberType.FLOAT.getPriority() > outputType.getPriority()) {
+        outputType = NumberType.FLOAT;
+      } else if (num instanceof Double && NumberType.DOUBLE.getPriority() > outputType.getPriority()) {
+        outputType = NumberType.DOUBLE;
+      } else if (num instanceof BigDecimal) {
+        return NumberType.BIGDECIMAL;
+      }
     }
-    return x + y;
+    return outputType;
   }
 
   /**
-   * Arithmetic operation - Add two columns.
+   * Utility function to convert a number type to BigDecimal
    */
-  public static Float add(Float x, Float y) {
-    if (x == null || y == null) {
-      return null;
-    }
-    return x + y;
+  private static BigDecimal numberToBigDecimal(Number num) {
+    return num instanceof BigDecimal ? (BigDecimal) num : new BigDecimal(num.toString());
   }
 
   /**
-   * Arithmetic operation - Add two columns.
+   * Arithmetic operation - Find the sum of any number of columns, of any valid types.
+   * Output type is most general of input types.
+   * Returns null if any input value is null.
    */
-  public static BigDecimal add(BigDecimal x, BigDecimal y) {
-    if (x == null || y == null) {
+  public static Number add(Number... nums) throws DirectiveExecutionException {
+    NumberType outputType = getOutputType(nums);
+    if (outputType == null) {
       return null;
     }
-    return x.add(y).stripTrailingZeros();
+    switch (outputType) {
+      case SHORT:
+        short shortSum = 0;
+        for (Number num : nums) {
+          shortSum += num.shortValue();
+        }
+        return shortSum;
+      case INTEGER:
+        int intSum = 0;
+        for (Number num : nums) {
+          intSum += num.intValue();
+        }
+        return intSum;
+      case LONG:
+        long longSum = 0;
+        for (Number num : nums) {
+          longSum += num.longValue();
+        }
+        return longSum;
+      case FLOAT:
+        float floatSum = 0;
+        for (Number num : nums) {
+          floatSum += num.floatValue();
+        }
+        return floatSum;
+      case DOUBLE:
+        double doubleSum = 0;
+        for (Number num : nums) {
+          doubleSum += num.doubleValue();
+        }
+        return doubleSum;
+      default:
+        BigDecimal bdSum = BigDecimal.valueOf(0);
+        for (Number num : nums) {
+          bdSum = bdSum.add(numberToBigDecimal(num));
+        }
+        return bdSum.stripTrailingZeros();
+    }
   }
 
   /**
-   * Arithmetic operation - Subtract a column from another column.
+   * Arithmetic operation - subtract a column from another column.
+   * Output type is most general of input types.
+   * Returns null if any input value is null.
    */
-  public static Integer minus(Integer x, Integer y) {
-    if (x == null || y == null) {
+  public static Number minus(Number x, Number y) throws DirectiveExecutionException {
+    NumberType outputType = getOutputType(x, y);
+    if (outputType == null) {
       return null;
     }
-    return x - y;
+    switch (outputType) {
+      case SHORT:
+        return (short) (x.shortValue() - y.shortValue());
+      case INTEGER:
+        return x.intValue() - y.intValue();
+      case LONG:
+        return x.longValue() - y.longValue();
+      case FLOAT:
+        return x.floatValue() - y.floatValue();
+      case DOUBLE:
+        return x.doubleValue() - y.doubleValue();
+      default:
+        BigDecimal bdX = numberToBigDecimal(x);
+        BigDecimal bdY = numberToBigDecimal(y);
+        return bdX.subtract(bdY).stripTrailingZeros();
+    }
   }
 
   /**
-   * Arithmetic operation - Subtract a column from another column.
+   * Arithmetic operation - multiply any number of columns, of any types.
+   * Output type is most general of input types.
+   * Returns null if any input value is null.
    */
-  public static Double minus(Double x, Double y) {
-    if (x == null || y == null) {
+  public static Number multiply(Number... nums) throws DirectiveExecutionException {
+    NumberType outputType = getOutputType(nums);
+    if (outputType == null) {
       return null;
     }
-    return x - y;
+    switch (outputType) {
+      case SHORT:
+        short shortProd = 1;
+        for (Number num : nums) {
+          shortProd *= num.shortValue();
+        }
+        return shortProd;
+      case INTEGER:
+        int intProd = 1;
+        for (Number num : nums) {
+          intProd *= num.intValue();
+        }
+        return intProd;
+      case LONG:
+        long longProd = 1;
+        for (Number num : nums) {
+          longProd *= num.longValue();
+        }
+        return longProd;
+      case FLOAT:
+        float floatProd = 1;
+        for (Number num : nums) {
+          floatProd *= num.floatValue();
+        }
+        return floatProd;
+      case DOUBLE:
+        double doubleProd = 1;
+        for (Number num : nums) {
+          doubleProd *= num.doubleValue();
+        }
+        return doubleProd;
+      default:
+        BigDecimal bdProd = BigDecimal.valueOf(1);
+        for (Number num : nums) {
+          bdProd = bdProd.multiply(numberToBigDecimal(num));
+        }
+        return bdProd;
+    }
   }
 
   /**
-   * Arithmetic operation - Subtract a column from another column.
+   * Arithmetic operation - divides one column by another.
+   * Output type is Double, except when there is an input of type BigDecimal, in which case the output is BigDecimal.
+   * Returns null if any input value is null, or if the divisor equals 0.
    */
-  public static Float minus(Float x, Float y) {
-    if (x == null || y == null) {
+  public static Number divideq(Number x, Number y) throws DirectiveExecutionException {
+    NumberType outputType = getOutputType(x, y);
+    if (outputType == null || y.doubleValue() == 0) {
       return null;
     }
-    return x - y;
+    switch (outputType) {
+      case BIGDECIMAL:
+        BigDecimal bdX = numberToBigDecimal(x);
+        BigDecimal bdY = numberToBigDecimal(y);
+        return bdX.divide(bdY, BigDecimal.ROUND_HALF_EVEN).stripTrailingZeros();
+      default:
+        return x.doubleValue() / y.doubleValue();
+    }
   }
 
   /**
-   * Arithmetic operation - Subtract a column from another column.
+   * Arithmetic operation - divides one column by another and returns the remainder.
+   * Output type is most general of input types, except 2 Shorts should give an Integer.
+   * Returns null if any input value is null.
    */
-  public static BigDecimal minus(BigDecimal x, BigDecimal y) {
-    if (x == null || y == null) {
+  public static Number divider(Number x, Number y) throws DirectiveExecutionException {
+    NumberType outputType = getOutputType(x, y);
+    if (outputType == null || y.doubleValue() == 0) {
       return null;
     }
-    return x.subtract(y).stripTrailingZeros();
+    switch (outputType) {
+      case SHORT:
+        return x.shortValue() % y.shortValue();
+      case INTEGER:
+        return x.intValue() % y.intValue();
+      case LONG:
+        return x.longValue() % y.longValue();
+      case FLOAT:
+        return x.floatValue() % y.floatValue();
+      case DOUBLE:
+        return x.doubleValue() % y.doubleValue();
+      default:
+        BigDecimal bdX = numberToBigDecimal(x);
+        BigDecimal bdY = numberToBigDecimal(y);
+        return bdX.remainder(bdY);
+    }
   }
 
   /**
-   Arithmetic operation - Multiply a column with another column.
+   * Arithmetic operation - calculates the LCM of two columns.
+   * Output type is most general of input types.
+   * Returns null if any input value is null.
    */
-  public static Integer multiply(Integer x, Integer y) {
-    if (x == null || y == null) {
+  public static Number lcm(Number x, Number y) throws DirectiveExecutionException {
+    NumberType outputType = getOutputType(x, y);
+    if (outputType == null) {
       return null;
     }
-    return x * y;
+    BigDecimal bdX = numberToBigDecimal(x);
+    BigDecimal bdY = numberToBigDecimal(y);
+    switch (outputType) {
+      case SHORT:
+        return lcm(bdX, bdY).shortValue();
+      case INTEGER:
+        return lcm(bdX, bdY).intValue();
+      case LONG:
+        return lcm(bdX, bdY).longValue();
+      case FLOAT:
+        return lcm(bdX, bdY).floatValue();
+      case DOUBLE:
+        return lcm(bdX, bdY).doubleValue();
+      default:
+        BigDecimal pow = BigDecimal.valueOf(Math.pow(10, Math.max(bdX.scale(), bdY.scale())));
+        BigInteger val1 = bdX.multiply(pow).toBigInteger();
+        BigInteger val2 = bdY.multiply(pow).toBigInteger();
+        BigDecimal absProduct = new BigDecimal(val1.multiply(val2).abs())
+          .setScale(Math.min(bdX.scale(), bdY.scale()), BigDecimal.ROUND_HALF_EVEN);
+        BigDecimal gcd = new BigDecimal(val1.gcd(val2));
+        if (gcd.compareTo(BigDecimal.ZERO) == 0) {
+          return BigDecimal.ZERO;
+        }
+        return absProduct.divide(gcd.multiply(pow), BigDecimal.ROUND_HALF_EVEN);
+    }
   }
 
   /**
-   * Arithmetic operation - Multiply a column with another column.
+   Arithmetic operation - Check if all values are equal across any number of Short columns.
    */
-  public static Double multiply(Double x, Double y) {
-    if (x == null || y == null) {
-      return null;
+  public static Boolean equal(Short... nums) {
+    for (Short num : nums) {
+      if (num == null) {
+        return null;
+      }
+      if (!num.equals(nums[0])) {
+        return Boolean.FALSE;
+      }
     }
-    return x * y;
+    return Boolean.TRUE;
   }
 
   /**
-   * Arithmetic operation - Multiply a column with another column.
+   Arithmetic operation - Check if all values are equal across any number of Integer columns.
    */
-  public static Float multiply(Float x, Float y) {
-    if (x == null || y == null) {
-      return null;
+  public static Boolean equal(Integer... nums) {
+    for (Integer num : nums) {
+      if (num == null) {
+        return null;
+      }
+      if (!num.equals(nums[0])) {
+        return Boolean.FALSE;
+      }
     }
-    return x * y;
+    return Boolean.TRUE;
   }
 
   /**
-   * Arithmetic operation - Multiply a column with another column.
+   Arithmetic operation - Check if all values are equal across any number of Long columns.
    */
-  public static BigDecimal multiply(BigDecimal x, BigDecimal y) {
-    if (x == null || y == null) {
-      return null;
+  public static Boolean equal(Long... nums) {
+    for (Long num : nums) {
+      if (num == null) {
+        return null;
+      }
+      if (!num.equals(nums[0])) {
+        return Boolean.FALSE;
+      }
     }
-    return x.multiply(y);
+    return Boolean.TRUE;
   }
 
   /**
-   * Arithmetic operation - Divide a column by another and return the quotient.
+   Arithmetic operation - Check if all values are equal across any number of Float columns.
    */
-  public static Integer divideq(Integer x, Integer y) {
-    if (x == null || y == null || y == 0) {
-      return null;
+  public static Boolean equal(Float... nums) {
+    for (Float num : nums) {
+      if (num == null) {
+        return null;
+      }
+      if (!num.equals(nums[0])) {
+        return Boolean.FALSE;
+      }
     }
-    return x / y;
+    return Boolean.TRUE;
   }
 
   /**
-   * Arithmetic operation - Divide a column by another and return the quotient.
+   Arithmetic operation - Check if all values are equal across any number of Double columns.
    */
-  public static Double divideq(Double x, Double y) {
-    if (x == null || y == null || y == 0) {
-      return null;
+  public static Boolean equal(Double... nums) {
+    for (Double num : nums) {
+      if (num == null) {
+        return null;
+      }
+      if (!num.equals(nums[0])) {
+        return Boolean.FALSE;
+      }
     }
-    return x / y;
+    return Boolean.TRUE;
   }
 
   /**
-   * Arithmetic operation - Divide a column by another and return the quotient.
+   Arithmetic operation - Check if all values are equal across any number of BigDecimal columns.
    */
-  public static Float divideq(Float x, Float y) {
-    if (x == null || y == null || y == 0) {
-      return null;
+  public static Boolean equal(BigDecimal... nums) {
+    for (BigDecimal num : nums) {
+      if (num == null) {
+        return null;
+      }
+      if (!num.equals(nums[0])) {
+        return Boolean.FALSE;
+      }
     }
-    return x / y;
+    return Boolean.TRUE;
   }
 
   /**
-   * Arithmetic operation - Divide a column by another and return the quotient.
+   * Arithmetic operation - Find the maximum of any number of columns, of any valid types.
+   * Output type is most general of input types.
+   * Returns null if any input value is null.
    */
-  public static BigDecimal divideq(BigDecimal x, BigDecimal y) {
-    if (x == null || y == null || y.equals(BigDecimal.valueOf(0))) {
+  public static Number max(Number... nums) throws DirectiveExecutionException {
+    NumberType outputType = getOutputType(nums);
+    if (outputType == null) {
       return null;
     }
-    return x.divide(y, BigDecimal.ROUND_HALF_EVEN).stripTrailingZeros();
+    switch (outputType) {
+      case SHORT:
+        short shortMax = nums[0].shortValue();
+        for (Number num : nums) {
+          if (num.shortValue() > shortMax) {
+            shortMax = num.shortValue();
+          }
+        }
+        return shortMax;
+      case INTEGER:
+        int intMax = nums[0].intValue();
+        for (Number num : nums) {
+          if (num.intValue() > intMax) {
+            intMax = num.intValue();
+          }
+        }
+        return intMax;
+      case LONG:
+        long longMax = nums[0].longValue();
+        for (Number num : nums) {
+          if (num.longValue() > longMax) {
+            longMax = num.longValue();
+          }
+        }
+        return longMax;
+      case FLOAT:
+        float floatMax = nums[0].floatValue();
+        for (Number num : nums) {
+          if (num.floatValue() > floatMax) {
+            floatMax = num.floatValue();
+          }
+        }
+        return floatMax;
+      case DOUBLE:
+        double doubleMax = nums[0].doubleValue();
+        for (Number num : nums) {
+          if (num.doubleValue() > doubleMax) {
+            doubleMax = num.doubleValue();
+          }
+        }
+        return doubleMax;
+      default:
+        BigDecimal bdMax = new BigDecimal(nums[0].toString());
+        for (Number num : nums) {
+          bdMax = bdMax.max(numberToBigDecimal(num));
+        }
+        return bdMax;
+    }
   }
 
   /**
-   * Arithmetic operation - Divide a column by another and return the remainder.
+   * Arithmetic operation - Find the minimum of any number of columns, of any valid types.
+   * Output type is most general of input types.
+   * Returns null if any input value is null.
    */
-  public static Integer divider(Integer x, Integer y) {
-    if (x == null || y == null || y == 0) {
+  public static Number min(Number... nums) throws DirectiveExecutionException {
+    NumberType outputType = getOutputType(nums);
+    if (outputType == null) {
       return null;
     }
-    return x % y;
-  }
-
-  /**
-   * Arithmetic operation - Divide a column by another and return the remainder.
-   */
-  public static Double divider(Double x, Double y) {
-    if (x == null || y == null || y == 0) {
-      return null;
+    switch (outputType) {
+      case SHORT:
+        short shortMin = nums[0].shortValue();
+        for (Number num : nums) {
+          if (num.shortValue() < shortMin) {
+            shortMin = num.shortValue();
+          }
+        }
+        return shortMin;
+      case INTEGER:
+        int intMin = nums[0].intValue();
+        for (Number num : nums) {
+          if (num.intValue() < intMin) {
+            intMin = num.intValue();
+          }
+        }
+        return intMin;
+      case LONG:
+        long longMin = nums[0].longValue();
+        for (Number num : nums) {
+          if (num.longValue() < longMin) {
+            longMin = num.longValue();
+          }
+        }
+        return longMin;
+      case FLOAT:
+        float floatMin = nums[0].floatValue();
+        for (Number num : nums) {
+          if (num.floatValue() < floatMin) {
+            floatMin = num.floatValue();
+          }
+        }
+        return floatMin;
+      case DOUBLE:
+        double doubleMin = nums[0].doubleValue();
+        for (Number num : nums) {
+          if (num.doubleValue() < doubleMin) {
+            doubleMin = num.doubleValue();
+          }
+        }
+        return doubleMin;
+      default:
+        BigDecimal bdMin = new BigDecimal(nums[0].toString());
+        for (Number num : nums) {
+          bdMin = bdMin.min(numberToBigDecimal(num));
+        }
+        return bdMin;
     }
-    return x % y;
-  }
-
-  /**
-   * Arithmetic operation - Divide a column by another and return the remainder.
-   */
-  public static Float divider(Float x, Float y) {
-    if (x == null || y == null || y == 0) {
-      return null;
-    }
-    return x % y;
-  }
-
-  /**
-   * Arithmetic operation - Divide a column by another and return the remainder.
-   */
-  public static BigDecimal divider(BigDecimal x, BigDecimal y) {
-    if (x == null || y == null || y.equals(BigDecimal.valueOf(0))) {
-      return null;
-    }
-    return x.remainder(y);
-  }
-
-  /**
-   * Arithmetic operation - calculate LCM of two columns.
-   */
-  public static Integer lcm(Integer i1, Integer i2) {
-    if (i1 == null || i2 == null) {
-      return null;
-    }
-    BigDecimal bd1 = BigDecimal.valueOf(i1);
-    BigDecimal bd2 = BigDecimal.valueOf(i2);
-
-    return lcm(bd1, bd2).intValue();
-  }
-
-  /**
-   * Arithmetic operation - calculate LCM of two columns.
-   */
-  public static Double lcm(Double d1, Double d2) {
-    if (d1 == null || d2 == null) {
-      return null;
-    }
-    BigDecimal bd1 = BigDecimal.valueOf(d1);
-    BigDecimal bd2 = BigDecimal.valueOf(d2);
-    return lcm(bd1, bd2).doubleValue();
-  }
-
-  /**
-   * Arithmetic operation - calculate LCM of two columns.
-   */
-  public static Float lcm(Float f1, Float f2) {
-    if (f1 == null || f2 == null) {
-      return null;
-    }
-    BigDecimal bd1 = BigDecimal.valueOf(f1);
-    BigDecimal bd2 = BigDecimal.valueOf(f2);
-    return lcm(bd1, bd2).floatValue();
-  }
-
-  /**
-   * Arithmetic operation - calculate LCM of two columns.
-   */
-  public static BigDecimal lcm(BigDecimal bd1, BigDecimal bd2) {
-    if (bd1 == null || bd2 == null) {
-      return null;
-    }
-    BigDecimal pow = BigDecimal.valueOf(Math.pow(10, Math.max(bd1.scale(), bd2.scale())));
-    BigInteger val1 = bd1.multiply(pow).toBigInteger();
-    BigInteger val2 = bd2.multiply(pow).toBigInteger();
-    BigDecimal absProduct = new BigDecimal(val1.multiply(val2).abs())
-      .setScale(Math.min(bd1.scale(), bd2.scale()), BigDecimal.ROUND_HALF_EVEN);
-    BigDecimal gcd = new BigDecimal(val1.gcd(val2));
-    if (gcd.compareTo(BigDecimal.ZERO) == 0) {
-      return BigDecimal.ZERO;
-    }
-    return absProduct.divide(gcd.multiply(pow), BigDecimal.ROUND_HALF_EVEN);
-  }
-
-  /**
-   * Arithmetic operation - Check if a value is equal to another column.
-   */
-  public static Boolean equal(Integer i1, Integer i2) {
-    if (i1 == null || i2 == null) {
-      return null;
-    }
-    return i1.equals(i2);
-  }
-
-  /**
-   * Arithmetic operation - Check if a value is equal to another column.
-   */
-  public static Boolean equal(Double d1, Double d2) {
-    if (d1 == null || d2 == null) {
-      return null;
-    }
-    return d1.equals(d2);
-  }
-
-  /**
-   * Arithmetic operation - Check if a value is equal to another column.
-   */
-  public static Boolean equal(Float f1, Float f2) {
-    if (f1 == null || f2 == null) {
-      return null;
-    }
-    return f1.equals(f2);
-  }
-
-  /**
-   * Arithmetic operation - Check if a value is equal to another column.
-   */
-  public static Boolean equal(BigDecimal bd1, BigDecimal bd2) {
-    if (bd1 == null || bd2 == null) {
-      return null;
-    }
-    return bd1.equals(bd2);
-  }
-
-  /**
-   * Arithmetic operation - Find the maximum of two columns.
-   */
-  public static Integer max(Integer i1, Integer i2) {
-    if (i1 == null || i2 == null) {
-      return null;
-    }
-    return Math.max(i1, i2);
-  }
-
-  /**
-   * Arithmetic operation - Find the maximum of two columns.
-   */
-  public static Double max(Double d1, Double d2) {
-    if (d1 == null || d2 == null) {
-      return null;
-    }
-    return Math.max(d1, d2);
-  }
-
-  /**
-   * Arithmetic operation - Find the maximum of two columns.
-   */
-  public static Float max(Float f1, Float f2) {
-    if (f1 == null || f2 == null) {
-      return null;
-    }
-    return Math.max(f1, f2);
-  }
-
-  /**
-   * Arithmetic operation - Find the maximum of two columns.
-   */
-  public static BigDecimal max(BigDecimal bd1, BigDecimal bd2) {
-    if (bd1 == null || bd2 == null) {
-      return null;
-    }
-    return bd1.max(bd2);
-  }
-
-  /**
-   * Arithmetic operation - Find the minimum of two columns.
-   */
-  public static Integer min(Integer i1, Integer i2) {
-    if (i1 == null || i2 == null) {
-      return null;
-    }
-    return Math.min(i1, i2);
-  }
-
-  /**
-   * Arithmetic operation - Find the minimum of two columns.
-   */
-  public static Double min(Double d1, Double d2) {
-    if (d1 == null || d2 == null) {
-      return null;
-    }
-    return Math.min(d1, d2);
-  }
-
-  /**
-   * Arithmetic operation - Find the minimum of two columns.
-   */
-  public static Float min(Float f1, Float f2) {
-    if (f1 == null || f2 == null) {
-      return null;
-    }
-    return Math.min(f1, f2);
-  }
-
-  /**
-   * Arithmetic operation - Find the minimum of two columns.
-   */
-  public static BigDecimal min(BigDecimal bd1, BigDecimal bd2) {
-    if (bd1 == null || bd2 == null) {
-      return null;
-    }
-    return bd1.min(bd2);
   }
 
   /**
@@ -433,12 +536,7 @@ public class ArithmeticOperations {
       }
       // Compute average
       if (containsBigDecimal) {
-        BigDecimal numer;
-        if (num instanceof BigDecimal) {
-          numer = ((BigDecimal) num).subtract((BigDecimal) avg);
-        } else {
-          numer = BigDecimal.valueOf(num.doubleValue()).subtract((BigDecimal) avg);
-        }
+        BigDecimal numer = numberToBigDecimal(num).subtract((BigDecimal) avg);
         BigDecimal denom = BigDecimal.valueOf(t);
         avg = ((BigDecimal) avg).add(numer.divide(denom, RoundingMode.HALF_EVEN));
       } else {

--- a/wrangler-core/src/test/java/io/cdap/wrangler/utils/ArithmeticOperationsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/utils/ArithmeticOperationsTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.wrangler.utils;
 
+import io.cdap.wrangler.api.DirectiveExecutionException;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +31,398 @@ import java.math.RoundingMode;
 public class ArithmeticOperationsTest {
   @Rule
   public ExpectedException expectedEx = ExpectedException.none();
+
+  private static final double DELTA = 0.0001;
+
+  /**
+   * Test add operation functionality
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testAdd() throws Exception {
+
+    // Test 1 value
+    Assert.assertEquals((short) 5, ArithmeticOperations.add((short) 5)); // short
+    Assert.assertEquals(5, ArithmeticOperations.add(5)); // int
+    Assert.assertEquals((long) 5, ArithmeticOperations.add((long) 5)); // long
+    Assert.assertEquals((float) 5, ArithmeticOperations.add((float) 5)); // float
+    Assert.assertEquals(5.0, ArithmeticOperations.add(5.0)); // double
+    Assert.assertEquals(BigDecimal.valueOf(5),
+                        ArithmeticOperations.add(BigDecimal.valueOf(5))); // BigDecimal
+
+    // Test 3 values
+    Assert.assertEquals((short) 4,
+                        ArithmeticOperations.add((short) 1, (short) 3)); // short
+    Assert.assertEquals(4, ArithmeticOperations.add(1, 3)); // int
+    Assert.assertEquals((long) 4,
+                        ArithmeticOperations.add((long) 1, (long) 3)); // long
+    Assert.assertEquals((float) 4,
+                        ArithmeticOperations.add((float) 1, (float) 3)); // float
+    Assert.assertEquals(4.0, ArithmeticOperations.add(1.0, 3.0)); // double
+    Assert.assertEquals(BigDecimal.valueOf(4),
+                        ArithmeticOperations.add(BigDecimal.ONE,
+                                                 BigDecimal.valueOf(3))); // BigDecimal
+
+    // Test all null values
+    Assert.assertNull(ArithmeticOperations.add(null, null));
+
+    // Test one null value
+    Assert.assertNull(ArithmeticOperations.add((short) 2, null, (short) 3)); // short
+    Assert.assertNull(ArithmeticOperations.add(2, null, 3)); // int
+    Assert.assertNull(ArithmeticOperations.add((long) 2, null, (long) 3)); // long
+    Assert.assertNull(ArithmeticOperations.add((float) 2, null, (float) 3)); // float
+    Assert.assertNull(ArithmeticOperations.add(2.0, null, 3.0)); // double
+    Assert.assertNull(ArithmeticOperations.add(BigDecimal.valueOf(2),
+                                               null,
+                                               BigDecimal.valueOf(3))); // BigDecimal
+
+    // Test multiple types (pairs)
+    Assert.assertEquals(5,
+                        ArithmeticOperations.add((short) 2, 2, (short) 1)); // short + int
+    Assert.assertEquals((long) 5,
+                        ArithmeticOperations.add(2, (long) 2, 1)); // int + long
+    Assert.assertEquals((float) 5,
+                        ArithmeticOperations.add((long) 2, (float) 2, (long) 1)); // long + float
+    Assert.assertEquals((double) 5,
+                        ArithmeticOperations.add((float) 2, 2.0, (float) 1)); // float + double
+    Assert.assertEquals(BigDecimal.valueOf(5),
+                        ArithmeticOperations.add(2.0, BigDecimal.valueOf(2), 1.0)); // double + BigDecimal
+
+    // Test multiple types (all)
+    Assert.assertEquals(BigDecimal.valueOf(21), ArithmeticOperations.add((short) 1,
+                                                                         2,
+                                                                         (long) 3,
+                                                                         (float) 4,
+                                                                         5.0,
+                                                                         BigDecimal.valueOf(6)));
+  }
+
+  /**
+   * Test minus (subtraction) operation functionality
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testMinus() throws Exception {
+
+    // Test same type
+    Assert.assertEquals((short) 2, ArithmeticOperations.minus((short) 10, (short) 8)); // Short
+    Assert.assertEquals(2, ArithmeticOperations.minus(10, 8)); // Integer
+    Assert.assertEquals((long) 2, ArithmeticOperations.minus((long) 10, (long) 8)); // Long
+    Assert.assertEquals((float) 2.5, (float) ArithmeticOperations.minus((float) 10.7, (float) 8.2), DELTA); // Float
+    Assert.assertEquals(2.5, (double) ArithmeticOperations.minus(10.7, 8.2), DELTA); // Double
+    Assert.assertEquals(BigDecimal.valueOf(2.5), ArithmeticOperations.minus(BigDecimal.valueOf(10.7),
+                                                                            BigDecimal.valueOf(8.2))); // BigDecimal
+
+    // Test different types; expected behavior is to output the most "general" type
+    Assert.assertEquals(2, ArithmeticOperations.minus((short) 10, 8)); // Short + Integer
+    Assert.assertEquals((long) 2, ArithmeticOperations.minus(10,  (long) 8)); // Integer + Long
+    Assert.assertEquals((float) 2, (float) ArithmeticOperations.minus((long) 10, (float) 8), DELTA); // Long + Float
+    Assert.assertEquals(2.5, (double) ArithmeticOperations.minus((float) 10.7, 8.2), DELTA); // Float + Double
+    Assert.assertEquals(BigDecimal.valueOf(2.5),
+                        ArithmeticOperations.minus(10.7, BigDecimal.valueOf(8.2))); // Double + BigDecimal
+  }
+
+  /**
+   * Test multiply operation multi-column functionality
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testMultiply() throws Exception {
+
+    // Test 1 value
+    Assert.assertEquals((short) 5, ArithmeticOperations.multiply((short) 5)); // short
+    Assert.assertEquals(5, ArithmeticOperations.multiply(5)); // int
+    Assert.assertEquals((long) 5, ArithmeticOperations.multiply((long) 5)); // long
+    Assert.assertEquals((float) 5, ArithmeticOperations.multiply((float) 5)); // float
+    Assert.assertEquals(5.0, ArithmeticOperations.multiply(5.0)); // double
+    Assert.assertEquals(BigDecimal.valueOf(5),
+                        ArithmeticOperations.multiply(BigDecimal.valueOf(5))); // BigDecimal
+
+    // Test 3 values
+    Assert.assertEquals((short) 3,
+                        ArithmeticOperations.multiply((short) 1, (short) 3)); // short
+    Assert.assertEquals(3, ArithmeticOperations.multiply(1, 3)); // int
+    Assert.assertEquals((long) 3,
+                        ArithmeticOperations.multiply((long) 1, (long) 3)); // long
+    Assert.assertEquals((float) 3,
+                        ArithmeticOperations.multiply((float) 1, (float) 3)); // float
+    Assert.assertEquals(3.0, ArithmeticOperations.multiply(1.0, 3.0)); // double
+    Assert.assertEquals(BigDecimal.valueOf(3),
+                        ArithmeticOperations.multiply(BigDecimal.ONE,
+                                                      BigDecimal.valueOf(3))); // BigDecimal
+
+    // Test all null values
+    Assert.assertNull(ArithmeticOperations.multiply(null, null));
+
+    // Test one null value
+    Assert.assertNull(ArithmeticOperations.multiply((short) 2, null, (short) 3)); // short
+    Assert.assertNull(ArithmeticOperations.multiply(2, null, 3)); // int
+    Assert.assertNull(ArithmeticOperations.multiply((long) 2, null, (long) 3)); // long
+    Assert.assertNull(ArithmeticOperations.multiply((float) 2, null, (float) 3)); // float
+    Assert.assertNull(ArithmeticOperations.multiply(2.0, null, 3.0)); // double
+    Assert.assertNull(ArithmeticOperations.multiply(BigDecimal.valueOf(2),
+                                                    null,
+                                                    BigDecimal.valueOf(3))); // BigDecimal
+
+    // Test multiple types (pairs)
+    Assert.assertEquals(4,
+                        ArithmeticOperations.multiply((short) 2, 2, (short) 1)); // short + int
+    Assert.assertEquals((long) 4,
+                        ArithmeticOperations.multiply(2, (long) 2, 1)); // int + long
+    Assert.assertEquals((float) 4,
+                        ArithmeticOperations.multiply((long) 2, (float) 2, (long) 1)); // long + float
+    Assert.assertEquals((double) 4,
+                        ArithmeticOperations.multiply((float) 2, 2.0, (float) 1)); // float + double
+    Assert.assertEquals(new BigDecimal("4.00"),
+                        ArithmeticOperations.multiply(2.0,
+                                                      BigDecimal.valueOf(2),
+                                                      1.0)); // double + BigDecimal
+
+    // Test multiple types (all)
+    Assert.assertEquals(new BigDecimal("720.00"),
+                        ArithmeticOperations.multiply((short) 1,
+                                                      2,
+                                                      (long) 3,
+                                                      (float) 4,
+                                                      5.0,
+                                                      BigDecimal.valueOf(6)));
+  }
+
+  /**
+   * Test divideq (division) operation functionality
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testDivideq() throws Exception {
+
+    // Test same type
+    // Expected behavior is to output Double, unless any input has type BigDecimal
+    Assert.assertEquals(2.4, (double) ArithmeticOperations.divideq((short) 12, (short) 5), DELTA); // Short
+    Assert.assertEquals(2.4, (double) ArithmeticOperations.divideq(12, 5), DELTA); // Integer
+    Assert.assertEquals(2.4, (double) ArithmeticOperations.divideq((long) 12, (long) 5), DELTA); // Long
+    Assert.assertEquals(30.25, (double) ArithmeticOperations.divideq((float) 12.1, (float) 0.4),
+                        DELTA); // Float
+    Assert.assertEquals(30.25, (double) ArithmeticOperations.divideq(12.1, 0.4), DELTA); // Double
+    Assert.assertEquals(BigDecimal.valueOf(30.3), ArithmeticOperations.divideq(BigDecimal.valueOf(9.09),
+                                                                              BigDecimal.valueOf(0.3))); // BigDecimal
+
+    // Test different types
+    Assert.assertEquals(2.4, (double) ArithmeticOperations.divideq((short) 12, 5), DELTA); // Short + Integer
+    Assert.assertEquals(2.4, (double) ArithmeticOperations.divideq(12,  (long) 5), DELTA); // Integer + Long
+    Assert.assertEquals(2.4, (double) ArithmeticOperations.divideq((long) 12,
+                                                                          (float) 5.0), DELTA); // Long + Float
+    Assert.assertEquals(30.25, (double) ArithmeticOperations.divideq((float) 12.1, 0.4),
+                         DELTA); // Float + Double
+    Assert.assertEquals(BigDecimal.valueOf(30.3),
+                        ArithmeticOperations.divideq(9.09, BigDecimal.valueOf(0.3))); // Double + BigDecimal
+
+    // Test division by 0
+    Assert.assertEquals(null, ArithmeticOperations.divideq(5, 0)); // Integer 0
+    Assert.assertEquals(null, ArithmeticOperations.divideq(5, (double) 0)); // Double 0
+    Assert.assertEquals(null, ArithmeticOperations.divideq(5, BigDecimal.valueOf(0))); // BigDecimal 0
+  }
+
+  /**
+   * Test divider (modulus) operation functionality
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testDivider() throws Exception {
+
+    // Test same type
+    Assert.assertEquals(2, ArithmeticOperations.divider((short) 12, (short) 5)); // Short
+    Assert.assertEquals(2, ArithmeticOperations.divider(12, 5)); // Integer
+    Assert.assertEquals((long) 2, ArithmeticOperations.divider((long) 12, (long) 5)); // Long
+    Assert.assertEquals((float) 0.2, (float) ArithmeticOperations.divider((float) 12.2, (float) 0.5), DELTA); // Float
+    Assert.assertEquals(0.2, (double) ArithmeticOperations.divider(12.2, 0.5), DELTA); // Double
+    Assert.assertEquals(BigDecimal.valueOf(0.2), ArithmeticOperations.divider(BigDecimal.valueOf(12.2),
+                                                                             BigDecimal.valueOf(0.5))); // BigDecimal
+
+    // Test different types; expected behavior is to output the most "general" type
+    Assert.assertEquals(2, ArithmeticOperations.divider((short) 12, 5)); // Short + Integer
+    Assert.assertEquals((long) 2, ArithmeticOperations.divider(12,  (long) 5)); // Integer + Long
+    Assert.assertEquals((float) 2.0, (float) ArithmeticOperations.divider((long) 12,
+                                                                          (float) 5.0), DELTA); // Long + Float
+    Assert.assertEquals(0.2, (double) ArithmeticOperations.divider((float) 12.2, 0.5), DELTA); // Float + Double
+    Assert.assertEquals(BigDecimal.valueOf(0.2),
+                        ArithmeticOperations.divider(12.2, BigDecimal.valueOf(0.5))); // Double + BigDecimal
+
+    // Test division by 0
+    Assert.assertEquals(null, ArithmeticOperations.divider(5, 0)); // Integer 0
+    Assert.assertEquals(null, ArithmeticOperations.divider(5, (double) 0)); // Double 0
+    Assert.assertEquals(null, ArithmeticOperations.divider(5, BigDecimal.valueOf(0))); // BigDecimal 0
+  }
+
+  /**
+   * Test LCM operation functionality
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testLCM() throws Exception {
+
+    // Test same type
+    Assert.assertEquals((short) 36, ArithmeticOperations.lcm((short) 12, (short) 18)); // Short
+    Assert.assertEquals(36, ArithmeticOperations.lcm(12, 18)); // Integer
+    Assert.assertEquals((long) 36, ArithmeticOperations.lcm((long) 12, (long) 18)); // Long
+    Assert.assertEquals((float) 2262.5, ArithmeticOperations.lcm((float) 12.5, (float) 18.1)); // Float
+    Assert.assertEquals(2262.5, ArithmeticOperations.lcm(12.5, 18.1)); // Double
+    Assert.assertEquals(BigDecimal.valueOf(2262.5), ArithmeticOperations.lcm(BigDecimal.valueOf(12.5),
+                                                                             BigDecimal.valueOf(18.1))); // BigDecimal
+
+    // Test different types; expected behavior is to output the most "general" type
+    Assert.assertEquals(36, ArithmeticOperations.lcm((short) 12, 18)); // Short + Integer
+    Assert.assertEquals((long) 36, ArithmeticOperations.lcm(12,  (long) 18)); // Integer + Long
+    Assert.assertEquals((float) 36.0, ArithmeticOperations.lcm((long) 12,  (float) 18.0)); // Long + Float
+    Assert.assertEquals(2262.5, ArithmeticOperations.lcm((float) 12.5, 18.1)); // Float + Double
+    Assert.assertEquals(BigDecimal.valueOf(2262.5),
+                         ArithmeticOperations.lcm(12.5, BigDecimal.valueOf(18.1))); // Double + BigDecimal
+  }
+
+  /**
+   * Test equal operation functionality
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testEqual() throws Exception {
+
+    // Test 1 value
+    Assert.assertTrue(ArithmeticOperations.equal(3));
+
+    // Test 3 of the same value
+    Assert.assertTrue(ArithmeticOperations.equal(3, 3, 3));
+
+    // Test different values
+    Assert.assertFalse(ArithmeticOperations.equal(2, 4));
+
+    // Test null value
+    Assert.assertNull(ArithmeticOperations.equal((Integer) null));
+
+    // Test multiple null values
+    Assert.assertNull(ArithmeticOperations.equal((Integer) null, null));
+
+    // Test embedded null value
+    Assert.assertNull(ArithmeticOperations.equal(3, null, 3));
+
+    // Test precision
+    Assert.assertFalse(ArithmeticOperations.equal(BigDecimal.ONE, BigDecimal.valueOf(1.0)));
+  }
+
+  /**
+   * Test max operation functionality
+   *
+   * @throws DirectiveExecutionException
+   */
+  @Test
+  public void testMax() throws DirectiveExecutionException {
+
+    // Test 1 value
+    Assert.assertEquals(2.0, ArithmeticOperations.max(2.0));
+
+    // Test 3 of the same value
+    Assert.assertEquals(2.0, ArithmeticOperations.max(2.0, 2.0, 2.0));
+
+    // Test at beginning
+    Assert.assertEquals(4.0, ArithmeticOperations.max(4.0, 2.0, 3.5));
+
+    // Test in middle
+    Assert.assertEquals(5.0, ArithmeticOperations.max(4.0, 5.0, 3.5));
+
+    // Test at end
+    Assert.assertEquals(3.0, ArithmeticOperations.max(2.0, 1.0, 3.0));
+
+    // Test negative numbers
+    Assert.assertEquals(-1.0, ArithmeticOperations.max(-5.0, -1.0, -2.0));
+
+    // Test cross-type
+    Assert.assertEquals((long) 5, ArithmeticOperations.max(5, (long) 3, 5));
+    Assert.assertEquals((float) 4, ArithmeticOperations.max((long) 4,
+                                                                      (float) 2,
+                                                                      (long) 4));
+    Assert.assertEquals(3.0, ArithmeticOperations.max((float) 3, 2.0, (float) 3));
+    Assert.assertEquals(BigDecimal.valueOf(2.0), ArithmeticOperations.max(2.0,
+                                                                          BigDecimal.valueOf(1.0),
+                                                                          2.0));
+
+    // Test overall cross-type
+    Assert.assertEquals(BigDecimal.valueOf(5), ArithmeticOperations.max(5,
+                                                                          (long) 4,
+                                                                          (float) 3,
+                                                                          2.0,
+                                                                          BigDecimal.valueOf(1.0)));
+  }
+
+  /**
+   * Tests for max operation exception with Byte input
+   *
+   * @throws DirectiveExecutionException
+   */
+  @Test
+  public void testMaxByteException() throws DirectiveExecutionException {
+    expectedEx.expect(Exception.class);
+    ArithmeticOperations.max(Byte.valueOf((byte) 0));
+  }
+
+  /**
+   * Test min operation functionality
+   *
+   * @throws DirectiveExecutionException
+   */
+  @Test
+  public void testMin() throws DirectiveExecutionException {
+
+    // Test 1 value
+    Assert.assertEquals(2.0, ArithmeticOperations.min(2.0));
+
+    // Test 3 of the same value
+    Assert.assertEquals(2.0, ArithmeticOperations.min(2.0, 2.0, 2.0));
+
+    // Test at beginning
+    Assert.assertEquals(2.0, ArithmeticOperations.min(2.0, 4.0, 3.5));
+
+    // Test in middle
+    Assert.assertEquals(3.5, ArithmeticOperations.min(4.0, 3.5, 5.0));
+
+    // Test at end
+    Assert.assertEquals(1.0, ArithmeticOperations.min(2.0, 3.0, 1.0));
+
+    // Test negative numbers
+    Assert.assertEquals(-5.0, ArithmeticOperations.min(-5.0, -1.0, -2.0));
+
+    // Test cross-type
+    Assert.assertEquals((long) 3, ArithmeticOperations.min(3, (long) 5, 3));
+    Assert.assertEquals((float) 4, ArithmeticOperations.min((long) 4,
+                                                                      (float) 5,
+                                                                      (long) 4));
+    Assert.assertEquals(2.0, ArithmeticOperations.min((float) 2, 3.0, (float) 2));
+    Assert.assertEquals(BigDecimal.valueOf(1.0), ArithmeticOperations.min(1.0,
+                                                                 BigDecimal.valueOf(2.0),
+                                                                 1.0));
+
+    // Test overall cross-type
+    Assert.assertEquals(BigDecimal.valueOf(1.0), ArithmeticOperations.min(5,
+                                                                 (long) 4,
+                                                                 (float) 3,
+                                                                 2.0,
+                                                                 BigDecimal.valueOf(1.0)));
+  }
+
+  /**
+   * Tests for min operation exception with Byte input
+   *
+   * @throws DirectiveExecutionException
+   */
+  @Test
+  public void testMinByteException() throws DirectiveExecutionException {
+    expectedEx.expect(Exception.class);
+    ArithmeticOperations.min(Byte.valueOf((byte) 0));
+  }
 
   /**
    * Test average operation functionality.


### PR DESCRIPTION
# Expand Calculate Options

## Description
Consolidated most functions (except `equal`) in `ArithmeticOperations.java` to take in any supported numeric type. Also expanded  some functions (`add`, `multiply`, `equal`, `max`, `min`) to take in >2 inputs/columns. PR [#565](https://github.com/cdapio/cdap-ui/pull/565) in [cdap-ui](https://github.com/cdapio/cdap-ui) depends on this one.

Also added unit tests for `ArithmeticOperations.java`.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: none