### PR TITLE
Add metrics for directives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.5.0</version>
           <extensions>true</extensions>
           <configuration>
             <instructions>

--- a/wrangler-api/pom.xml
+++ b/wrangler-api/pom.xml
@@ -24,7 +24,7 @@
 
   <artifactId>wrangler-api</artifactId>
   <name>Wrangler API</name>
-  <description>Wrangler API Libaray.</description>
+  <description>Wrangler API Library.</description>
 
   <dependencies>
     <dependency>
@@ -36,6 +36,12 @@
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
+      <version>${cdap.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-watchdog-api</artifactId>
       <version>${cdap.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityMetricDef.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityMetricDef.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api;
+
+import io.cdap.cdap.api.metrics.MetricType;
+
+import java.util.Map;
+
+/**
+ * Represents generic metadata information for a metric that is emitted in Wrangler
+ */
+public class EntityMetricDef {
+  private final String name;
+  private final Map<String, String> tags;
+  private final MetricType type;
+  private final long value;
+
+  public EntityMetricDef(String name, Map<String, String> tags, MetricType type, long value) {
+    this.name = name;
+    this.tags = tags;
+    this.type = type;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Map<String, String> getTags() {
+    return tags;
+  }
+
+  public MetricType getType() {
+    return type;
+  }
+
+  public long getValue() {
+    return value;
+  }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityMetrics.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityMetrics.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api;
+
+import java.util.List;
+
+/**
+ * Metrics emitted by a Wrangler entity
+ */
+public interface EntityMetrics {
+  /**
+   * This method can be used to return a list of metrics to be emitted by a Wrangler entity (ex: {@link Directive}).
+   * Note that this method doesn't emit metrics, it only returns metadata to be used in metrics emission logic elsewhere
+   * @return list of {@link EntityMetricDef}s to be emitted
+   */
+  List<EntityMetricDef> getMetrics();
+}

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -58,6 +58,11 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${cdap.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api</artifactId>
       <version>${cdap.version}</version>
       <scope>provided</scope>

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/IncrementTransientVariable.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/IncrementTransientVariable.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.aggregates;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.TransientVariableScope;
@@ -36,6 +38,7 @@ import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
+import io.cdap.wrangler.metrics.DirectiveJEXLCategoryMetric;
 
 import java.util.List;
 
@@ -47,7 +50,7 @@ import java.util.List;
 @Name(IncrementTransientVariable.NAME)
 @Categories(categories = { "transient"})
 @Description("Wrangler - A interactive tool for data cleansing and transformation.")
-public class IncrementTransientVariable implements Directive {
+public class IncrementTransientVariable implements Directive, DirectiveJEXLCategoryMetric {
   public static final String NAME = "increment-variable";
   private String variable;
   private long incrementBy;
@@ -107,5 +110,11 @@ public class IncrementTransientVariable implements Directive {
 
   public void destroy() {
     // no-op
+  }
+
+  @Override
+  public List<EntityMetricDef> getMetrics() {
+    EntityMetricDef jexlCategoryMetric = getJEXLCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? ImmutableList.of() : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.aggregates;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.TransientVariableScope;
@@ -35,6 +37,7 @@ import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
+import io.cdap.wrangler.metrics.DirectiveJEXLCategoryMetric;
 
 import java.util.List;
 
@@ -48,7 +51,7 @@ import java.util.List;
 @Name(SetTransientVariable.NAME)
 @Categories(categories = { "transient"})
 @Description("Sets the value for a transient variable for the record being processed.")
-public class SetTransientVariable implements Directive {
+public class SetTransientVariable implements Directive, DirectiveJEXLCategoryMetric {
   public static final String NAME = "set-variable";
   private EL el;
   private String variable;
@@ -95,5 +98,11 @@ public class SetTransientVariable implements Directive {
       }
     }
     return rows;
+  }
+
+  @Override
+  public List<EntityMetricDef> getMetrics() {
+    EntityMetricDef jexlCategoryMetric = getJEXLCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? ImmutableList.of() : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.row;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.annotations.Categories;
@@ -35,6 +37,7 @@ import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
+import io.cdap.wrangler.metrics.DirectiveJEXLCategoryMetric;
 
 import java.util.List;
 
@@ -45,7 +48,7 @@ import java.util.List;
 @Name(Fail.NAME)
 @Categories(categories = { "row", "data-quality"})
 @Description("Fails when the condition is evaluated to true.")
-public class Fail implements Directive, Lineage {
+public class Fail implements Directive, Lineage, DirectiveJEXLCategoryMetric {
   public static final String NAME = "fail";
   private String condition;
   private EL el;
@@ -105,5 +108,11 @@ public class Fail implements Directive, Lineage {
                                  .readable(String.format("Pipeline set to fail based on condition '%s'", condition));
     el.variables().forEach(col -> builder.relation(col, col));
     return builder.build();
+  }
+
+  @Override
+  public List<EntityMetricDef> getMetrics() {
+    EntityMetricDef jexlCategoryMetric = getJEXLCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? ImmutableList.of() : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.row;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.Row;
@@ -36,6 +38,7 @@ import io.cdap.wrangler.api.parser.UsageDefinition;
 import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
+import io.cdap.wrangler.metrics.DirectiveJEXLCategoryMetric;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +56,7 @@ import java.util.List;
 @Name(RecordConditionFilter.NAME)
 @Categories(categories = { "row", "data-quality"})
 @Description("Filters rows based on condition type specified.")
-public class RecordConditionFilter implements Directive, Lineage {
+public class RecordConditionFilter implements Directive, Lineage, DirectiveJEXLCategoryMetric {
   public static final String NAME = "filter-row";
   private EL el;
   private boolean isTrue;
@@ -118,5 +121,11 @@ public class RecordConditionFilter implements Directive, Lineage {
       .readable("Filtered records based on columns '%s'", el.variables());
     el.variables().forEach(column -> builder.relation(column, column));
     return builder.build();
+  }
+
+  @Override
+  public List<EntityMetricDef> getMetrics() {
+    EntityMetricDef jexlCategoryMetric = getJEXLCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? ImmutableList.of() : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.row;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityMetricDef;
 import io.cdap.wrangler.api.ErrorRowException;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
@@ -39,6 +41,7 @@ import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
+import io.cdap.wrangler.metrics.DirectiveJEXLCategoryMetric;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +59,7 @@ import java.util.List;
 @Name(SendToError.NAME)
 @Categories(categories = { "row", "data-quality"})
 @Description("Send records that match condition to the error collector.")
-public class SendToError implements Directive, Lineage {
+public class SendToError implements Directive, Lineage, DirectiveJEXLCategoryMetric {
   public static final String NAME = "send-to-error";
   private EL el;
   private String condition;
@@ -137,5 +140,11 @@ public class SendToError implements Directive, Lineage {
       .readable("Redirecting records to error path based on expression '%s'", condition);
     el.variables().forEach(column -> builder.relation(column, column));
     return builder.build();
+  }
+
+  @Override
+  public List<EntityMetricDef> getMetrics() {
+    EntityMetricDef jexlCategoryMetric = getJEXLCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? ImmutableList.of() : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SendToErrorAndContinue.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SendToErrorAndContinue.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.row;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.ReportErrorAndProceed;
@@ -40,6 +42,7 @@ import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
+import io.cdap.wrangler.metrics.DirectiveJEXLCategoryMetric;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +60,7 @@ import java.util.List;
 @Name(SendToErrorAndContinue.NAME)
 @Categories(categories = { "row", "data-quality"})
 @Description("Send records that match condition to the error collector and continues processing.")
-public class SendToErrorAndContinue implements Directive, Lineage {
+public class SendToErrorAndContinue implements Directive, Lineage, DirectiveJEXLCategoryMetric {
   public static final String NAME = "send-to-error-and-continue";
   private EL el;
   private String condition;
@@ -136,5 +139,11 @@ public class SendToErrorAndContinue implements Directive, Lineage {
       .readable("Redirect records to error path based on expression'%s'", condition);
     el.variables().forEach(column -> builder.relation(column, column));
     return builder.build();
+  }
+
+  @Override
+  public List<EntityMetricDef> getMetrics() {
+    EntityMetricDef jexlCategoryMetric = getJEXLCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? ImmutableList.of() : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.transformation;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.annotations.Categories;
@@ -37,6 +39,7 @@ import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
+import io.cdap.wrangler.metrics.DirectiveJEXLCategoryMetric;
 
 import java.util.List;
 
@@ -56,7 +59,7 @@ import java.util.List;
 @Name(ColumnExpression.NAME)
 @Categories(categories = { "transform"})
 @Description("Sets a column by evaluating a JEXL expression.")
-public class ColumnExpression implements Directive, Lineage {
+public class ColumnExpression implements Directive, DirectiveJEXLCategoryMetric, Lineage {
   public static final String NAME = "set-column";
   // Column to which the result of experience is applied to.
   private String column;
@@ -123,6 +126,10 @@ public class ColumnExpression implements Directive, Lineage {
     });
     return builder.build();
   }
+
+  @Override
+  public List<EntityMetricDef> getMetrics() {
+    EntityMetricDef jexlCategoryMetric = getJEXLCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? ImmutableList.of() : ImmutableList.of(jexlCategoryMetric);
+  }
 }
-
-

--- a/wrangler-core/src/main/java/io/cdap/wrangler/expression/EL.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/expression/EL.java
@@ -123,6 +123,10 @@ public final class EL {
     return variables;
   }
 
+  public String getScriptParsedText() {
+    return script.getParsedText();
+  }
+
   public ELResult execute(ELContext context) throws ELException {
     try {
       // Null the missing fields

--- a/wrangler-core/src/main/java/io/cdap/wrangler/metrics/DirectiveJEXLCategoryMetric.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/metrics/DirectiveJEXLCategoryMetric.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import io.cdap.wrangler.api.EntityMetricDef;
+import io.cdap.wrangler.api.EntityMetrics;
+import io.cdap.wrangler.expression.EL;
+
+import java.util.Map;
+
+import static io.cdap.cdap.api.metrics.MetricType.COUNTER;
+import static io.cdap.cdap.common.conf.Constants.Metrics.Tag.APP_ENTITY_TYPE;
+import static io.cdap.cdap.common.conf.Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME;
+import static io.cdap.cdap.common.conf.Constants.Metrics.Tag.SERVICE;
+
+/**
+ * Represents a directive that emits the 'JEXL category' metric. This metric counts the number of times
+ * a JEXL function category in {@link io.cdap.wrangler.expression.EL.DefaultFunctions} is used.
+ */
+public interface DirectiveJEXLCategoryMetric extends EntityMetrics {
+  String JEXL_CATEGORY_METRIC_NAME = "wrangler.jexl-category.count";
+  int JEXL_CATEGORY_METRIC_COUNT = 1;
+  String JEXL_CATEGORY_ENTITY_NAME = "jexl-category";
+  String APPLICATION_NAME = "dataprep";
+  Map<?, ?> EL_DEFAULT_FUNCTIONS = new EL.DefaultFunctions().functions();
+
+  /**
+   * This method parses the JEXL function category from the given JEXL script and returns the metric if the category is
+   * present in {@link io.cdap.wrangler.expression.EL.DefaultFunctions}
+   *
+   * @param jexlScript the JEXL script from which the JEXL function category will be parsed
+   * @return {@link EntityMetricDef} with the metric name and necessary tags representing a JEXL category metric
+   */
+  default EntityMetricDef getJEXLCategoryMetric(String jexlScript) {
+    String jexlCategory = jexlScript.split(":")[0].trim();
+    if (EL_DEFAULT_FUNCTIONS.containsKey(jexlCategory)) {
+      return new EntityMetricDef(
+        JEXL_CATEGORY_METRIC_NAME, ImmutableMap.of(SERVICE, APPLICATION_NAME,
+                                                   APP_ENTITY_TYPE, JEXL_CATEGORY_ENTITY_NAME,
+                                                   APP_ENTITY_TYPE_NAME, jexlCategory),
+        COUNTER, JEXL_CATEGORY_METRIC_COUNT);
+    }
+    return null;
+  }
+}

--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -249,7 +249,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.5.0</version>
           <extensions>true</extensions>
           <configuration>
             <archive>
@@ -286,7 +286,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.5.0</version>
       </plugin>
     </plugins>
 

--- a/wrangler-transform/pom.xml
+++ b/wrangler-transform/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.5.0</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>


### PR DESCRIPTION
The following new metrics are collected per pipeline run to help improve Wrangler directives:
- Number of times a directive is used
- Number of times a JEXL function category is used

## Changes
- Add utility classes and a new interface to simplify emitting metrics from Wrangler directives
- Add functions to emit metrics from the prepareRun method in Wrangler plugin class