### PR TITLE
Add API to list Recipes

### DIFF
--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeId.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeId.java
@@ -28,13 +28,8 @@ public class RecipeId {
   private final NamespaceSummary namespace;
   private final String recipeId;
 
-  public RecipeId(NamespaceSummary namespace) {
-    this(namespace, UUID.randomUUID().toString());
-  }
-
-  public RecipeId(NamespaceSummary namespace, String recipeId) {
-    // Set namespace description to null - to avoid duplicate storage of large descriptions
-    this.namespace = new NamespaceSummary(namespace.getName(), null, namespace.getGeneration());
+  private RecipeId(NamespaceSummary namespace, String recipeId) {
+    this.namespace = namespace;
     this.recipeId = recipeId;
   }
 
@@ -64,5 +59,35 @@ public class RecipeId {
   @Override
   public int hashCode() {
     return Objects.hash(namespace, recipeId);
+  }
+
+  public static Builder builder(NamespaceSummary namespace) {
+    return new Builder(namespace);
+  }
+
+  public static Builder builder(RecipeId existing) {
+    return new Builder(existing.getNamespace()).setRecipeId(existing.getRecipeId());
+  }
+
+  /**
+   * Creates a Recipe id object
+   */
+  public static class Builder {
+    private final NamespaceSummary namespace;
+    private String recipeId;
+
+    Builder(NamespaceSummary namespace) {
+      this.namespace = new NamespaceSummary(namespace.getName(), null, namespace.getGeneration());
+      this.recipeId = UUID.randomUUID().toString();
+    }
+
+    public Builder setRecipeId(String recipeId) {
+      this.recipeId = recipeId;
+      return this;
+    }
+
+    public RecipeId build() {
+      return new RecipeId(namespace, recipeId);
+    }
   }
 }

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeListResponse.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/recipe/v2/RecipeListResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.proto.recipe.v2;
+
+import io.cdap.wrangler.proto.ServiceResponse;
+
+import java.util.List;
+
+/**
+ * Represents a paginated list of recipes as a response.
+ */
+public class RecipeListResponse extends ServiceResponse<Recipe> {
+  String nextPageToken;
+
+  public RecipeListResponse(List<Recipe> recipes, String nextPageToken) {
+    super(recipes);
+    this.nextPageToken = nextPageToken;
+  }
+
+  public String getNextPageToken() {
+    return nextPageToken;
+  }
+}

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipePageRequest.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/recipe/RecipePageRequest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.dataset.recipe;
+
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.spi.data.SortOrder;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.wrangler.dataset.utils.PageRequest;
+import io.cdap.wrangler.proto.recipe.v2.Recipe;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static io.cdap.cdap.spi.data.table.field.Range.Bound.INCLUSIVE;
+import static io.cdap.wrangler.store.recipe.RecipeStore.GENERATION_COL;
+import static io.cdap.wrangler.store.recipe.RecipeStore.NAMESPACE_FIELD;
+import static io.cdap.wrangler.store.recipe.RecipeStore.RECIPE_NAME_FIELD;
+import static io.cdap.wrangler.store.recipe.RecipeStore.UPDATE_TIME_COL;
+import static io.cdap.wrangler.store.utils.Stores.getNamespaceKeys;
+
+/**
+ * Represents a request to fetch a page of Recipes.
+ */
+public class RecipePageRequest extends PageRequest<Recipe> {
+  public static final String SORT_BY_NAME = "name";
+  public static final String SORT_BY_UPDATE_TIME = "updated";
+
+  private static final Map<String, String> sortByMap = createSortByMap();
+
+  private final NamespaceSummary namespace;
+
+  protected RecipePageRequest(Integer pageSize, String pageToken, String sortBy,
+                            String sortOrder, NamespaceSummary namespace) {
+    super(pageSize, pageToken, sortBy, sortOrder);
+    this.namespace = namespace;
+    validatePageTokenDataType(this.getPageToken(), this.getSortBy());
+  }
+
+  public NamespaceSummary getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void validateSortBy(String sortBy) {
+    if (sortBy != null && !sortByMap.containsKey(sortBy)) {
+      throw new IllegalArgumentException(
+        String.format("Invalid sortBy '%s' specified. sortBy must be one of: '%s' or '%s'",
+                      sortBy, SORT_BY_NAME, SORT_BY_UPDATE_TIME));
+    }
+  }
+
+  @Override
+  protected String getDefaultSortBy() {
+    return RECIPE_NAME_FIELD;
+  }
+
+  @Override
+  protected String getSortByColumnName(String sortBy) {
+    return sortByMap.get(sortBy);
+  }
+
+  @Override
+  public Range getScanRange() {
+    Collection<Field<?>> begin = getNamespaceKeys(NAMESPACE_FIELD, GENERATION_COL, namespace);
+    Collection<Field<?>> end = getNamespaceKeys(NAMESPACE_FIELD, GENERATION_COL, namespace);
+
+    // If pageToken has a value, add the respective field (column, value) to the range to filter results
+    if (getPageToken() != null) {
+      Field<?> sortByField = getSortByField();
+
+      if (getSortOrder().equals(SortOrder.ASC)) {
+        begin.add(sortByField);
+      } else {
+        end.add(sortByField);
+      }
+    }
+
+    return Range.create(begin, INCLUSIVE, end, INCLUSIVE);
+  }
+
+  @Override
+  public String getNextPageToken(Recipe recipe) {
+    String nextPageToken;
+    switch (getSortBy()) {
+      case RECIPE_NAME_FIELD:
+        nextPageToken = recipe.getRecipeName();
+        break;
+      case UPDATE_TIME_COL:
+        nextPageToken = String.valueOf(recipe.getUpdatedTimeMillis());
+        break;
+      default:
+        throw new IllegalArgumentException(
+          String.format("Invalid sortBy field '%s' is not mapped to any field in Recipe to return as a pageToken.",
+                        getSortBy()));
+    }
+    return nextPageToken;
+  }
+
+  private static Map<String, String> createSortByMap() {
+    Map<String, String> sortByMap = new HashMap<>();
+    sortByMap.put(SORT_BY_NAME, RECIPE_NAME_FIELD);
+    sortByMap.put(SORT_BY_UPDATE_TIME, UPDATE_TIME_COL);
+    return sortByMap;
+  }
+
+  private void validatePageTokenDataType(String pageToken, String sortBy) {
+    if (pageToken != null && sortBy.equals(UPDATE_TIME_COL)) {
+      try {
+        Long.parseLong(pageToken);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+          "pageToken value is of invalid data type: expected 'long' value for sortBy 'updated'");
+      }
+    }
+  }
+
+  private Field<?> getSortByField() {
+    Field<?> sortByField;
+    switch (getSortBy()) {
+      case RECIPE_NAME_FIELD:
+        sortByField = Fields.stringField(RECIPE_NAME_FIELD, getPageToken());
+        break;
+      case UPDATE_TIME_COL:
+        sortByField = Fields.longField(UPDATE_TIME_COL, Long.parseLong(Objects.requireNonNull(getPageToken())));
+        break;
+      default:
+        throw new IllegalArgumentException(
+          String.format("Invalid sortBy field '%s' is not mapped to any Recipe store column name.",
+                        getSortBy()));
+    }
+    return sortByField;
+  }
+
+  public static Builder builder(NamespaceSummary namespace) {
+    return new Builder(namespace);
+  }
+
+  /**
+   * Creates a {@link RecipePageRequest} object
+   */
+  public static class Builder {
+    private final NamespaceSummary namespace;
+    private Integer pageSize;
+    private String pageToken;
+    private String sortBy;
+    private String sortOrder;
+
+    Builder(NamespaceSummary namespace) {
+      this.namespace = namespace;
+    }
+
+    public Builder setPageSize(Integer pageSize) {
+      this.pageSize = pageSize;
+      return this;
+    }
+
+    public Builder setPageToken(String pageToken) {
+      this.pageToken = pageToken;
+      return this;
+    }
+
+    public Builder setSortBy(String sortBy) {
+      this.sortBy = sortBy;
+      return this;
+    }
+
+    public Builder setSortOrder(String sortOrder) {
+      this.sortOrder = sortOrder;
+      return this;
+    }
+
+    public RecipePageRequest build() {
+      return new RecipePageRequest(pageSize, pageToken, sortBy, sortOrder, namespace);
+    }
+  }
+}

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/utils/PageRequest.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/utils/PageRequest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.dataset.utils;
+
+import io.cdap.cdap.spi.data.SortOrder;
+import io.cdap.cdap.spi.data.table.field.Range;
+
+import javax.annotation.Nullable;
+
+/**
+ * An interface to implement a page request. Pagination utility class that contains relevant fields and methods
+ * that describe a page.
+ * @param <T> Type of resource that the page request is for.
+ */
+public abstract class PageRequest<T> {
+  /**
+   * Maximum number of results to return in a page.
+   */
+  protected final int pageSize;
+
+  /**
+   * Token to identify the page to retrieve. Either received from a previous page or left empty to fetch the first page.
+   */
+  @Nullable
+  protected final String pageToken;
+
+  /**
+   * Indicates the table column name based on which results should be sorted.
+   */
+  protected final String sortBy;
+
+  /**
+   * Indicates the sorting order (ascending or descending).
+   */
+  protected final SortOrder sortOrder;
+
+  public static final String SORT_ORDER_ASC = "asc";
+  public static final String SORT_ORDER_DESC = "desc";
+  public static final int PAGE_SIZE_DEFAULT = 10;
+
+  protected PageRequest(Integer pageSize, @Nullable String pageToken, String sortBy, String sortOrder) {
+    this.pageToken = pageToken;
+
+    validateSortBy(sortBy);
+    this.sortBy = sortBy == null ? getDefaultSortBy() : getSortByColumnName(sortBy);
+
+    validatePageSize(pageSize);
+    this.pageSize = pageSize == null ? PAGE_SIZE_DEFAULT : pageSize;
+
+    validateSortOrder(sortOrder);
+    this.sortOrder = (sortOrder == null || sortOrder.equals(SORT_ORDER_ASC)) ? SortOrder.ASC : SortOrder.DESC;
+  }
+
+  public int getPageSize() {
+    return pageSize;
+  }
+
+  @Nullable
+  public String getPageToken() {
+    return pageToken;
+  }
+
+  public String getSortBy() {
+    return sortBy;
+  }
+
+  public SortOrder getSortOrder() {
+    return sortOrder;
+  }
+
+  /**
+   * Checks whether given sortBy value has a respective table column mapping.
+   * @param sortBy field based on which results should be sorted
+   * @throws IllegalArgumentException if the value does not have a mapping
+   */
+  protected abstract void validateSortBy(String sortBy) throws IllegalArgumentException;
+
+  /**
+   * Get the default table column name using which results will be sorted.
+   */
+  protected abstract String getDefaultSortBy();
+
+  /**
+   * Get the table column name mapped to given sortBy value.
+   */
+  protected abstract String getSortByColumnName(String sortBy);
+
+  /**
+   * Constructs the range used to query the storage table.
+   * @return {@link Range} corresponding to page query parameters.
+   */
+  public abstract Range getScanRange();
+
+  /**
+   * Get the nextPageToken returned as part of response to request.
+   * @param object resource returned by the request
+   */
+  public abstract String getNextPageToken(T object);
+
+  protected void validatePageSize(Integer pageSize) {
+    if (pageSize != null && pageSize <= 0) {
+      throw new IllegalArgumentException("pageSize cannot be negative or zero.");
+    }
+  }
+
+  protected void validateSortOrder(String sortOrder) {
+    if (sortOrder != null && !(sortOrder.equals(SORT_ORDER_ASC) || sortOrder.equals(SORT_ORDER_DESC))) {
+      throw new IllegalArgumentException(
+        String.format("Invalid sortOrder '%s' specified. sortOrder must be one of: '%s' or '%s'",
+                      sortOrder, SORT_ORDER_ASC, SORT_ORDER_DESC));
+    }
+  }
+}

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/store/utils/Stores.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/store/utils/Stores.java
@@ -28,6 +28,13 @@ import java.util.List;
  * Utility methods for Stores
  */
 public class Stores {
+  /**
+   * Constructs a list of {@link Field}s that map table column names to values
+   * @param namespaceField table column name for storing namespace name
+   * @param generationField table column name for storing namespace generation
+   * @param namespace {@link NamespaceSummary} object that contains namespace metadata
+   * @return list of {@link Field} objects
+   */
   public static Collection<Field<?>> getNamespaceKeys(
     String namespaceField, String generationField, NamespaceSummary namespace) {
     List<Field<?>> keys = new ArrayList<>();

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/RecipePageRequestTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/RecipePageRequestTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.dataset;
+
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.wrangler.dataset.recipe.RecipePageRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static io.cdap.cdap.spi.data.table.field.Range.Bound.INCLUSIVE;
+import static io.cdap.wrangler.dataset.recipe.RecipePageRequest.SORT_BY_UPDATE_TIME;
+import static io.cdap.wrangler.store.recipe.RecipeStore.GENERATION_COL;
+import static io.cdap.wrangler.store.recipe.RecipeStore.NAMESPACE_FIELD;
+import static io.cdap.wrangler.store.utils.Stores.getNamespaceKeys;
+
+public class RecipePageRequestTest {
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidSortBy() {
+    NamespaceSummary namespace = new NamespaceSummary("n1", "", 10L);
+    RecipePageRequest.builder(namespace).setSortBy("invalid-sortBy").build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidSortOrder() {
+    NamespaceSummary namespace = new NamespaceSummary("n1", "", 10L);
+    RecipePageRequest.builder(namespace).setSortOrder("invalid-sortOrder").build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidPageSize() {
+    NamespaceSummary namespace = new NamespaceSummary("n1", "", 10L);
+    RecipePageRequest.builder(namespace).setPageSize(0).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPageRequestWithInvalidPageToken() {
+    NamespaceSummary namespace = new NamespaceSummary("n1", "", 10L);
+    RecipePageRequest.builder(namespace).setSortBy(SORT_BY_UPDATE_TIME).setPageToken("abc123").build();
+  }
+
+  @Test
+  public void testGetRangeForFirstPage() {
+    NamespaceSummary namespace = new NamespaceSummary("n1", "", 10L);
+    RecipePageRequest pageRequest = RecipePageRequest.builder(namespace).build();
+    Range range = pageRequest.getScanRange();
+    Collection<Field<?>> fields = getNamespaceKeys(NAMESPACE_FIELD, GENERATION_COL, namespace);
+    Assert.assertEquals(range, Range.create(fields, INCLUSIVE, fields, INCLUSIVE));
+  }
+}

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
@@ -23,14 +23,22 @@ import io.cdap.cdap.test.SystemAppTestBase;
 import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.wrangler.dataset.recipe.RecipeAlreadyExistsException;
 import io.cdap.wrangler.dataset.recipe.RecipeNotFoundException;
+import io.cdap.wrangler.dataset.recipe.RecipePageRequest;
 import io.cdap.wrangler.dataset.recipe.RecipeRow;
 import io.cdap.wrangler.proto.recipe.v2.Recipe;
 import io.cdap.wrangler.proto.recipe.v2.RecipeId;
+import io.cdap.wrangler.proto.recipe.v2.RecipeListResponse;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import java.util.List;
+
+import static io.cdap.wrangler.dataset.recipe.RecipePageRequest.SORT_BY_UPDATE_TIME;
+import static io.cdap.wrangler.dataset.utils.PageRequest.SORT_ORDER_DESC;
+import static io.cdap.wrangler.store.recipe.RecipeStore.RECIPE_TABLE_SPEC;
 
 public class RecipeStoreTest extends SystemAppTestBase {
   @ClassRule
@@ -39,7 +47,7 @@ public class RecipeStoreTest extends SystemAppTestBase {
 
   @BeforeClass
   public static void setupTest() throws Exception {
-    getStructuredTableAdmin().createOrUpdate(RecipeStore.RECIPE_TABLE_SPEC);
+    getStructuredTableAdmin().createOrUpdate(RECIPE_TABLE_SPEC);
     store = new RecipeStore(getTransactionRunner());
   }
 
@@ -51,10 +59,10 @@ public class RecipeStoreTest extends SystemAppTestBase {
   @Test
   public void testSaveAndGetNewRecipe() {
     NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
-    RecipeId recipeId = new RecipeId(summary);
+    RecipeId recipeId = RecipeId.builder(summary).build();
     ImmutableList<String> directives = ImmutableList.of("dir1", "dir2");
     Recipe recipe = Recipe.builder(recipeId)
-      .setRecipeName("dummy-name")
+      .setRecipeName("dummy name")
       .setDescription("dummy description")
       .setCreatedTimeMillis(100L)
       .setUpdatedTimeMillis(100L)
@@ -70,21 +78,102 @@ public class RecipeStoreTest extends SystemAppTestBase {
   @Test(expected = RecipeAlreadyExistsException.class)
   public void testSaveRecipeWithDuplicateName() {
     NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
-    RecipeId recipeId = new RecipeId(summary);
-    Recipe recipe = Recipe.builder(recipeId).setRecipeName("duplicate-name").build();
-    RecipeRow recipeRow = RecipeRow.builder(recipe).build();
+    RecipeId recipeId = RecipeId.builder(summary).build();
+    RecipeRow recipeRow = RecipeRow.builder(
+      Recipe.builder(recipeId).setRecipeName("duplicate name").build()).build();
     store.saveRecipe(recipeId, recipeRow);
 
-    RecipeId newRecipeId = new RecipeId(summary);
-    Recipe newRecipe = Recipe.builder(newRecipeId).setRecipeName("duplicate-name").build();
-    RecipeRow newRecipeRow = RecipeRow.builder(newRecipe).build();
+    RecipeId newRecipeId = RecipeId.builder(summary).build();
+    RecipeRow newRecipeRow = RecipeRow.builder(
+      Recipe.builder(newRecipeId).setRecipeName("duplicate name").build()).build();
     store.saveRecipe(newRecipeId, newRecipeRow);
   }
 
   @Test(expected = RecipeNotFoundException.class)
   public void testGetRecipeDoesNotExist() {
     NamespaceSummary summary = new NamespaceSummary("n100", "", 40L);
-    RecipeId recipeId = new RecipeId(summary, "non-existent-recipe-id");
+    RecipeId recipeId = RecipeId.builder(summary).setRecipeId("non-existent-recipe-id").build();
     store.getRecipe(recipeId);
+  }
+
+  @Test
+  public void testListRecipesDefault() {
+    NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
+    RecipeId recipeId1 = RecipeId.builder(summary).build();
+    RecipeId recipeId2 = RecipeId.builder(summary).build();
+    RecipeRow recipeRow1 = RecipeRow.builder(Recipe.builder(recipeId1).setRecipeName("xyz").build()).build();
+    RecipeRow recipeRow2 = RecipeRow.builder(Recipe.builder(recipeId2).setRecipeName("abc").build()).build();
+
+    store.saveRecipe(recipeId1, recipeRow1);
+    store.saveRecipe(recipeId2, recipeRow2);
+
+    // Assuming default values for query parameters
+    RecipePageRequest pageRequest = RecipePageRequest.builder(summary).build();
+    RecipeListResponse response = store.listRecipes(pageRequest);
+    List<Recipe> values = (List<Recipe>) response.getValues();
+
+    // Check whether values are sorted in alphabetical order by recipeName
+    Assert.assertEquals(2, (int) response.getCount());
+    Assert.assertEquals(values.get(0), recipeRow2.getRecipe());
+    Assert.assertEquals(values.get(1), recipeRow1.getRecipe());
+  }
+
+  @Test
+  public void testListRecipesSortByUpdated() {
+    NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
+    RecipeId recipeId1 = RecipeId.builder(summary).build();
+    RecipeId recipeId2 = RecipeId.builder(summary).build();
+    RecipeRow recipeRow1 = RecipeRow.builder(
+      Recipe.builder(recipeId1).setRecipeName("first").setUpdatedTimeMillis(100L).build()).build();
+    RecipeRow recipeRow2 = RecipeRow.builder(
+      Recipe.builder(recipeId2).setRecipeName("second").setUpdatedTimeMillis(200L).build()).build();
+
+    store.saveRecipe(recipeId1, recipeRow1);
+    store.saveRecipe(recipeId2, recipeRow2);
+
+    RecipePageRequest pageRequest = RecipePageRequest.builder(summary)
+      .setSortBy(SORT_BY_UPDATE_TIME)
+      .setSortOrder(SORT_ORDER_DESC)
+      .build();
+    RecipeListResponse response = store.listRecipes(pageRequest);
+    List<Recipe> values = (List<Recipe>) response.getValues();
+
+    // Check whether values are sorted in descending order by updatedTime
+    Assert.assertEquals(2, (int) response.getCount());
+    Assert.assertEquals(values.get(0), recipeRow2.getRecipe());
+    Assert.assertEquals(values.get(1), recipeRow1.getRecipe());
+  }
+
+  @Test
+  public void testListRecipesPagination() {
+    NamespaceSummary summary = new NamespaceSummary("n1", "", 10L);
+    RecipeId recipeId1 = RecipeId.builder(summary).build();
+    RecipeId recipeId2 = RecipeId.builder(summary).build();
+    RecipeId recipeId3 = RecipeId.builder(summary).build();
+    RecipeRow recipeRow1 = RecipeRow.builder(Recipe.builder(recipeId1).setRecipeName("recipe 1").build()).build();
+    RecipeRow recipeRow2 = RecipeRow.builder(Recipe.builder(recipeId2).setRecipeName("recipe 2").build()).build();
+    RecipeRow recipeRow3 = RecipeRow.builder(Recipe.builder(recipeId3).setRecipeName("recipe 3").build()).build();
+
+    store.saveRecipe(recipeId1, recipeRow1);
+    store.saveRecipe(recipeId2, recipeRow2);
+    store.saveRecipe(recipeId3, recipeRow3);
+
+    RecipePageRequest pageRequest1 = RecipePageRequest.builder(summary).setPageSize(2).build();
+    RecipeListResponse page1 = store.listRecipes(pageRequest1);
+    List<Recipe> values = (List<Recipe>) page1.getValues();
+
+    Assert.assertEquals(2, (int) page1.getCount());
+    Assert.assertEquals(values.get(0), recipeRow1.getRecipe());
+    Assert.assertEquals(values.get(1), recipeRow2.getRecipe());
+    Assert.assertEquals(page1.getNextPageToken(), recipeRow3.getRecipe().getRecipeName());
+
+    // Fetching the next page
+    RecipePageRequest pageRequest2 = RecipePageRequest.builder(summary).setPageToken(page1.getNextPageToken()).build();
+    RecipeListResponse page2 = store.listRecipes(pageRequest2);
+    values = (List<Recipe>) page2.getValues();
+
+    Assert.assertEquals(1, (int) page2.getCount());
+    Assert.assertEquals(values.get(0), recipeRow3.getRecipe());
+    Assert.assertEquals(page2.getNextPageToken(), "");
   }
 }


### PR DESCRIPTION
- Add api endpoint to fetch a paginated list of recipes
- Pagination query parameters:
    - `sortBy` field recipe name (ascending, default) or updated time (descending)
    - `pageSize` (default = 10)
    - `pageToken` (default = empty fetches first page)
- `RecipeListResponse` returns `nextPageToken`
- Add unit tests that test the following:
    - default values for pagination (and sort by name)
    - sort by updated
    - pagination