### PR TITLE
[CDAP-20566] Add directive metrics 

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/Directive.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/Directive.java
@@ -51,7 +51,7 @@ import java.util.List;
  *   }
  * </code>
  */
-public interface Directive extends Executor<List<Row>, List<Row>> {
+public interface Directive extends Executor<List<Row>, List<Row>>, EntityMetrics {
   /**
    * This defines a interface variable that is static and final for specify
    * the {@code type} of the plugin this interface would provide.
@@ -115,4 +115,15 @@ public interface Directive extends Executor<List<Row>, List<Row>> {
    * @see io.cdap.wrangler.api.parser.TokenType
    */
   UsageDefinition define();
+
+  /**
+   * This method provides a way to emit metrics from the Directive. Metadata about each metric to be emitted can be
+   * returned and used in the metrics emission logic elsewhere.
+   * @return List of metrics ({@link EntityCountMetricDef}s) emitted by this directive
+   */
+  @Override
+  default List<EntityCountMetricDef> getCountMetrics() {
+    // no op
+    return null;
+  }
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/Directive.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/Directive.java
@@ -119,10 +119,10 @@ public interface Directive extends Executor<List<Row>, List<Row>>, EntityMetrics
   /**
    * This method provides a way to emit metrics from the Directive. Metadata about each metric to be emitted can be
    * returned and used in the metrics emission logic elsewhere.
-   * @return List of metrics ({@link EntityCountMetricDef}s) emitted by this directive
+   * @return List of metrics ({@link EntityCountMetric}s) emitted by this directive
    */
   @Override
-  default List<EntityCountMetricDef> getCountMetrics() {
+  default List<EntityCountMetric> getCountMetrics() {
     // no op
     return null;
   }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityCountMetric.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityCountMetric.java
@@ -20,7 +20,7 @@ package io.cdap.wrangler.api;
  * Represents generic metadata information for a count metric that is emitted in Wrangler. The entity's type and name
  * will be automatically mapped to corresponding metric tags.
  */
-public class EntityCountMetricDef {
+public class EntityCountMetric {
   /**
    * Metric name
    */
@@ -38,7 +38,7 @@ public class EntityCountMetricDef {
    */
   private final String appEntityTypeName;
 
-  public EntityCountMetricDef(String name, String appEntityType, String appEntityTypeName, long count) {
+  public EntityCountMetric(String name, String appEntityType, String appEntityTypeName, long count) {
     this.name = name;
     this.appEntityType = appEntityType;
     this.appEntityTypeName = appEntityTypeName;

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityCountMetricDef.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityCountMetricDef.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api;
+
+/**
+ * Represents generic metadata information for a count metric that is emitted in Wrangler. The entity's type and name
+ * will be automatically mapped to corresponding metric tags.
+ */
+public class EntityCountMetricDef {
+  /**
+   * Metric name
+   */
+  private final String name;
+  /**
+   * Value by which to increment the count
+   */
+  private final long count;
+  /**
+   * System app entity type
+   */
+  private final String appEntityType;
+  /**
+   * System app entity type name
+   */
+  private final String appEntityTypeName;
+
+  public EntityCountMetricDef(String name, String appEntityType, String appEntityTypeName, long count) {
+    this.name = name;
+    this.appEntityType = appEntityType;
+    this.appEntityTypeName = appEntityTypeName;
+    this.count = count;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getAppEntityType() {
+    return appEntityType;
+  }
+
+  public String getAppEntityTypeName() {
+    return appEntityTypeName;
+  }
+
+  public long getCount() {
+    return count;
+  }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityMetrics.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityMetrics.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api;
+
+import java.util.List;
+
+/**
+ * Metrics emitted by a Wrangler entity
+ */
+public interface EntityMetrics {
+  /**
+   * This method is used to return a list of count metrics to be emitted by a Wrangler entity (ex: {@link Directive}).
+   * Note that this method doesn't emit metrics, it only returns metadata to be used in metrics emission logic elsewhere
+   * @return list of {@link EntityCountMetricDef}s to be emitted
+   */
+  List<EntityCountMetricDef> getCountMetrics();
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityMetrics.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/EntityMetrics.java
@@ -25,7 +25,7 @@ public interface EntityMetrics {
   /**
    * This method is used to return a list of count metrics to be emitted by a Wrangler entity (ex: {@link Directive}).
    * Note that this method doesn't emit metrics, it only returns metadata to be used in metrics emission logic elsewhere
-   * @return list of {@link EntityCountMetricDef}s to be emitted
+   * @return list of {@link EntityCountMetric}s to be emitted
    */
-  List<EntityCountMetricDef> getCountMetrics();
+  List<EntityCountMetric> getCountMetrics();
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/IncrementTransientVariable.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/IncrementTransientVariable.java
@@ -24,7 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.TransientVariableScope;
@@ -112,8 +112,8 @@ public class IncrementTransientVariable implements Directive {
     // no-op
   }
 
-  public List<EntityCountMetricDef> getCountMetrics() {
-    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+  public List<EntityCountMetric> getCountMetrics() {
+    EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/IncrementTransientVariable.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/IncrementTransientVariable.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.aggregates;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.TransientVariableScope;
@@ -39,6 +41,7 @@ import io.cdap.wrangler.expression.ELResult;
 
 import java.util.List;
 
+import static io.cdap.wrangler.metrics.JexlCategoryMetricUtils.getJexlCategoryMetric;
 
 /**
  * A directive for incrementing the a transient variable based on conditions.
@@ -107,5 +110,10 @@ public class IncrementTransientVariable implements Directive {
 
   public void destroy() {
     // no-op
+  }
+
+  public List<EntityCountMetricDef> getCountMetrics() {
+    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.aggregates;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.TransientVariableScope;
@@ -37,6 +39,8 @@ import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
 
 import java.util.List;
+
+import static io.cdap.wrangler.metrics.JexlCategoryMetricUtils.getJexlCategoryMetric;
 
 /**
  * A directive that defines a transient variable who's life-expectancy is only within the record.
@@ -95,5 +99,11 @@ public class SetTransientVariable implements Directive {
       }
     }
     return rows;
+  }
+
+  @Override
+  public List<EntityCountMetricDef> getCountMetrics() {
+    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
@@ -24,7 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.TransientVariableScope;
@@ -102,8 +102,8 @@ public class SetTransientVariable implements Directive {
   }
 
   @Override
-  public List<EntityCountMetricDef> getCountMetrics() {
-    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+  public List<EntityCountMetric> getCountMetrics() {
+    EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
@@ -24,7 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.annotations.Categories;
@@ -112,8 +112,8 @@ public class Fail implements Directive, Lineage {
   }
 
   @Override
-  public List<EntityCountMetricDef> getCountMetrics() {
-    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+  public List<EntityCountMetric> getCountMetrics() {
+    EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.row;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.annotations.Categories;
@@ -37,6 +39,8 @@ import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
 
 import java.util.List;
+
+import static io.cdap.wrangler.metrics.JexlCategoryMetricUtils.getJexlCategoryMetric;
 
 /**
  * A directive for erroring the processing if condition is set to true.
@@ -105,5 +109,11 @@ public class Fail implements Directive, Lineage {
                                  .readable(String.format("Pipeline set to fail based on condition '%s'", condition));
     el.variables().forEach(col -> builder.relation(col, col));
     return builder.build();
+  }
+
+  @Override
+  public List<EntityCountMetricDef> getCountMetrics() {
+    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.row;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.Row;
@@ -39,6 +41,8 @@ import io.cdap.wrangler.expression.ELException;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static io.cdap.wrangler.metrics.JexlCategoryMetricUtils.getJexlCategoryMetric;
 
 /**
  * A Wrangle step for filtering rows based on the condition.
@@ -118,5 +122,11 @@ public class RecordConditionFilter implements Directive, Lineage {
       .readable("Filtered records based on columns '%s'", el.variables());
     el.variables().forEach(column -> builder.relation(column, column));
     return builder.build();
+  }
+
+  @Override
+  public List<EntityCountMetricDef> getCountMetrics() {
+    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
@@ -24,7 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.Row;
@@ -125,8 +125,8 @@ public class RecordConditionFilter implements Directive, Lineage {
   }
 
   @Override
-  public List<EntityCountMetricDef> getCountMetrics() {
-    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+  public List<EntityCountMetric> getCountMetrics() {
+    EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
@@ -24,7 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ErrorRowException;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
@@ -144,8 +144,8 @@ public class SendToError implements Directive, Lineage {
   }
 
   @Override
-  public List<EntityCountMetricDef> getCountMetrics() {
-    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+  public List<EntityCountMetric> getCountMetrics() {
+    EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SendToError.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.row;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetricDef;
 import io.cdap.wrangler.api.ErrorRowException;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
@@ -42,6 +44,8 @@ import io.cdap.wrangler.expression.ELResult;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static io.cdap.wrangler.metrics.JexlCategoryMetricUtils.getJexlCategoryMetric;
 
 /**
  * A directive for erroring the record if
@@ -137,5 +141,11 @@ public class SendToError implements Directive, Lineage {
       .readable("Redirecting records to error path based on expression '%s'", condition);
     el.variables().forEach(column -> builder.relation(column, column));
     return builder.build();
+  }
+
+  @Override
+  public List<EntityCountMetricDef> getCountMetrics() {
+    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SendToErrorAndContinue.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SendToErrorAndContinue.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.row;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.ReportErrorAndProceed;
@@ -43,6 +45,8 @@ import io.cdap.wrangler.expression.ELResult;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static io.cdap.wrangler.metrics.JexlCategoryMetricUtils.getJexlCategoryMetric;
 
 /**
  * A directive for erroring the record if
@@ -136,5 +140,11 @@ public class SendToErrorAndContinue implements Directive, Lineage {
       .readable("Redirect records to error path based on expression'%s'", condition);
     el.variables().forEach(column -> builder.relation(column, column));
     return builder.build();
+  }
+
+  @Override
+  public List<EntityCountMetricDef> getCountMetrics() {
+    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SendToErrorAndContinue.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SendToErrorAndContinue.java
@@ -24,7 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.ReportErrorAndProceed;
@@ -143,8 +143,8 @@ public class SendToErrorAndContinue implements Directive, Lineage {
   }
 
   @Override
-  public List<EntityCountMetricDef> getCountMetrics() {
-    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+  public List<EntityCountMetric> getCountMetrics() {
+    EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
@@ -24,7 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.annotations.Categories;
@@ -129,8 +129,8 @@ public class ColumnExpression implements Directive, Lineage {
   }
 
   @Override
-  public List<EntityCountMetricDef> getCountMetrics() {
-    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+  public List<EntityCountMetric> getCountMetrics() {
+    EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.transformation;
 
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -23,6 +24,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.annotations.Categories;
@@ -39,6 +41,8 @@ import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
 
 import java.util.List;
+
+import static io.cdap.wrangler.metrics.JexlCategoryMetricUtils.getJexlCategoryMetric;
 
 /**
  * A directive for apply an expression to store the result in a column.
@@ -123,6 +127,10 @@ public class ColumnExpression implements Directive, Lineage {
     });
     return builder.build();
   }
+
+  @Override
+  public List<EntityCountMetricDef> getCountMetrics() {
+    EntityCountMetricDef jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
+    return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
+  }
 }
-
-

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/MessageHash.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/MessageHash.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.transformation;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
@@ -24,6 +25,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetricDef;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.Row;
@@ -102,6 +104,9 @@ public class MessageHash implements Directive, Lineage {
     "TIGER",
     "WHIRLPOOL"
   );
+  private static final String HASH_ALGORITHM_METRIC_NAME = "wrangler.hash-algo.count";
+  private static final int HASH_ALGORITHM_COUNT = 1;
+  private static final String HASH_ALGORITHM_ENTITY_NAME = "directive-hash-algo";
   private String column;
   private boolean encode;
   private MessageDigest digest;
@@ -193,5 +198,11 @@ public class MessageHash implements Directive, Lineage {
     }
     return rows;
   }
-}
 
+  @Override
+  public List<EntityCountMetricDef> getCountMetrics() {
+    return ImmutableList.of(
+      new EntityCountMetricDef(HASH_ALGORITHM_METRIC_NAME, HASH_ALGORITHM_ENTITY_NAME,
+                               digest.getAlgorithm(), HASH_ALGORITHM_COUNT));
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/MessageHash.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/MessageHash.java
@@ -25,7 +25,7 @@ import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.Row;
@@ -200,9 +200,9 @@ public class MessageHash implements Directive, Lineage {
   }
 
   @Override
-  public List<EntityCountMetricDef> getCountMetrics() {
+  public List<EntityCountMetric> getCountMetrics() {
     return ImmutableList.of(
-      new EntityCountMetricDef(HASH_ALGORITHM_METRIC_NAME, HASH_ALGORITHM_ENTITY_NAME,
+      new EntityCountMetric(HASH_ALGORITHM_METRIC_NAME, HASH_ALGORITHM_ENTITY_NAME,
                                digest.getAlgorithm(), HASH_ALGORITHM_COUNT));
   }
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/expression/EL.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/expression/EL.java
@@ -123,6 +123,10 @@ public final class EL {
     return variables;
   }
 
+  public String getScriptParsedText() {
+    return script.getParsedText();
+  }
+
   public ELResult execute(ELContext context) throws ELException {
     try {
       // Null the missing fields

--- a/wrangler-core/src/main/java/io/cdap/wrangler/metrics/Constants.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/metrics/Constants.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.metrics;
+
+/**
+ * Constants for emitting CDAP metrics from Wrangler
+ */
+public class Constants {
+  /**
+   * Metric tags (same as those defined in CDAP)
+   */
+  public static final class Tags {
+    public static final String APP_ENTITY_TYPE = "aet";
+    public static final String APP_ENTITY_TYPE_NAME = "tpe";
+  }
+
+  private Constants() {
+    throw new AssertionError("Cannot instantiate a static utility class.");
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/metrics/JexlCategoryMetricUtils.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/metrics/JexlCategoryMetricUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.metrics;
+
+import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.expression.EL;
+import org.apache.commons.jexl3.parser.ParserTokenManager;
+import org.apache.commons.jexl3.parser.SimpleCharStream;
+
+import java.io.ByteArrayInputStream;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+/**
+ * Utility class for the 'JEXL category' metric. This metric counts the number of times a JEXL function category
+ * in {@link io.cdap.wrangler.expression.EL.DefaultFunctions} is used.
+ */
+public final class JexlCategoryMetricUtils {
+  private static final Map<?, ?> EL_DEFAULT_FUNCTIONS = new EL.DefaultFunctions().functions();
+
+  // JEXL Metric constants
+  public static final String JEXL_CATEGORY_METRIC_NAME = "wrangler.jexl-category.count";
+  public static final int JEXL_CATEGORY_METRIC_COUNT = 1;
+  public  static final String JEXL_CATEGORY_ENTITY_TYPE = "jexl-category";
+
+  /**
+   * This method parses the JEXL function category from the given JEXL script and returns the metric if the category is
+   * present in {@link io.cdap.wrangler.expression.EL.DefaultFunctions}
+   *
+   * @param jexlScript the JEXL script from which the JEXL function category will be parsed
+   * @return {@link EntityCountMetricDef} with the metric name and necessary tags representing a JEXL category metric
+   */
+  @Nullable
+  public static EntityCountMetricDef getJexlCategoryMetric(String jexlScript) {
+    String category = parseJexlCategory(jexlScript);
+    if (EL_DEFAULT_FUNCTIONS.containsKey(category)) {
+      return new EntityCountMetricDef(
+        JEXL_CATEGORY_METRIC_NAME, JEXL_CATEGORY_ENTITY_TYPE, category, JEXL_CATEGORY_METRIC_COUNT);
+    }
+    return null;
+  }
+
+  private static String parseJexlCategory(String script) {
+    ParserTokenManager manager = new ParserTokenManager(
+      new SimpleCharStream(new ByteArrayInputStream(script.getBytes())));
+    return manager.getNextToken().toString();
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/metrics/JexlCategoryMetricUtils.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/metrics/JexlCategoryMetricUtils.java
@@ -16,7 +16,7 @@
 
 package io.cdap.wrangler.metrics;
 
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.expression.EL;
 import org.apache.commons.jexl3.parser.ParserTokenManager;
 import org.apache.commons.jexl3.parser.SimpleCharStream;
@@ -43,13 +43,13 @@ public final class JexlCategoryMetricUtils {
    * present in {@link io.cdap.wrangler.expression.EL.DefaultFunctions}
    *
    * @param jexlScript the JEXL script from which the JEXL function category will be parsed
-   * @return {@link EntityCountMetricDef} with the metric name and necessary tags representing a JEXL category metric
+   * @return {@link EntityCountMetric} with the metric name and necessary tags representing a JEXL category metric
    */
   @Nullable
-  public static EntityCountMetricDef getJexlCategoryMetric(String jexlScript) {
+  public static EntityCountMetric getJexlCategoryMetric(String jexlScript) {
     String category = parseJexlCategory(jexlScript);
     if (EL_DEFAULT_FUNCTIONS.containsKey(category)) {
-      return new EntityCountMetricDef(
+      return new EntityCountMetric(
         JEXL_CATEGORY_METRIC_NAME, JEXL_CATEGORY_ENTITY_TYPE, category, JEXL_CATEGORY_METRIC_COUNT);
     }
     return null;

--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -595,20 +595,23 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
    */
   private void emitDirectiveMetrics(List<Directive> directives, Metrics metrics) throws DirectiveLoadException {
     for (Directive directive : directives) {
-      List<EntityCountMetric> metricDefs = new ArrayList<>();
-
-      // Emit directive usage metric only if directive is present in system directive registry
+      // skip emitting metrics if the directive is not system metric
       if (registry.get(Contexts.SYSTEM, directive.define().getDirectiveName()) != null) {
-        metricDefs.add(getDirectiveUsageMetric(directive.define().getDirectiveName()));
+        continue;
       }
+      List<EntityCountMetric> countMetrics = new ArrayList<>();
 
+      // add usage metric
+      countMetrics.add(getDirectiveUsageMetric(directive.define().getDirectiveName()));
+
+      // add custom directive metrics
       if (directive.getCountMetrics() != null) {
-        metricDefs.addAll(directive.getCountMetrics());
+        countMetrics.addAll(directive.getCountMetrics());
       }
 
-      for (EntityCountMetric metricDef : metricDefs) {
-        Metrics child = metrics.child(getEntityMetricTags(metricDef));
-        child.countLong(metricDef.getName(), metricDef.getCount());
+      for (EntityCountMetric countMetric : countMetrics) {
+        Metrics child = metrics.child(getEntityMetricTags(countMetric));
+        child.countLong(countMetric.getName(), countMetric.getCount());
       }
     }
   }

--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -49,7 +49,7 @@ import io.cdap.wrangler.api.Compiler;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveLoadException;
 import io.cdap.wrangler.api.DirectiveParseException;
-import io.cdap.wrangler.api.EntityCountMetricDef;
+import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ErrorRecord;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.RecipeParser;
@@ -595,7 +595,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
    */
   private void emitDirectiveMetrics(List<Directive> directives, Metrics metrics) throws DirectiveLoadException {
     for (Directive directive : directives) {
-      List<EntityCountMetricDef> metricDefs = new ArrayList<>();
+      List<EntityCountMetric> metricDefs = new ArrayList<>();
 
       // Emit directive usage metric only if directive is present in system directive registry
       if (registry.get(Contexts.SYSTEM, directive.define().getDirectiveName()) != null) {
@@ -606,19 +606,19 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
         metricDefs.addAll(directive.getCountMetrics());
       }
 
-      for (EntityCountMetricDef metricDef : metricDefs) {
+      for (EntityCountMetric metricDef : metricDefs) {
         Metrics child = metrics.child(getEntityMetricTags(metricDef));
         child.countLong(metricDef.getName(), metricDef.getCount());
       }
     }
   }
 
-  private EntityCountMetricDef getDirectiveUsageMetric(String directiveName) {
-    return new EntityCountMetricDef(
+  private EntityCountMetric getDirectiveUsageMetric(String directiveName) {
+    return new EntityCountMetric(
       DIRECTIVE_METRIC_NAME, DIRECTIVE_ENTITY_TYPE, directiveName, DIRECTIVE_METRIC_COUNT);
   }
 
-  private Map<String, String> getEntityMetricTags(EntityCountMetricDef metricDef) {
+  private Map<String, String> getEntityMetricTags(EntityCountMetric metricDef) {
     Map<String, String> tags = new HashMap<>();
     tags.put(APP_ENTITY_TYPE, metricDef.getAppEntityType());
     tags.put(APP_ENTITY_TYPE_NAME, metricDef.getAppEntityTypeName());

--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.metrics.Metrics;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.etl.api.Emitter;
@@ -48,6 +49,7 @@ import io.cdap.wrangler.api.Compiler;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveLoadException;
 import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetricDef;
 import io.cdap.wrangler.api.ErrorRecord;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.RecipeParser;
@@ -63,6 +65,7 @@ import io.cdap.wrangler.parser.GrammarBasedParser;
 import io.cdap.wrangler.parser.MigrateToV2;
 import io.cdap.wrangler.parser.NoOpDirectiveContext;
 import io.cdap.wrangler.parser.RecipeCompiler;
+import io.cdap.wrangler.proto.Contexts;
 import io.cdap.wrangler.registry.CompositeDirectiveRegistry;
 import io.cdap.wrangler.registry.DirectiveInfo;
 import io.cdap.wrangler.registry.DirectiveRegistry;
@@ -73,9 +76,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -83,6 +89,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import static io.cdap.cdap.features.Feature.WRANGLER_FAIL_PIPELINE_FOR_ERROR;
+import static io.cdap.wrangler.metrics.Constants.Tags.APP_ENTITY_TYPE;
+import static io.cdap.wrangler.metrics.Constants.Tags.APP_ENTITY_TYPE_NAME;
 
 /**
  * Wrangler - A interactive tool for data cleansing and transformation.
@@ -105,6 +113,11 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
   private static final String ON_ERROR_FAIL_PIPELINE = "fail-pipeline";
   private static final String ON_ERROR_PROCEED = "send-to-error-port";
   private static final String ERROR_STRATEGY_DEFAULT = "wrangler.error.strategy.default";
+
+  // Directive usage metric
+  public static final String DIRECTIVE_METRIC_NAME = "wrangler.directive.count";
+  public static final int DIRECTIVE_METRIC_COUNT = 1;
+  public static final String DIRECTIVE_ENTITY_TYPE = "directive";
 
   // Precondition languages
   private static final String PRECONDITION_LANGUAGE_JEXL = "jexl";
@@ -306,6 +319,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
     // to be processed for extracting lineage.
     RecipeParser recipe = getRecipeParser(context);
     List<Directive> directives = recipe.parse();
+    emitDirectiveMetrics(directives, context.getMetrics());
 
     LineageOperations lineageOperations = new LineageOperations(input, output, directives);
     context.record(lineageOperations.generate());
@@ -571,6 +585,44 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
 
   private Optional<ExpressionFactory<String>> getExpressionFactory(RelationalTranformContext ctx) {
     return ctx.getEngine().getExpressionFactory(StringExpressionFactoryType.SQL);
+  }
+
+  /**
+   * This method emits all metrics for the given list of directives
+   *
+   * @param directives a list of Wrangler directives
+   * @param metrics CDAP {@link Metrics} object using which metrics can be emitted
+   */
+  private void emitDirectiveMetrics(List<Directive> directives, Metrics metrics) throws DirectiveLoadException {
+    for (Directive directive : directives) {
+      List<EntityCountMetricDef> metricDefs = new ArrayList<>();
+
+      // Emit directive usage metric only if directive is present in system directive registry
+      if (registry.get(Contexts.SYSTEM, directive.define().getDirectiveName()) != null) {
+        metricDefs.add(getDirectiveUsageMetric(directive.define().getDirectiveName()));
+      }
+
+      if (directive.getCountMetrics() != null) {
+        metricDefs.addAll(directive.getCountMetrics());
+      }
+
+      for (EntityCountMetricDef metricDef : metricDefs) {
+        Metrics child = metrics.child(getEntityMetricTags(metricDef));
+        child.countLong(metricDef.getName(), metricDef.getCount());
+      }
+    }
+  }
+
+  private EntityCountMetricDef getDirectiveUsageMetric(String directiveName) {
+    return new EntityCountMetricDef(
+      DIRECTIVE_METRIC_NAME, DIRECTIVE_ENTITY_TYPE, directiveName, DIRECTIVE_METRIC_COUNT);
+  }
+
+  private Map<String, String> getEntityMetricTags(EntityCountMetricDef metricDef) {
+    Map<String, String> tags = new HashMap<>();
+    tags.put(APP_ENTITY_TYPE, metricDef.getAppEntityType());
+    tags.put(APP_ENTITY_TYPE_NAME, metricDef.getAppEntityTypeName());
+    return tags;
   }
 
   /**


### PR DESCRIPTION
The following new metrics are collected per pipeline run to help improve Wrangler directives:

- Number of times a directive is used
- Number of times a JEXL function category is used
- Number of times a hash algorithm is used

## Changes
- Add utility classes and a new interface to simplify emitting metrics from Wrangler directives
- Add functions to emit metrics from the prepareRun method in Wrangler plugin class

Note: same as PR #614 but with cdap-common dependency issue removed [CDAP-20502]

[CDAP-20502]: https://cdap.atlassian.net/browse/CDAP-20502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ