### PR TITLE
[WIP] Fix the null identifier issue in MigrateToV2

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/MigrateToV2.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/MigrateToV2.java
@@ -814,7 +814,7 @@ public final class MigrateToV2 implements GrammarMigrator {
   public static String getNextToken(StringTokenizer tokenizer, String delimiter,
                                     String directive, String field, int lineno, boolean optional)
     throws DirectiveParseException {
-    String value = null;
+    String value = "";
     if (tokenizer.hasMoreTokens()) {
       if (delimiter == null) {
         value = tokenizer.nextToken().trim();


### PR DESCRIPTION
In case of optional arguments to directives, when the optional argument(s) is/are not provided, the parser parses these as null identifiers (incorrectly).

This was because of a bug in the MigrateToV2 class. In Java, the value null is stringified as `"null"` instead of `""` when used in `String.format` . Therefore, when the method `getNextToken` returns `null` (this happens when we are trying to get an optional argument and there are no tokens left), and we use the `null` value in `String.format` to create the transformed / migrated directive string, we get a string with `null` substrings in it.

Example:

Consider the `set-type` directive. It expects 2 optional arguments `scale` and `rounding-mode`. When the directive `set-type :col decimal` is given, it should be transformed to `set-type :col decimal` (no change). But it incorrectly gets transformed to `set-type :col decimal null null` because of this issue.

JIRA: [CDAP-20576](https://cdap.atlassian.net/browse/CDAP-20576)

[CDAP-20576]: https://cdap.atlassian.net/browse/CDAP-20576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ