### PR TITLE
Fix ArithmeticOperations.java null pointer exception bug

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/ArithmeticOperations.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/ArithmeticOperations.java
@@ -67,7 +67,7 @@ public class ArithmeticOperations {
       } else if (num instanceof Double && NumberType.DOUBLE.getPriority() > outputType.getPriority()) {
         outputType = NumberType.DOUBLE;
       } else if (num instanceof BigDecimal) {
-        return NumberType.BIGDECIMAL;
+        outputType = NumberType.BIGDECIMAL;
       }
     }
     return outputType;


### PR DESCRIPTION
# Fix ArithmeticOperations.java null pointer exception bug

## Description
Fixed null pointer exception bug caused by PR #569.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: none