### PR TITLE
[CDAP-20224] Remove Explore References from `wrangler`

### DIFF
--- a/wrangler-service/src/test/java/io/cdap/wrangler/service/WranglerServiceTest.java
+++ b/wrangler-service/src/test/java/io/cdap/wrangler/service/WranglerServiceTest.java
@@ -20,18 +20,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.ServiceManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
 import io.cdap.wrangler.DataPrep;
 import io.cdap.wrangler.service.directive.DirectivesHandler;
 import org.junit.Assert;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -49,9 +46,6 @@ import java.util.Map;
 public class WranglerServiceTest extends WranglerServiceTestBase {
   private static final Gson GSON =
     new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-
 
   @Test
   public void test() throws Exception {

--- a/wrangler-service/src/test/java/io/cdap/wrangler/service/filesystem/FilesystemExplorerTest.java
+++ b/wrangler-service/src/test/java/io/cdap/wrangler/service/filesystem/FilesystemExplorerTest.java
@@ -18,15 +18,12 @@ package io.cdap.wrangler.service.filesystem;
 
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.dataset.lib.FileSet;
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.ServiceManager;
 import io.cdap.cdap.test.TestBase;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.wrangler.service.explorer.DatasetProvider;
 import io.cdap.wrangler.service.explorer.Explorer;
 import org.junit.Assert;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -37,9 +34,6 @@ import java.util.Map;
  */
 @Ignore
 public class FilesystemExplorerTest extends TestBase {
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-
   @Test
   public void testExplorer() throws Exception {
     ApplicationManager app = deployApplication(TestApp.class);

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/ConnectionStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/ConnectionStoreTest.java
@@ -16,10 +16,8 @@
 
 package io.cdap.wrangler.dataset;
 
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.test.SystemAppTestBase;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.wrangler.dataset.connections.ConnectionAlreadyExistsException;
 import io.cdap.wrangler.dataset.connections.ConnectionNotFoundException;
 import io.cdap.wrangler.dataset.connections.ConnectionStore;
@@ -31,7 +29,6 @@ import io.cdap.wrangler.proto.connection.ConnectionType;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
@@ -40,9 +37,6 @@ import java.util.List;
  * Tests for the {@link ConnectionStore}.
  */
 public class ConnectionStoreTest extends SystemAppTestBase {
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Before
   public void setupTest() throws Exception {

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/SchemaRegistryTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/SchemaRegistryTest.java
@@ -16,10 +16,8 @@
 
 package io.cdap.wrangler.dataset;
 
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.test.SystemAppTestBase;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.wrangler.dataset.schema.SchemaDescriptor;
 import io.cdap.wrangler.dataset.schema.SchemaNotFoundException;
 import io.cdap.wrangler.dataset.schema.SchemaRegistry;
@@ -30,7 +28,6 @@ import io.cdap.wrangler.proto.schema.SchemaEntry;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -41,9 +38,6 @@ import java.util.Set;
  * Tests for {@link SchemaRegistry}.
  */
 public class SchemaRegistryTest extends SystemAppTestBase {
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Before
   public void setupTest() throws Exception {

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/WorkspaceDatasetTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/WorkspaceDatasetTest.java
@@ -17,10 +17,8 @@
 package io.cdap.wrangler.dataset;
 
 import com.google.gson.JsonObject;
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.test.SystemAppTestBase;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.wrangler.dataset.workspace.DataType;
 import io.cdap.wrangler.dataset.workspace.Workspace;
 import io.cdap.wrangler.dataset.workspace.WorkspaceDataset;
@@ -36,7 +34,6 @@ import io.cdap.wrangler.proto.WorkspaceIdentifier;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -47,9 +44,6 @@ import java.util.Map;
  */
 public class WorkspaceDatasetTest extends SystemAppTestBase {
 
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-  
   @Before
   public void setupTest() throws Exception {
     getStructuredTableAdmin().create(WorkspaceDataset.TABLE_SPEC);

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/store/recipe/RecipeStoreTest.java
@@ -18,9 +18,7 @@ package io.cdap.wrangler.store.recipe;
 
 import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.NamespaceSummary;
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.test.SystemAppTestBase;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.wrangler.dataset.recipe.RecipeAlreadyExistsException;
 import io.cdap.wrangler.dataset.recipe.RecipeNotFoundException;
 import io.cdap.wrangler.dataset.recipe.RecipePageRequest;
@@ -31,7 +29,6 @@ import io.cdap.wrangler.proto.recipe.v2.RecipeListResponse;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
@@ -41,8 +38,6 @@ import static io.cdap.wrangler.dataset.utils.PageRequest.SORT_ORDER_DESC;
 import static io.cdap.wrangler.store.recipe.RecipeStore.RECIPE_TABLE_SPEC;
 
 public class RecipeStoreTest extends SystemAppTestBase {
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
   private static RecipeStore store;
 
   @BeforeClass

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/store/upgrade/UpgradeStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/store/upgrade/UpgradeStoreTest.java
@@ -19,14 +19,11 @@ package io.cdap.wrangler.store.upgrade;
 
 import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.NamespaceSummary;
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.test.SystemAppTestBase;
-import io.cdap.cdap.test.TestConfiguration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
@@ -36,8 +33,6 @@ import java.util.concurrent.TimeUnit;
  * Upgrade store test
  */
 public class UpgradeStoreTest extends SystemAppTestBase {
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
   private static UpgradeStore store;
 
   @BeforeClass

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/store/workspace/WorkspaceStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/store/workspace/WorkspaceStoreTest.java
@@ -20,9 +20,7 @@ package io.cdap.wrangler.store.workspace;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.NamespaceSummary;
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.test.SystemAppTestBase;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.dataset.workspace.WorkspaceNotFoundException;
 import io.cdap.wrangler.proto.workspace.v2.SampleSpec;
@@ -32,7 +30,6 @@ import io.cdap.wrangler.proto.workspace.v2.WorkspaceId;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -40,9 +37,6 @@ import java.util.Collections;
 import java.util.HashSet;
 
 public class WorkspaceStoreTest extends SystemAppTestBase {
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
   private static WorkspaceStore store;
 
   @BeforeClass


### PR DESCRIPTION
- As part of cdapio/cdap/pull/14802, the module `cdap-explore` and its references and occurrences are removed from CDAP repository.
- Similar references in `wrangler-transform` need to be removed.
[JIRA](https://cdap.atlassian.net/browse/CDAP-20224)