### PR TITLE
Put the precondition language selector behind a feature flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <aws.sdk.version>1.11.133</aws.sdk.version>
     <bigquery.connector.hadoop2.version>0.10.2-hadoop2</bigquery.connector.hadoop2.version>
     <bouncycastle.version>1.56</bouncycastle.version>
-    <cdap.version>6.9.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.10.0-SNAPSHOT</cdap.version>
     <chlorine.version>1.1.5</chlorine.version>
     <commons.validator.version>1.6</commons.validator.version>
     <commons-io.version>2.5</commons-io.version>

--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -42,6 +42,7 @@ import io.cdap.cdap.etl.api.relational.LinearRelationalTransform;
 import io.cdap.cdap.etl.api.relational.Relation;
 import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.cdap.etl.api.relational.StringExpressionFactoryType;
+import io.cdap.cdap.features.Feature;
 import io.cdap.directives.aggregates.DefaultTransientStore;
 import io.cdap.wrangler.api.CompileException;
 import io.cdap.wrangler.api.CompileStatus;
@@ -570,6 +571,11 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
   public Relation transform(RelationalTranformContext relationalTranformContext, Relation relation) {
     if (PRECONDITION_LANGUAGE_SQL.equalsIgnoreCase(config.getPreconditionLanguage())
             && checkPreconditionNotEmpty(true)) {
+
+      if (!Feature.WRANGLER_PRECONDITION_SQL.isEnabled(relationalTranformContext)) {
+        throw new RuntimeException("SQL Precondition feature is not available");
+      }
+
       Optional<ExpressionFactory<String>> expressionFactory = getExpressionFactory(relationalTranformContext);
       if (!expressionFactory.isPresent()) {
         return new InvalidRelation("Cannot find an Expression Factory");

--- a/wrangler-transform/widgets/Wrangler-transform.json
+++ b/wrangler-transform/widgets/Wrangler-transform.json
@@ -128,6 +128,18 @@
           "name": "preconditionSQL"
         }
       ]
+    },
+    {
+      "name": "preconditionSQLEnabled",
+      "condition": {
+        "expression": "featureFlags['wrangler.precondition.sql.enabled'] == true"
+      },
+      "show": [
+        {
+          "type": "properties",
+          "name": "preconditionLanguage"
+        }
+      ]
     }
   ],
   "outputs": [


### PR DESCRIPTION
This change puts display of the Precondition Language selector behind the feature flag `feature.wrangler.precondition.sql.enabled`.