### PR TITLE
Better error propagation while executing directives

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/RecipeException.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/RecipeException.java
@@ -21,16 +21,31 @@ package io.cdap.wrangler.api;
  * communicating issues with execution of pipeline.
  */
 public class RecipeException extends Exception {
-  public RecipeException(Exception e) {
-    super(e);
+  public static final int UNKNOWN_INDEX = -1;
+
+  // Index of row in dataset and directive in recipe that caused the error
+  private final int rowIndex;
+  private final int directiveIndex;
+
+  public RecipeException(String message, Throwable throwable, int rowIndex, int directiveIndex) {
+    super(message, throwable);
+    this.rowIndex = rowIndex;
+    this.directiveIndex = directiveIndex;
   }
 
-  public RecipeException(String message) {
-    super(message);
+  public RecipeException(String message, Throwable throwable, int directiveIndex) {
+    this(message, throwable, UNKNOWN_INDEX, directiveIndex);
   }
 
   public RecipeException(String message, Throwable throwable) {
-    super(message, throwable);
+    this(message, throwable, UNKNOWN_INDEX, UNKNOWN_INDEX);
+  }
+
+  public int getRowIndex() {
+    return rowIndex;
+  }
+
+  public int getDirectiveIndex() {
+    return directiveIndex;
   }
 }
-

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/RecipeParser.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/RecipeParser.java
@@ -30,5 +30,5 @@ public interface RecipeParser {
    *
    * @return List of {@link Executor}.
    */
-  List<Directive> parse() throws DirectiveLoadException, DirectiveNotFoundException, DirectiveParseException;
+  List<Directive> parse() throws RecipeException;
 }

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/ConfigDirectiveContextTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/ConfigDirectiveContextTest.java
@@ -19,8 +19,7 @@ package io.cdap.wrangler.parser;
 import com.google.gson.Gson;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveConfig;
-import io.cdap.wrangler.api.DirectiveNotFoundException;
-import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.RecipeException;
 import io.cdap.wrangler.api.RecipeParser;
 import io.cdap.wrangler.proto.Contexts;
 import io.cdap.wrangler.registry.CompositeDirectiveRegistry;
@@ -52,7 +51,7 @@ public class ConfigDirectiveContextTest {
 
   private static final String EMPTY = "{}";
 
-  @Test(expected = DirectiveParseException.class)
+  @Test(expected = RecipeException.class)
   public void testBasicExclude() throws Exception {
     String[] text = new String[] {
       "parse-as-csv body , true"
@@ -67,7 +66,7 @@ public class ConfigDirectiveContextTest {
     directives.parse();
   }
 
-  @Test(expected = DirectiveParseException.class)
+  @Test(expected = RecipeException.class)
   public void testAliasedAndExcluded() throws Exception {
     String[] text = new String[] {
       "js-parser body"
@@ -98,7 +97,7 @@ public class ConfigDirectiveContextTest {
     Assert.assertEquals(1, steps.size());
   }
 
-  @Test(expected = DirectiveNotFoundException.class)
+  @Test(expected = RecipeException.class)
   public void testEmptyAliasingShouldFail() throws Exception {
     String[] text = new String[] {
       "json-parser :body;"

--- a/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/RecipeExceptionResponse.java
+++ b/wrangler-proto/src/main/java/io/cdap/wrangler/proto/workspace/v2/RecipeExceptionResponse.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.proto.workspace.v2;
+
+/**
+ * Response returned when a {@link io.cdap.wrangler.api.RecipeException} occurs. Contains information about row index
+ * in dataset and directive index in recipe that caused the error.
+ * @param <T>
+ */
+public class RecipeExceptionResponse<T> extends ServiceResponse<T> {
+  private final Integer rowIndex;
+  private final Integer directiveIndex;
+  public RecipeExceptionResponse(String message, Integer rowIndex, Integer directiveIndex) {
+    super(message);
+    this.rowIndex = rowIndex;
+    this.directiveIndex = directiveIndex;
+  }
+}

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/common/AbstractWranglerHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/common/AbstractWranglerHandler.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.service.http.HttpServiceRequest;
 import io.cdap.cdap.api.service.http.HttpServiceResponder;
 import io.cdap.cdap.api.service.worker.RemoteExecutionException;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.cdap.wrangler.api.RecipeException;
 import io.cdap.wrangler.dataset.connections.ConnectionNotFoundException;
 import io.cdap.wrangler.dataset.connections.ConnectionStore;
 import io.cdap.wrangler.dataset.workspace.Workspace;
@@ -39,6 +40,7 @@ import io.cdap.wrangler.proto.ServiceResponse;
 import io.cdap.wrangler.proto.StatusCodeException;
 import io.cdap.wrangler.proto.connection.Connection;
 import io.cdap.wrangler.proto.connection.ConnectionType;
+import io.cdap.wrangler.proto.workspace.v2.RecipeExceptionResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -198,6 +200,9 @@ public class AbstractWranglerHandler extends AbstractSystemHttpServiceHandler {
 
     try {
       runnable.respond(namespaceSummary);
+    } catch (RecipeException e) {
+      responder.sendJson(HttpURLConnection.HTTP_BAD_REQUEST,
+                         new RecipeExceptionResponse<>(e.getMessage(), e.getRowIndex(), e.getDirectiveIndex()));
     } catch (StatusCodeException e) {
       responder.sendJson(e.getCode(), new io.cdap.wrangler.proto.workspace.v2.ServiceResponse<>(e.getMessage()));
     } catch (ErrorRecordsException e) {

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/AbstractDirectiveHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/AbstractDirectiveHandler.java
@@ -19,7 +19,6 @@ package io.cdap.wrangler.service.directive;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
 import io.cdap.directives.aggregates.DefaultTransientStore;
@@ -112,7 +111,7 @@ public class AbstractDirectiveHandler extends AbstractWranglerHandler {
       String namespace,
       List<String> directives,
       List<Row> sample,
-      GrammarWalker.Visitor<E> grammarVisitor) throws DirectiveParseException, E {
+      GrammarWalker.Visitor<E> grammarVisitor) throws DirectiveParseException, E, RecipeException {
 
     if (directives.isEmpty()) {
       return sample;
@@ -146,8 +145,6 @@ public class AbstractDirectiveHandler extends AbstractWranglerHandler {
         throw new ErrorRecordsException(errors);
       }
       return result;
-    } catch (RecipeException e) {
-      throw new BadRequestException(e.getMessage(), e);
     }
   }
 

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceHandler.java
@@ -47,6 +47,7 @@ import io.cdap.wrangler.api.DirectiveConfig;
 import io.cdap.wrangler.api.DirectiveLoadException;
 import io.cdap.wrangler.api.DirectiveParseException;
 import io.cdap.wrangler.api.GrammarMigrator;
+import io.cdap.wrangler.api.RecipeException;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.parser.ConfigDirectiveContext;
 import io.cdap.wrangler.parser.DirectiveClass;
@@ -567,7 +568,7 @@ public class WorkspaceHandler extends AbstractDirectiveHandler {
    */
   private <E extends Exception> List<Row> executeLocally(String namespace, List<String> directives,
                                    WorkspaceDetail detail, GrammarWalker.Visitor<E> grammarVisitor)
-    throws DirectiveLoadException, DirectiveParseException, E {
+    throws DirectiveLoadException, DirectiveParseException, E, RecipeException {
 
     // load the udd
     composite.reload(namespace);


### PR DESCRIPTION
## Changes
- Add `rowIndex` and `directiveIndex` fields to `RecipeException` to track which row and directive caused the error
- Add a new response object returned by API call when RecipeException occurs
- Change handlers to handle different exceptions being re-thrown as `RecipeException`s
- Get and propagate row, directive indices from parser & recipe executor classes