### PR TITLE
Add Resampling to Wrangler

### DIFF
--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/SampleSpec.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/SampleSpec.java
@@ -17,6 +17,11 @@
 
 package io.cdap.wrangler.proto.workspace.v2;
 
+import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.api.connector.SampleType;
+
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -29,13 +34,30 @@ public class SampleSpec {
   private final String connectionType;
   private final String path;
   private final Set<StageSpec> relatedPlugins;
+  // This gives the different methods the current connection supports for sampling
+  // (e.g. first N rows, randomized, stratified)
+  private final Set<SampleType> supportedSampleTypes;
+  // We store the SampleRequest so that the frontend knows the most recent sampling action (if any)
+  // when it gets passed the SampleSpec
+  private final SampleRequest sampleRequest;
 
   public SampleSpec(String connectionName, String connectionType, @Nullable String path,
-                    Set<StageSpec> relatedPlugins) {
+                    Set<StageSpec> relatedPlugins, Set<SampleType> supportedSampleTypes, SampleRequest sampleRequest) {
     this.connectionName = connectionName;
     this.connectionType = connectionType;
     this.path = path;
     this.relatedPlugins = relatedPlugins;
+    if (supportedSampleTypes != null) {
+      this.supportedSampleTypes = supportedSampleTypes;
+    } else {
+      this.supportedSampleTypes = new HashSet<>();
+    }
+    this.sampleRequest = sampleRequest;
+  }
+
+  public SampleSpec(String connectionName, String connectionType, @Nullable String path,
+                    Set<StageSpec> relatedPlugins) {
+    this(connectionName, connectionType, path, relatedPlugins, Collections.emptySet(), null);
   }
 
   public String getConnectionName() {
@@ -56,6 +78,14 @@ public class SampleSpec {
     return relatedPlugins;
   }
 
+  public Set<SampleType> getSupportedSampleTypes() {
+    return supportedSampleTypes;
+  }
+
+  public SampleRequest getSampleRequest() {
+    return sampleRequest;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,11 +100,13 @@ public class SampleSpec {
     return Objects.equals(connectionName, that.connectionName) &&
              Objects.equals(connectionType, that.connectionType) &&
              Objects.equals(path, that.path) &&
-             Objects.equals(relatedPlugins, that.relatedPlugins);
+             Objects.equals(relatedPlugins, that.relatedPlugins) &&
+             Objects.equals(supportedSampleTypes, that.supportedSampleTypes) &&
+             Objects.equals(sampleRequest, that.sampleRequest);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(connectionName, connectionType, path, relatedPlugins);
+    return Objects.hash(connectionName, connectionType, path, relatedPlugins, supportedSampleTypes, sampleRequest);
   }
 }

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/store/workspace/WorkspaceStore.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/store/workspace/WorkspaceStore.java
@@ -146,10 +146,10 @@ public class WorkspaceStore {
   }
 
   /**
-   * Create the workspace from given workspace.
+   * Create/update the workspace from given workspace.
    *
    * @param workspaceId the id of the workspace
-   * @param workspace workspace to create
+   * @param workspace workspace to create/update
    */
   public void saveWorkspace(WorkspaceId workspaceId, WorkspaceDetail workspace) {
     saveWorkspace(workspaceId, workspace.getWorkspace(), workspace.getSampleAsBytes(), false);


### PR DESCRIPTION
# Add Resampling to Wrangler

## Description
Expanded the `SampleSpec` class to include the type (first, random, stratified) to be used for the sample. Also added the `resampleWorkspace` API endpoint, allowing users to resample data from certain supported connectors. 

Note: the build only failed because it relies on other changes we made in `/cdap`.

Related PRs:
- [cdap #14495](https://github.com/cdapio/cdap/pull/14495)
- [database-plugins #285](https://github.com/data-integrations/database-plugins/pull/285)
- [google-cloud #1084](https://github.com/data-integrations/google-cloud/pull/1084)
- [cdap-ui #603](https://github.com/cdapio/cdap-ui/pull/603)

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: none