### PR TITLE
Add API to create a recipe

### DIFF
--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/Recipe.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/Recipe.java
@@ -25,15 +25,15 @@ import java.util.Objects;
  * Metadata information about a Recipe
  */
 public class Recipe {
+  private final RecipeId recipeId;
   private final String recipeName;
-  private final String recipeId;
   private final String description;
   private final List<String> directives;
   private final long createdTimeMillis;
   private final long updatedTimeMillis;
   private final int recipeStepsCount;
 
-  private Recipe(String recipeName, String recipeId, String description, List<String> directives,
+  private Recipe(RecipeId recipeId, String recipeName, String description, List<String> directives,
                  long createdTimeMillis, long updatedTimeMillis, int recipeStepsCount) {
     this.recipeName = recipeName;
     this.recipeId = recipeId;
@@ -48,7 +48,7 @@ public class Recipe {
     return recipeName;
   }
 
-  public String getRecipeId() {
+  public RecipeId getRecipeId() {
     return recipeId;
   }
 
@@ -91,7 +91,7 @@ public class Recipe {
     return Objects.hash(recipeName, recipeId, directives);
   }
 
-  public static Builder builder(String recipeId) {
+  public static Builder builder(RecipeId recipeId) {
     return new Builder(recipeId);
   }
 
@@ -109,7 +109,7 @@ public class Recipe {
    * Creates a Recipe meta object
    */
   public static class Builder {
-    private final String recipeId;
+    private final RecipeId recipeId;
     private String recipeName;
     private String description;
     private List<String> directives;
@@ -117,7 +117,7 @@ public class Recipe {
     private long updatedTimeMillis;
     private int recipeStepsCount;
 
-    Builder(String recipeId) {
+    Builder(RecipeId recipeId) {
       this.recipeId = recipeId;
       this.directives = new ArrayList<>();
     }
@@ -154,7 +154,7 @@ public class Recipe {
     }
 
     public Recipe build() {
-      return new Recipe(recipeName, recipeId, description, directives,
+      return new Recipe(recipeId, recipeName, description, directives,
                         createdTimeMillis, updatedTimeMillis, recipeStepsCount);
     }
   }

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/Recipe.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/Recipe.java
@@ -83,9 +83,7 @@ public class Recipe {
     }
 
     Recipe other = (Recipe) o;
-    return Objects.equals(recipeId, other.recipeId) &&
-      Objects.equals(recipeName, other.recipeName) &&
-      Objects.equals(directives, other.directives);
+    return Objects.equals(recipeId, other.recipeId);
   }
 
   @Override

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/Recipe.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/Recipe.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.proto.recipe.v2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Metadata information about a Recipe
+ */
+public class Recipe {
+  private final String recipeName;
+  private final String recipeId;
+  private final String description;
+  private final List<String> directives;
+  private final long createdTimeMillis;
+  private final long updatedTimeMillis;
+  private final int recipeStepsCount;
+
+  private Recipe(String recipeName, String recipeId, String description, List<String> directives,
+                 long createdTimeMillis, long updatedTimeMillis, int recipeStepsCount) {
+    this.recipeName = recipeName;
+    this.recipeId = recipeId;
+    this.description = description;
+    this.directives = Collections.unmodifiableList(directives);
+    this.createdTimeMillis = createdTimeMillis;
+    this.updatedTimeMillis = updatedTimeMillis;
+    this.recipeStepsCount = recipeStepsCount;
+  }
+
+  public String getRecipeName() {
+    return recipeName;
+  }
+
+  public String getRecipeId() {
+    return recipeId;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public List<String> getDirectives() {
+    return directives;
+  }
+
+  public long getCreatedTimeMillis() {
+    return createdTimeMillis;
+  }
+
+  public long getUpdatedTimeMillis() {
+    return updatedTimeMillis;
+  }
+
+  public int getRecipeStepsCount() {
+    return recipeStepsCount;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Recipe other = (Recipe) o;
+    return Objects.equals(recipeId, other.recipeId) &&
+      Objects.equals(recipeName, other.recipeName) &&
+      Objects.equals(directives, other.directives);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(recipeName, recipeId, directives);
+  }
+
+  public static Builder builder(String recipeId) {
+    return new Builder(recipeId);
+  }
+
+  public static Builder builder(Recipe existing) {
+    return new Builder(existing.getRecipeId())
+      .setRecipeName(existing.getRecipeName())
+      .setDescription(existing.getDescription())
+      .setDirectives(existing.getDirectives())
+      .setCreatedTimeMillis(existing.getCreatedTimeMillis())
+      .setUpdatedTimeMillis(existing.getUpdatedTimeMillis())
+      .setRecipeStepsCount(existing.getRecipeStepsCount());
+  }
+
+  /**
+   * Creates a Recipe meta object
+   */
+  public static class Builder {
+    private final String recipeId;
+    private String recipeName;
+    private String description;
+    private List<String> directives;
+    private long createdTimeMillis;
+    private long updatedTimeMillis;
+    private int recipeStepsCount;
+
+    Builder(String recipeId) {
+      this.recipeId = recipeId;
+      this.directives = new ArrayList<>();
+    }
+
+    public Builder setRecipeName(String recipeName) {
+      this.recipeName = recipeName;
+      return this;
+    }
+
+    public Builder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    public Builder setDirectives(List<String> directives) {
+      this.directives.clear();
+      this.directives.addAll(directives);
+      return this;
+    }
+
+    public Builder setCreatedTimeMillis(long createdTimeMillis) {
+      this.createdTimeMillis = createdTimeMillis;
+      return this;
+    }
+
+    public Builder setUpdatedTimeMillis(long updatedTimeMillis) {
+      this.updatedTimeMillis = updatedTimeMillis;
+      return this;
+    }
+
+    public Builder setRecipeStepsCount(int recipeStepsCount) {
+      this.recipeStepsCount = recipeStepsCount;
+      return this;
+    }
+
+    public Recipe build() {
+      return new Recipe(recipeName, recipeId, description, directives,
+                        createdTimeMillis, updatedTimeMillis, recipeStepsCount);
+    }
+  }
+}

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeCreationRequest.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeCreationRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.proto.recipe.v2;
+
+import java.util.List;
+
+/**
+ * Creation request for a Recipe
+ */
+public class RecipeCreationRequest {
+  private final String recipeName;
+  private final String description;
+  private final List<String> directives;
+
+  public RecipeCreationRequest(String recipeName, String description, List<String> directives) {
+    this.recipeName = recipeName;
+    this.description = description;
+    this.directives = directives;
+  }
+
+  public String getRecipeName() {
+    return recipeName;
+  }
+
+  public List<String> getDirectives() {
+    return directives;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+}

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeId.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeId.java
@@ -29,7 +29,7 @@ public class RecipeId {
   private final String recipeId;
 
   public RecipeId(NamespaceSummary namespace) {
-    this.namespace = namespace;
+    this.namespace = new NamespaceSummary(namespace.getName(), null, namespace.getGeneration());
     this.recipeId = UUID.randomUUID().toString();
   }
 

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeId.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeId.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.proto.recipe.v2;
+
+import io.cdap.cdap.api.NamespaceSummary;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Recipe id
+ */
+public class RecipeId {
+  private final NamespaceSummary namespace;
+  private final String recipeId;
+
+  public RecipeId(NamespaceSummary namespace) {
+    this.namespace = namespace;
+    this.recipeId = UUID.randomUUID().toString();
+  }
+
+  public NamespaceSummary getNamespace() {
+    return namespace;
+  }
+
+  public String getRecipeId() {
+    return recipeId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RecipeId other = (RecipeId) o;
+    return Objects.equals(namespace, other.namespace) &&
+      Objects.equals(recipeId, other.recipeId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, recipeId);
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/DataPrepService.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/DataPrepService.java
@@ -29,6 +29,7 @@ import io.cdap.wrangler.service.connections.ConnectionTypeConfig;
 import io.cdap.wrangler.service.database.DatabaseHandler;
 import io.cdap.wrangler.service.directive.ConnectionUpgrader;
 import io.cdap.wrangler.service.directive.DirectivesHandler;
+import io.cdap.wrangler.service.directive.RecipeHandler;
 import io.cdap.wrangler.service.directive.WorkspaceHandler;
 import io.cdap.wrangler.service.directive.WorkspaceUpgrader;
 import io.cdap.wrangler.service.explorer.FilesystemExplorer;
@@ -38,6 +39,7 @@ import io.cdap.wrangler.service.s3.S3Handler;
 import io.cdap.wrangler.service.schema.DataModelHandler;
 import io.cdap.wrangler.service.schema.SchemaRegistryHandler;
 import io.cdap.wrangler.service.spanner.SpannerHandler;
+import io.cdap.wrangler.store.recipe.RecipeStore;
 import io.cdap.wrangler.store.upgrade.UpgradeEntityType;
 import io.cdap.wrangler.store.upgrade.UpgradeState;
 import io.cdap.wrangler.store.upgrade.UpgradeStore;
@@ -71,6 +73,7 @@ public class DataPrepService extends AbstractSystemService {
     createTable(WorkspaceDataset.TABLE_SPEC);
     createTable(WorkspaceStore.WORKSPACE_TABLE_SPEC);
     createTable(UpgradeStore.UPGRADE_TABLE_SPEC);
+    createTable(RecipeStore.RECIPE_TABLE_SPEC);
 
     addHandler(new DirectivesHandler());
     addHandler(new SchemaRegistryHandler());
@@ -85,6 +88,7 @@ public class DataPrepService extends AbstractSystemService {
     addHandler(new SpannerHandler());
     addHandler(new DataModelHandler());
     addHandler(new WorkspaceHandler());
+    addHandler(new RecipeHandler());
   }
 
   @Override

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
@@ -75,10 +75,10 @@ public class RecipeHandler extends AbstractWranglerHandler {
         .setRecipeStepsCount(directives.size())
         .build();
 
-      RecipeRow recipeRow = RecipeRow.builder(recipe).build();
+      RecipeRow recipeRow = RecipeRow.builder(ns, recipe).build();
 
       recipeStore.saveRecipe(recipeId, recipeRow);
-      responder.sendString("recipe added successfully");
+      responder.sendJson(GSON.toJson(recipe));
     });
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
@@ -64,9 +64,9 @@ public class RecipeHandler extends AbstractWranglerHandler {
 
       RecipeCreationRequest creationRequest = GSON.fromJson(
         StandardCharsets.UTF_8.decode(request.getContent()).toString(), RecipeCreationRequest.class);
-
       List<String> directives = creationRequest.getDirectives();
-      Recipe recipe = Recipe.builder(recipeId.getRecipeId())
+
+      Recipe recipe = Recipe.builder(recipeId)
         .setRecipeName(creationRequest.getRecipeName())
         .setDescription(creationRequest.getDescription())
         .setCreatedTimeMillis(now)
@@ -75,7 +75,7 @@ public class RecipeHandler extends AbstractWranglerHandler {
         .setRecipeStepsCount(directives.size())
         .build();
 
-      RecipeRow recipeRow = RecipeRow.builder(ns, recipe).build();
+      RecipeRow recipeRow = RecipeRow.builder(recipe).build();
 
       recipeStore.saveRecipe(recipeId, recipeRow);
       responder.sendJson(GSON.toJson(recipe));

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.service.directive;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.annotation.TransactionControl;
+import io.cdap.cdap.api.annotation.TransactionPolicy;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.service.http.HttpServiceRequest;
+import io.cdap.cdap.api.service.http.HttpServiceResponder;
+import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import io.cdap.wrangler.dataset.recipe.RecipeRow;
+import io.cdap.wrangler.proto.recipe.v2.Recipe;
+import io.cdap.wrangler.proto.recipe.v2.RecipeCreationRequest;
+import io.cdap.wrangler.proto.recipe.v2.RecipeId;
+import io.cdap.wrangler.service.common.AbstractWranglerHandler;
+import io.cdap.wrangler.store.recipe.RecipeStore;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * v2 endpoints for recipe
+ */
+public class RecipeHandler extends AbstractWranglerHandler {
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
+
+  private RecipeStore recipeStore;
+
+  @Override
+  public void initialize(SystemHttpServiceContext context) throws Exception {
+    super.initialize(context);
+    recipeStore = new RecipeStore(context);
+  }
+
+  @POST
+  @TransactionPolicy(value = TransactionControl.EXPLICIT)
+  @Path("v2/contexts/{context}/recipe")
+  public void createRecipe(HttpServiceRequest request, HttpServiceResponder responder,
+                           @PathParam("context") String namespace) {
+    respond(responder, namespace, ns -> {
+      RecipeId recipeId = new RecipeId(ns);
+      long now = System.currentTimeMillis();
+
+      RecipeCreationRequest creationRequest = GSON.fromJson(
+        StandardCharsets.UTF_8.decode(request.getContent()).toString(), RecipeCreationRequest.class);
+
+      List<String> directives = creationRequest.getDirectives();
+      Recipe recipe = Recipe.builder(recipeId.getRecipeId())
+        .setRecipeName(creationRequest.getRecipeName())
+        .setDescription(creationRequest.getDescription())
+        .setCreatedTimeMillis(now)
+        .setUpdatedTimeMillis(now)
+        .setDirectives(directives)
+        .setRecipeStepsCount(directives.size())
+        .build();
+
+      RecipeRow recipeRow = RecipeRow.builder(recipe).build();
+
+      recipeStore.saveRecipe(recipeId, recipeRow);
+      responder.sendString("recipe added successfully");
+    });
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
@@ -75,10 +75,10 @@ public class RecipeHandler extends AbstractWranglerHandler {
         .setRecipeStepsCount(directives.size())
         .build();
 
-      RecipeRow recipeRow = RecipeRow.builder(recipe).build();
+      RecipeRow recipeRow = RecipeRow.builder(ns, recipe).build();
 
       recipeStore.saveRecipe(recipeId, recipeRow);
-      responder.sendString("recipe added successfully");
+      responder.sendJson("recipe added successfully");
     });
   }
 }

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeAlreadyExistsException.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeAlreadyExistsException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.dataset.recipe;
+
+/**
+ * Thrown when a Recipe with a given recipe name already exists.
+ */
+public class RecipeAlreadyExistsException extends IllegalArgumentException {
+  public RecipeAlreadyExistsException(String message) {
+    super(message);
+  }
+}

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeNotFoundException.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.dataset.recipe;
+
+import io.cdap.wrangler.proto.NotFoundException;
+
+/**
+ * Thrown when a Recipe is not found when it is expected to exist.
+ */
+public class RecipeNotFoundException extends NotFoundException {
+  public RecipeNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeRow.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeRow.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.dataset.recipe;
+
+import io.cdap.wrangler.proto.recipe.v2.Recipe;
+import java.util.Objects;
+
+/**
+ * Stores information about Recipe, including information that should not be exposed to users.
+ * {@link Recipe} contains fields that are exposed to users.
+ */
+public class RecipeRow {
+  private final Recipe recipe;
+
+  private RecipeRow(Recipe recipe) {
+    this.recipe = recipe;
+  }
+
+  public Recipe getRecipe() {
+    return recipe;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RecipeRow other = (RecipeRow) o;
+    return Objects.equals(recipe, other.recipe);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(recipe);
+  }
+
+  public static Builder builder(Recipe recipe) {
+    return new Builder(recipe);
+  }
+
+  public static Builder builder(RecipeRow existing) {
+    return new Builder(existing.getRecipe());
+  }
+
+  /**
+   * Creates a RecipeRow storage object
+   */
+  public static class Builder {
+    private final Recipe recipe;
+
+    Builder(Recipe recipe) {
+      this.recipe = recipe;
+    }
+
+    public RecipeRow build() {
+      return new RecipeRow(recipe);
+    }
+  }
+}

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeRow.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeRow.java
@@ -16,7 +16,6 @@
 
 package io.cdap.wrangler.dataset.recipe;
 
-import io.cdap.cdap.api.NamespaceSummary;
 import io.cdap.wrangler.proto.recipe.v2.Recipe;
 import java.util.Objects;
 
@@ -25,11 +24,9 @@ import java.util.Objects;
  * {@link Recipe} contains fields that are exposed to users.
  */
 public class RecipeRow {
-  private final NamespaceSummary namespaceSummary;
   private final Recipe recipe;
 
-  private RecipeRow(NamespaceSummary namespaceSummary, Recipe recipe) {
-    this.namespaceSummary = namespaceSummary;
+  private RecipeRow(Recipe recipe) {
     this.recipe = recipe;
   }
 
@@ -48,7 +45,7 @@ public class RecipeRow {
     }
 
     RecipeRow other = (RecipeRow) o;
-    return Objects.equals(namespaceSummary, other.namespaceSummary) && Objects.equals(recipe, other.recipe);
+    return Objects.equals(recipe, other.recipe);
   }
 
   @Override
@@ -56,28 +53,26 @@ public class RecipeRow {
     return Objects.hash(recipe);
   }
 
-  public static Builder builder(NamespaceSummary namespaceSummary, Recipe recipe) {
-    return new Builder(namespaceSummary, recipe);
+  public static Builder builder(Recipe recipe) {
+    return new Builder(recipe);
   }
 
-  public static Builder builder(NamespaceSummary namespaceSummary, RecipeRow existing) {
-    return new Builder(namespaceSummary, existing.getRecipe());
+  public static Builder builder(RecipeRow existing) {
+    return new Builder(existing.getRecipe());
   }
 
   /**
    * Creates a RecipeRow storage object
    */
   public static class Builder {
-    private final NamespaceSummary namespaceSummary;
     private final Recipe recipe;
 
-    Builder(NamespaceSummary namespaceSummary, Recipe recipe) {
-      this.namespaceSummary = namespaceSummary;
+    Builder(Recipe recipe) {
       this.recipe = recipe;
     }
 
     public RecipeRow build() {
-      return new RecipeRow(namespaceSummary, recipe);
+      return new RecipeRow(recipe);
     }
   }
 }

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeRow.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipeRow.java
@@ -16,6 +16,7 @@
 
 package io.cdap.wrangler.dataset.recipe;
 
+import io.cdap.cdap.api.NamespaceSummary;
 import io.cdap.wrangler.proto.recipe.v2.Recipe;
 import java.util.Objects;
 
@@ -24,9 +25,11 @@ import java.util.Objects;
  * {@link Recipe} contains fields that are exposed to users.
  */
 public class RecipeRow {
+  private final NamespaceSummary namespaceSummary;
   private final Recipe recipe;
 
-  private RecipeRow(Recipe recipe) {
+  private RecipeRow(NamespaceSummary namespaceSummary, Recipe recipe) {
+    this.namespaceSummary = namespaceSummary;
     this.recipe = recipe;
   }
 
@@ -45,7 +48,7 @@ public class RecipeRow {
     }
 
     RecipeRow other = (RecipeRow) o;
-    return Objects.equals(recipe, other.recipe);
+    return Objects.equals(namespaceSummary, other.namespaceSummary) && Objects.equals(recipe, other.recipe);
   }
 
   @Override
@@ -53,26 +56,28 @@ public class RecipeRow {
     return Objects.hash(recipe);
   }
 
-  public static Builder builder(Recipe recipe) {
-    return new Builder(recipe);
+  public static Builder builder(NamespaceSummary namespaceSummary, Recipe recipe) {
+    return new Builder(namespaceSummary, recipe);
   }
 
-  public static Builder builder(RecipeRow existing) {
-    return new Builder(existing.getRecipe());
+  public static Builder builder(NamespaceSummary namespaceSummary, RecipeRow existing) {
+    return new Builder(namespaceSummary, existing.getRecipe());
   }
 
   /**
    * Creates a RecipeRow storage object
    */
   public static class Builder {
+    private final NamespaceSummary namespaceSummary;
     private final Recipe recipe;
 
-    Builder(Recipe recipe) {
+    Builder(NamespaceSummary namespaceSummary, Recipe recipe) {
+      this.namespaceSummary = namespaceSummary;
       this.recipe = recipe;
     }
 
     public RecipeRow build() {
-      return new RecipeRow(recipe);
+      return new RecipeRow(namespaceSummary, recipe);
     }
   }
 }

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/store/recipe/RecipeStore.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/store/recipe/RecipeStore.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.store.recipe;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import io.cdap.cdap.spi.data.StructuredRow;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.cdap.wrangler.dataset.recipe.RecipeAlreadyExistsException;
+import io.cdap.wrangler.dataset.recipe.RecipeNotFoundException;
+import io.cdap.wrangler.dataset.recipe.RecipeRow;
+import io.cdap.wrangler.proto.recipe.v2.Recipe;
+import io.cdap.wrangler.proto.recipe.v2.RecipeId;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Recipe store for v2 endpoint
+ */
+public class RecipeStore {
+  private static final StructuredTableId TABLE_ID = new StructuredTableId("recipes_store");
+  private static final String NAMESPACE_FIELD = "namespace";
+  private static final String GENERATION_COL = "generation";
+  private static final String RECIPE_ID_FIELD = "recipe_id";
+  private static final String RECIPE_NAME_FIELD = "recipe_name";
+  private static final String CREATE_TIME_COL = "create_time";
+  private static final String UPDATE_TIME_COL = "update_time";
+  private static final String RECIPE_INFO_COL = "recipe_info";
+
+  public static final StructuredTableSpecification RECIPE_TABLE_SPEC =
+    new StructuredTableSpecification.Builder()
+      .withId(TABLE_ID)
+      .withFields(Fields.stringType(NAMESPACE_FIELD),
+                  Fields.longType(GENERATION_COL),
+                  Fields.stringType(RECIPE_ID_FIELD),
+                  Fields.stringType(RECIPE_NAME_FIELD),
+                  Fields.longType(CREATE_TIME_COL),
+                  Fields.longType(UPDATE_TIME_COL),
+                  Fields.stringType(RECIPE_INFO_COL))
+      .withPrimaryKeys(NAMESPACE_FIELD, GENERATION_COL, RECIPE_ID_FIELD)
+      .withIndexes(RECIPE_NAME_FIELD, UPDATE_TIME_COL)
+      .build();
+
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
+
+  private final TransactionRunner transactionRunner;
+
+  public RecipeStore(TransactionRunner transactionRunner) {
+    this.transactionRunner = transactionRunner;
+  }
+
+  /**
+   * Create a new recipe
+   * @param recipeId id of the recipe
+   * @param recipeRow recipe to create/update
+   */
+  public void saveRecipe(RecipeId recipeId, RecipeRow recipeRow) {
+    saveRecipe(recipeId, recipeRow, false);
+  }
+
+  // Create or update a recipe
+  private void saveRecipe(RecipeId recipeId, RecipeRow recipeRow, boolean failIfNotFound)
+    throws RecipeAlreadyExistsException {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+
+      String recipeName = recipeRow.getRecipe().getRecipeName();
+      RecipeRow oldRecipeWithName = getRecipeByName(table, recipeName, recipeId.getNamespace(), failIfNotFound);
+      if (!failIfNotFound && oldRecipeWithName != null) {
+        throw new RecipeAlreadyExistsException(String.format("recipe with name '%s' already exists", recipeName));
+      }
+
+      RecipeRow oldRecipe = getRecipeInternal(table, recipeId, failIfNotFound);
+      RecipeRow newRecipe = recipeRow;
+      if (oldRecipe != null) {
+        Recipe updatedRecipe = Recipe.builder(newRecipe.getRecipe())
+          .setCreatedTimeMillis(oldRecipe.getRecipe().getCreatedTimeMillis()).build();
+        newRecipe = RecipeRow.builder(updatedRecipe).build();
+      }
+
+      Collection<Field<?>> fields = getRecipeKeys(recipeId);
+      fields.add(Fields.stringField(RECIPE_NAME_FIELD, newRecipe.getRecipe().getRecipeName()));
+      fields.add(Fields.longField(CREATE_TIME_COL, newRecipe.getRecipe().getCreatedTimeMillis()));
+      fields.add(Fields.longField(UPDATE_TIME_COL, newRecipe.getRecipe().getUpdatedTimeMillis()));
+      fields.add(Fields.stringField(RECIPE_INFO_COL, GSON.toJson(newRecipe)));
+
+      table.upsert(fields);
+    });
+  }
+
+  private RecipeRow getRecipeInternal(StructuredTable table, RecipeId recipeId, boolean failIfNotFound)
+    throws RecipeNotFoundException, IOException {
+    Optional<StructuredRow> row = table.read(getRecipeKeys(recipeId));
+    if (!row.isPresent()) {
+      if (!failIfNotFound) {
+        return null;
+      }
+      throw new RecipeNotFoundException(String.format("recipe with id '%s' does not exist", recipeId.getRecipeId()));
+    }
+    return GSON.fromJson(row.get().getString(RECIPE_INFO_COL), RecipeRow.class);
+  }
+
+  private RecipeRow getRecipeByName(StructuredTable table, String recipeName,
+                                    NamespaceSummary summary, boolean failIfNotFound) throws IOException {
+    Collection<Field<?>> keys = getNamespaceKeys(summary);
+    keys.add(Fields.stringField(RECIPE_NAME_FIELD, recipeName));
+    Range range = Range.singleton(keys);
+    CloseableIterator<StructuredRow> iterator = table.scan(range, 1);
+    if (!iterator.hasNext()) {
+      if (!failIfNotFound) {
+        return null;
+      }
+      throw new RecipeNotFoundException(String.format("recipe with name '%s' does not exist", recipeName));
+    }
+    return GSON.fromJson(iterator.next().getString(RECIPE_INFO_COL), RecipeRow.class);
+  }
+
+  private Collection<Field<?>> getRecipeKeys(RecipeId recipeId) {
+    List<Field<?>> keys = new ArrayList<>(getNamespaceKeys(recipeId.getNamespace()));
+    keys.add(Fields.stringField(RECIPE_ID_FIELD, recipeId.getRecipeId()));
+    return keys;
+  }
+
+  private Collection<Field<?>> getNamespaceKeys(NamespaceSummary namespace) {
+    List<Field<?>> keys = new ArrayList<>();
+    keys.add(Fields.stringField(NAMESPACE_FIELD, namespace.getName()));
+    keys.add(Fields.longField(GENERATION_COL, namespace.getGeneration()));
+    return keys;
+  }
+
+  // Clean up recipes - used only by unit tests
+  public void clear() {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      table.deleteAll(Range.all());
+    });
+  }
+}

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/store/recipe/RecipeStore.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/store/recipe/RecipeStore.java
@@ -105,7 +105,7 @@ public class RecipeStore {
       if (oldRecipe != null) {
         Recipe updatedRecipe = Recipe.builder(newRecipe.getRecipe())
           .setCreatedTimeMillis(oldRecipe.getRecipe().getCreatedTimeMillis()).build();
-        newRecipe = RecipeRow.builder(updatedRecipe).build();
+        newRecipe = RecipeRow.builder(recipeId.getNamespace(), updatedRecipe).build();
       }
 
       Collection<Field<?>> fields = getRecipeKeys(recipeId);

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/store/utils/Stores.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/store/utils/Stores.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.store.utils;
+
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Utility methods for Stores
+ */
+public class Stores {
+  public static Collection<Field<?>> getNamespaceKeys(
+    String namespaceField, String generationField, NamespaceSummary namespace) {
+    List<Field<?>> keys = new ArrayList<>();
+    keys.add(Fields.stringField(namespaceField, namespace.getName()));
+    keys.add(Fields.longField(generationField, namespace.getGeneration()));
+    return keys;
+  }
+}

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
@@ -59,7 +59,7 @@ public class RecipeStoreTest extends SystemAppTestBase {
       .setUpdatedTimeMillis(100L)
       .setDirectives(directives)
       .build();
-    RecipeRow recipeRow = RecipeRow.builder(recipe).build();
+    RecipeRow recipeRow = RecipeRow.builder(summary, recipe).build();
     store.saveRecipe(recipeId, recipeRow);
   }
 
@@ -68,12 +68,12 @@ public class RecipeStoreTest extends SystemAppTestBase {
     NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
     RecipeId recipeId = new RecipeId(summary);
     Recipe recipe = Recipe.builder(recipeId.getRecipeId()).setRecipeName("duplicate-name").build();
-    RecipeRow recipeRow = RecipeRow.builder(recipe).build();
+    RecipeRow recipeRow = RecipeRow.builder(summary, recipe).build();
     store.saveRecipe(recipeId, recipeRow);
 
     RecipeId newRecipeId = new RecipeId(summary);
     Recipe newRecipe = Recipe.builder(newRecipeId.getRecipeId()).setRecipeName("duplicate-name").build();
-    RecipeRow newRecipeRow = RecipeRow.builder(newRecipe).build();
+    RecipeRow newRecipeRow = RecipeRow.builder(summary, newRecipe).build();
     try {
       store.saveRecipe(newRecipeId, newRecipeRow);
       Assert.fail();

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
@@ -52,14 +52,14 @@ public class RecipeStoreTest extends SystemAppTestBase {
     NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
     RecipeId recipeId = new RecipeId(summary);
     ImmutableList<String> directives = ImmutableList.of("dir1", "dir2");
-    Recipe recipe = Recipe.builder(recipeId.getRecipeId())
+    Recipe recipe = Recipe.builder(recipeId)
       .setRecipeName("dummy-name")
       .setDescription("dummy description")
       .setCreatedTimeMillis(100L)
       .setUpdatedTimeMillis(100L)
       .setDirectives(directives)
       .build();
-    RecipeRow recipeRow = RecipeRow.builder(summary, recipe).build();
+    RecipeRow recipeRow = RecipeRow.builder(recipe).build();
     store.saveRecipe(recipeId, recipeRow);
   }
 
@@ -67,13 +67,13 @@ public class RecipeStoreTest extends SystemAppTestBase {
   public void testSaveRecipeWithDuplicateName() {
     NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
     RecipeId recipeId = new RecipeId(summary);
-    Recipe recipe = Recipe.builder(recipeId.getRecipeId()).setRecipeName("duplicate-name").build();
-    RecipeRow recipeRow = RecipeRow.builder(summary, recipe).build();
+    Recipe recipe = Recipe.builder(recipeId).setRecipeName("duplicate-name").build();
+    RecipeRow recipeRow = RecipeRow.builder(recipe).build();
     store.saveRecipe(recipeId, recipeRow);
 
     RecipeId newRecipeId = new RecipeId(summary);
-    Recipe newRecipe = Recipe.builder(newRecipeId.getRecipeId()).setRecipeName("duplicate-name").build();
-    RecipeRow newRecipeRow = RecipeRow.builder(summary, newRecipe).build();
+    Recipe newRecipe = Recipe.builder(newRecipeId).setRecipeName("duplicate-name").build();
+    RecipeRow newRecipeRow = RecipeRow.builder(newRecipe).build();
     try {
       store.saveRecipe(newRecipeId, newRecipeRow);
       Assert.fail();

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.store.recipe;
+
+import com.google.common.collect.ImmutableList;
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.test.SystemAppTestBase;
+import io.cdap.cdap.test.TestConfiguration;
+import io.cdap.wrangler.dataset.recipe.RecipeAlreadyExistsException;
+import io.cdap.wrangler.dataset.recipe.RecipeRow;
+import io.cdap.wrangler.proto.recipe.v2.Recipe;
+import io.cdap.wrangler.proto.recipe.v2.RecipeId;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class RecipeStoreTest extends SystemAppTestBase {
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+  private static RecipeStore store;
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    getStructuredTableAdmin().createOrUpdate(RecipeStore.RECIPE_TABLE_SPEC);
+    store = new RecipeStore(getTransactionRunner());
+  }
+
+  @After
+  public void cleanupTest() {
+    store.clear();
+  }
+
+  @Test
+  public void testSaveNewRecipe() {
+    NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
+    RecipeId recipeId = new RecipeId(summary);
+    ImmutableList<String> directives = ImmutableList.of("dir1", "dir2");
+    Recipe recipe = Recipe.builder(recipeId.getRecipeId())
+      .setRecipeName("dummy-name")
+      .setDescription("dummy description")
+      .setCreatedTimeMillis(100L)
+      .setUpdatedTimeMillis(100L)
+      .setDirectives(directives)
+      .build();
+    RecipeRow recipeRow = RecipeRow.builder(recipe).build();
+    store.saveRecipe(recipeId, recipeRow);
+  }
+
+  @Test
+  public void testSaveRecipeWithDuplicateName() {
+    NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
+    RecipeId recipeId = new RecipeId(summary);
+    Recipe recipe = Recipe.builder(recipeId.getRecipeId()).setRecipeName("duplicate-name").build();
+    RecipeRow recipeRow = RecipeRow.builder(recipe).build();
+    store.saveRecipe(recipeId, recipeRow);
+
+    RecipeId newRecipeId = new RecipeId(summary);
+    Recipe newRecipe = Recipe.builder(newRecipeId.getRecipeId()).setRecipeName("duplicate-name").build();
+    RecipeRow newRecipeRow = RecipeRow.builder(newRecipe).build();
+    try {
+      store.saveRecipe(newRecipeId, newRecipeRow);
+      Assert.fail();
+    } catch (RecipeAlreadyExistsException e) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
Changes:
- add handler and storage classes for recipe management
- add api endpoint to create a new recipe
- also checks whether a recipe with same name already exists
- add unit tests for the above two cases