### PR TITLE
[PLUGIN-1572][4.9] Added error message when Wrangler uses SQL filters and the wrangler stage has more than 1 inputs

### DIFF
--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -381,6 +381,15 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
    */
   @Override
   public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
+    // The Transform function should never execute if SQL filters are enabled. SQL filters are
+    // handled by the LinearRelationalTransform implementation. If this code is reached, it means
+    // the LinearRelationalTransform could not be executed correctly.
+    if (PRECONDITION_LANGUAGE_SQL.equals(config.getPreconditionLanguage())) {
+      throw new IllegalArgumentException("SQL filters are not supported with "
+          + "multiple input stages. Please ensure the Wrangler stages with SQL "
+          + "filters have only one input.");
+    }
+
     long start = 0;
     List<StructuredRecord> records;
 


### PR DESCRIPTION
Cherry Pick of https://github.com/data-integrations/wrangler/pull/627 into 4.9 (CDAP 6.9)