### PR TITLE
Add custom schema handling logic to directives that rename columns

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetHeader.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetHeader.java
@@ -19,12 +19,14 @@ package io.cdap.directives.column;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
 import io.cdap.wrangler.api.DirectiveParseException;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.SchemaResolutionContext;
 import io.cdap.wrangler.api.annotations.Categories;
 import io.cdap.wrangler.api.lineage.Lineage;
 import io.cdap.wrangler.api.lineage.Many;
@@ -90,5 +92,18 @@ public class SetHeader implements Directive, Lineage {
       .generate(Many.of(columns))
       .build();
   }
-}
 
+  @Override
+  public Schema getOutputSchema(SchemaResolutionContext context) {
+    List<Schema.Field> inputFields = context.getInputSchema().getFields();
+    List<Schema.Field> outputFields = new ArrayList<>();
+    for (int i = 0; i < columns.size() && i < inputFields.size(); i++) {
+      outputFields.add(Schema.Field.of(columns.get(i).trim(), inputFields.get(i).getSchema()));
+    }
+    // Leftover columns (not renamed)
+    for (int i = columns.size(); i < inputFields.size(); i++) {
+      outputFields.add(inputFields.get(i));
+    }
+    return Schema.recordOf("outputSchema", outputFields);
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/column/CleanseColumnNamesTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/CleanseColumnNamesTest.java
@@ -16,12 +16,14 @@
 
 package io.cdap.directives.column;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.wrangler.TestingRig;
 import io.cdap.wrangler.api.Row;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -35,17 +37,46 @@ public class CleanseColumnNamesTest {
       "cleanse-column-names",
     };
 
-    List<Row> rows = Arrays.asList(
+    List<Row> rows = Collections.singletonList(
       new Row("COL1", "1").add("col:2", "2").add("Col3", "3").add("COLUMN4", "4").add("col!5", "5")
     );
 
     rows = TestingRig.execute(directives, rows);
 
-    Assert.assertTrue(rows.size() == 1);
+    Assert.assertEquals(1, rows.size());
     Assert.assertEquals("col1", rows.get(0).getColumn(0));
     Assert.assertEquals("col_2", rows.get(0).getColumn(1));
     Assert.assertEquals("col3", rows.get(0).getColumn(2));
     Assert.assertEquals("column4", rows.get(0).getColumn(3));
     Assert.assertEquals("col_5", rows.get(0).getColumn(4));
+  }
+
+  @Test
+  public void testGetOutputSchemaForCleansedColumns() throws Exception {
+    String[] directives = new String[] {
+      "cleanse-column-names",
+    };
+    List<Row> rows = Collections.singletonList(
+      new Row("COL1", 1).add("col:2", new BigDecimal("143235.016"))
+    );
+    Schema inputSchema = Schema.recordOf(
+      "inputSchema",
+      Schema.Field.of("COL1", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("col:2", Schema.decimalOf(10, 3))
+    );
+    Schema expectedSchema = Schema.recordOf(
+      "expectedSchema",
+      Schema.Field.of("col1", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("col_2", Schema.decimalOf(10, 3))
+    );
+
+    Schema outputSchema = TestingRig.executeAndGetSchema(directives, rows, inputSchema);
+
+    Assert.assertEquals(outputSchema.getFields().size(), expectedSchema.getFields().size());
+    for (Schema.Field expectedField : expectedSchema.getFields()) {
+      Assert.assertEquals(
+        outputSchema.getField(expectedField.getName()).getSchema().getType(), expectedField.getSchema().getType()
+      );
+    }
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/column/SetHeaderTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/SetHeaderTest.java
@@ -16,13 +16,17 @@
 
 package io.cdap.directives.column;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.wrangler.TestingRig;
 import io.cdap.wrangler.api.RecipeException;
 import io.cdap.wrangler.api.Row;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests {@link SetHeader}
@@ -34,7 +38,7 @@ public class SetHeaderTest {
     String[] directives = {
       "set-header ,A,B"
     };
-    TestingRig.execute(directives, new ArrayList<Row>());
+    TestingRig.execute(directives, new ArrayList<>());
   }
 
   @Test(expected = RecipeException.class)
@@ -42,7 +46,7 @@ public class SetHeaderTest {
     String[] directives = {
       "set-header A,B, ,D"
     };
-    TestingRig.execute(directives, new ArrayList<Row>());
+    TestingRig.execute(directives, new ArrayList<>());
   }
 
   @Test(expected = RecipeException.class)
@@ -50,7 +54,7 @@ public class SetHeaderTest {
     String[] directives = {
       "set-header A,B,D,"
     };
-    TestingRig.execute(directives, new ArrayList<Row>());
+    TestingRig.execute(directives, new ArrayList<>());
     Assert.assertTrue(true);
   }
 
@@ -59,8 +63,38 @@ public class SetHeaderTest {
     String[] directives = {
       "set-header A,B,D,,"
     };
-    TestingRig.execute(directives, new ArrayList<Row>());
+    TestingRig.execute(directives, new ArrayList<>());
     Assert.assertTrue(true);
   }
 
+  @Test
+  public void testGetOutputSchemaAfterSettingHeader() throws Exception {
+    String[] directives = new String[] {
+      "set-headers :new_A ,:new_B",
+    };
+    List<Row> rows = Collections.singletonList(
+      new Row("col_A", 1).add("col_B", new BigDecimal("123.456")).add("col_c", "hello world")
+    );
+    Schema inputSchema = Schema.recordOf(
+      "inputSchema",
+      Schema.Field.of("col_A", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("col_B", Schema.decimalOf(10, 3)),
+      Schema.Field.of("col_c", Schema.of(Schema.Type.STRING))
+    );
+    Schema expectedSchema = Schema.recordOf(
+      "expectedSchema",
+      Schema.Field.of("new_A", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("new_B", Schema.decimalOf(10, 3)),
+      Schema.Field.of("col_c", Schema.of(Schema.Type.STRING))
+    );
+
+    Schema outputSchema = TestingRig.executeAndGetSchema(directives, rows, inputSchema);
+
+    Assert.assertEquals(expectedSchema.getFields().size(), outputSchema.getFields().size());
+    for (Schema.Field expectedField : expectedSchema.getFields()) {
+      Assert.assertEquals(
+        outputSchema.getField(expectedField.getName()).getSchema().getType(), expectedField.getSchema().getType()
+      );
+    }
+  }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/transformation/SwapTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/transformation/SwapTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.directives.transformation;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.directives.column.Swap;
 import io.cdap.wrangler.TestingRig;
 import io.cdap.wrangler.api.RecipeException;
@@ -23,7 +24,8 @@ import io.cdap.wrangler.api.Row;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -37,13 +39,13 @@ public class SwapTest {
       "swap a b",
     };
 
-    List<Row> rows = Arrays.asList(
+    List<Row> rows = Collections.singletonList(
       new Row("a", 1).add("b", "sample string")
     );
 
     rows = TestingRig.execute(directives, rows);
 
-    Assert.assertTrue(rows.size() == 1);
+    Assert.assertEquals(1, rows.size());
     Assert.assertEquals(1, rows.get(0).getValue("b"));
     Assert.assertEquals("sample string", rows.get(0).getValue("a"));
   }
@@ -54,11 +56,39 @@ public class SwapTest {
       "swap a b",
     };
 
-    List<Row> rows = Arrays.asList(
+    List<Row> rows = Collections.singletonList(
       new Row("a", 1).add("c", "sample string")
     );
 
     TestingRig.execute(directives, rows);
   }
 
+  @Test
+  public void testGetOutputSchemaForSwappedColumns() throws Exception {
+    String[] directives = new String[] {
+      "swap :col_A :col_B",
+    };
+    List<Row> rows = Collections.singletonList(
+      new Row("col_A", 1).add("col_B", new BigDecimal("143235.016"))
+    );
+    Schema inputSchema = Schema.recordOf(
+      "inputSchema",
+      Schema.Field.of("col_A", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("col_B", Schema.decimalOf(10, 3))
+    );
+    Schema expectedSchema = Schema.recordOf(
+      "expectedSchema",
+      Schema.Field.of("col_B", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("col_A", Schema.decimalOf(10, 3))
+    );
+
+    Schema outputSchema = TestingRig.executeAndGetSchema(directives, rows, inputSchema);
+
+    Assert.assertEquals(outputSchema.getFields().size(), expectedSchema.getFields().size());
+    for (Schema.Field expectedField : expectedSchema.getFields()) {
+      Assert.assertEquals(
+        outputSchema.getField(expectedField.getName()).getSchema().getType(), expectedField.getSchema().getType()
+      );
+    }
+  }
 }

--- a/wrangler-core/src/test/java/io/cdap/wrangler/executor/RecipePipelineExecutorTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/executor/RecipePipelineExecutorTest.java
@@ -158,11 +158,8 @@ public class RecipePipelineExecutorTest {
     Row row = new Row();
     row.add("id", "123");
     row.add("null_col", null);
-    ExecutorContext context = new TestingPipelineContext();
-    context.getTransientStore().set(TransientVariableScope.GLOBAL, TransientStoreKeys.INPUT_SCHEMA, inputSchema);
 
-    TestingRig.execute(commands, Collections.singletonList(row), context);
-    Schema outputSchema = context.getTransientStore().get(TransientStoreKeys.OUTPUT_SCHEMA);
+    Schema outputSchema = TestingRig.executeAndGetSchema(commands, Collections.singletonList(row), inputSchema);
 
     Assert.assertEquals(expectedSchema.getField("null_col").getSchema(), outputSchema.getField("null_col").getSchema());
   }


### PR DESCRIPTION
## Changes
- Override getOutputSchema method in `rename`, `set-headers`, `swap`, `cleanse-columns` directives
- All of these perform column renames, hence the necessary column schemas are also modified to avoid generating a new schema for renamed columns