### PR TITLE
Removing API metrics which are already captured by CDAP

### DIFF
--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RecipeHandler.java
@@ -61,7 +61,6 @@ public class RecipeHandler extends AbstractWranglerHandler {
   @SuppressWarnings("unused")
   private Metrics metrics;
 
-  private static final String RECIPE_CREATE_METRIC = "recipe.create";
   private static final String NUMBER_RECIPE_SAVED_METRIC = "recipe.saved";
 
   @Override
@@ -79,7 +78,6 @@ public class RecipeHandler extends AbstractWranglerHandler {
       RecipeId recipeId = RecipeId.builder(ns).build();
       Recipe recipe = buildRecipeFromRequest(request, recipeId);
       recipeStore.createRecipe(recipeId, RecipeRow.builder(recipe).build());
-      metrics.count(RECIPE_CREATE_METRIC, 1);
       metrics.gauge(NUMBER_RECIPE_SAVED_METRIC, recipe.getDirectives().size());
       responder.sendJson(recipe);
     });

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceHandler.java
@@ -117,9 +117,6 @@ public class WorkspaceHandler extends AbstractDirectiveHandler {
   @SuppressWarnings("unused")
   private Metrics metrics;
 
-  private static final String APPLY_RECIPE_SUCCESS_METRIC = "recipe.apply.success";
-  private static final String APPLY_RECIPE_FAILURE_METRIC = "recipe.apply.failure";
-
   @Override
   public void initialize(SystemHttpServiceContext context) throws Exception {
     super.initialize(context);
@@ -441,15 +438,8 @@ public class WorkspaceHandler extends AbstractDirectiveHandler {
       RecipeId recipeId = RecipeId.builder(ns).setRecipeId(recipeIdString).build();
       Recipe recipe = recipeStore.getRecipeById(recipeId);
 
-      DirectiveExecutionResponse response;
-      try {
-        response = execute(ns, request, new WorkspaceId(ns, workspaceId),
-                                                      recipe.getDirectives());
-      } catch (Throwable t) {
-        metrics.count(APPLY_RECIPE_FAILURE_METRIC, 1);
-        throw t;
-      }
-      metrics.count(APPLY_RECIPE_SUCCESS_METRIC, 1);
+      DirectiveExecutionResponse response = execute(ns, request, new WorkspaceId(ns, workspaceId),
+                                                    recipe.getDirectives());
       responder.sendJson(response);
     });
   }


### PR DESCRIPTION
- Removing API metrics since CDAP captures all HTTP api calls by default.
- Only metric we are pushing right now is Number of directives saved per recipe.