### PR TITLE
[CDAP-20584] Reverse the condition for SQL Preconditions

### DIFF
--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -581,8 +581,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
         return new InvalidRelation("Cannot find an Expression Factory");
       }
 
-      String negatedSQL = String.format("NOT (%s)", config.getPreconditionSQL());
-      Expression filterExpression = expressionFactory.get().compile(negatedSQL);
+      Expression filterExpression = expressionFactory.get().compile(config.getPreconditionSQL());
       return relation.filter(filterExpression);
     }
 
@@ -640,7 +639,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
   public static class Config extends PluginConfig {
     static final String NAME_PRECONDITION = "precondition";
     static final String NAME_PRECONDITION_SQL = "preconditionSQL";
-    static final String NAME_PRECONDITION_LANGUAGE = "preconditionLanguage";
+    static final String NAME_PRECONDITION_LANGUAGE = "expressionLanguage";
     static final String NAME_FIELD = "field";
     static final String NAME_DIRECTIVES = "directives";
     static final String NAME_UDD = "udd";
@@ -661,7 +660,7 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
 
 
     @Name(NAME_PRECONDITION_SQL)
-    @Description("SQL Precondition expression specifying filtering before applying directives (true to filter)")
+    @Description("SQL Precondition expression specifying filtering before applying directives (false to filter)")
     @Macro
     @Nullable
     private String preconditionSQL;

--- a/wrangler-transform/widgets/Wrangler-transform.json
+++ b/wrangler-transform/widgets/Wrangler-transform.json
@@ -20,7 +20,7 @@
         },
         {
           "widget-type": "radio-group",
-          "name": "preconditionLanguage",
+          "name": "expressionLanguage",
           "label": "Precondition Language",
           "widget-attributes": {
             "layout": "inline",
@@ -108,7 +108,7 @@
     {
       "name": "PreconditionValueNotSQL",
       "condition": {
-        "expression": "preconditionLanguage != 'sql'"
+        "expression": "expressionLanguage != 'sql'"
       },
       "show": [
         {
@@ -120,7 +120,7 @@
     {
       "name": "preconditionValueSQL",
       "condition": {
-        "expression": "preconditionLanguage == 'sql'"
+        "expression": "expressionLanguage == 'sql'"
       },
       "show": [
         {
@@ -137,7 +137,7 @@
       "show": [
         {
           "type": "properties",
-          "name": "preconditionLanguage"
+          "name": "expressionLanguage"
         }
       ]
     }


### PR DESCRIPTION
This PR reverses the condition for the SQL precondition so that the SQL filter will now pass through the records for which the condition is true and filter out the others. The JEXL filters are unchanged.