### PR TITLE
[CDAP-15361] Add feature flag for schema management

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/ExecutorContext.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/ExecutorContext.java
@@ -77,4 +77,8 @@ public interface ExecutorContext extends LookupProvider, Serializable {
    * @return A transient store.
    */
   TransientStore getTransientStore();
+
+  default boolean isSchemaManagementEnabled() {
+    return false;
+  }
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/schema/DirectiveOutputSchemaGenerator.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/schema/DirectiveOutputSchemaGenerator.java
@@ -95,7 +95,7 @@ public class DirectiveOutputSchemaGenerator {
       if (generated != null) {
         outputFields.add(Schema.Field.of(fieldName, generated));
       } else if (existing != null) {
-        if (!existing.isNullable()) {
+        if (!existing.getType().equals(Schema.Type.NULL) && !existing.isNullable()) {
           existing = Schema.nullableOf(existing);
         }
         outputFields.add(Schema.Field.of(fieldName, existing));

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/RowHelper.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/RowHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.utils;
+
+import io.cdap.wrangler.api.Row;
+
+import java.util.List;
+
+/**
+ * Utility methods for {@link Row}
+ */
+public class RowHelper {
+  private RowHelper() {
+    throw new AssertionError("Cannot instantiate a static utility class");
+  }
+
+  /**
+   * Creates a merged record after iterating through all rows.
+   *
+   * @param rows list of all rows.
+   * @return A single record will rows merged across all columns.
+   */
+  public static Row createMergedRow(List<Row> rows) {
+    Row merged = new Row();
+    for (Row row : rows) {
+      for (int i = 0; i < row.width(); ++i) {
+        Object o = row.getValue(i);
+        if (o != null) {
+          int idx = merged.find(row.getColumn(i));
+          if (idx == -1) {
+            merged.add(row.getColumn(i), o);
+          }
+        }
+      }
+    }
+    return merged;
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/TestingPipelineContext.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/TestingPipelineContext.java
@@ -16,7 +16,6 @@
 
 package io.cdap.wrangler;
 
-import io.cdap.cdap.api.metrics.Metrics;
 import io.cdap.cdap.etl.api.Lookup;
 import io.cdap.cdap.etl.api.StageMetrics;
 import io.cdap.directives.aggregates.DefaultTransientStore;
@@ -24,9 +23,9 @@ import io.cdap.wrangler.api.Executor;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.TransientStore;
 import io.cdap.wrangler.proto.Contexts;
+import org.mockito.Mockito;
 
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,42 +38,17 @@ public class TestingPipelineContext implements ExecutorContext {
   private final String name;
   private final TransientStore store;
   private final Map<String, String> properties;
+  private boolean schemaManagementEnabled;
 
   public TestingPipelineContext() {
     name = "testing";
-    properties = new HashMap<>();
     store = new DefaultTransientStore();
-    metrics = new StageMetrics() {
-      @Override
-      public void count(String s, int i) {
+    properties = new HashMap<>();
 
-      }
+    metrics = Mockito.mock(StageMetrics.class);
+    Mockito.doNothing().when(metrics).count(Mockito.anyString(), Mockito.anyInt());
 
-      @Override
-      public void gauge(String s, long l) {
-
-      }
-
-      @Override
-      public void pipelineCount(String s, int i) {
-
-      }
-
-      @Override
-      public void pipelineGauge(String s, long l) {
-
-      }
-
-      @Override
-      public Metrics child(Map<String, String> tags) {
-        return this;
-      }
-
-      @Override
-      public Map<String, String> getTags() {
-        return Collections.emptyMap();
-      }
-    };
+    schemaManagementEnabled = false;
   }
 
   /**
@@ -131,6 +105,11 @@ public class TestingPipelineContext implements ExecutorContext {
     return store;
   }
 
+  public TestingPipelineContext setSchemaManagementEnabled() {
+    this.schemaManagementEnabled = true;
+    return this;
+  }
+
   /**
    * Provides a handle to dataset for lookup.
    *
@@ -141,5 +120,10 @@ public class TestingPipelineContext implements ExecutorContext {
   @Override
   public <T> Lookup<T> provide(String s, Map<String, String> map) {
     return null;
+  }
+
+  @Override
+  public boolean isSchemaManagementEnabled() {
+    return schemaManagementEnabled;
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/wrangler/TestingRig.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/TestingRig.java
@@ -63,7 +63,7 @@ public final class TestingRig {
    */
   public static Schema executeAndGetSchema(String[] recipe, List<Row> rows, Schema inputSchema)
     throws DirectiveParseException, DirectiveLoadException, RecipeException {
-    ExecutorContext context = new TestingPipelineContext();
+    ExecutorContext context = new TestingPipelineContext().setSchemaManagementEnabled();
     context.getTransientStore().set(TransientVariableScope.GLOBAL, TransientStoreKeys.INPUT_SCHEMA, inputSchema);
     execute(recipe, rows, context);
     return context.getTransientStore().get(TransientStoreKeys.OUTPUT_SCHEMA);

--- a/wrangler-core/src/test/java/io/cdap/wrangler/executor/RecipePipelineExecutorTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/executor/RecipePipelineExecutorTest.java
@@ -18,21 +18,13 @@ package io.cdap.wrangler.executor;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.wrangler.TestingPipelineContext;
 import io.cdap.wrangler.TestingRig;
-import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.RecipePipeline;
 import io.cdap.wrangler.api.Row;
-import io.cdap.wrangler.api.TransientVariableScope;
-import io.cdap.wrangler.schema.TransientStoreKeys;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 /**
  * Tests {@link RecipePipelineExecutor}.
@@ -103,97 +95,5 @@ public class RecipePipelineExecutorTest {
     Assert.assertEquals("lperezqt@umn.edu", record.get("email"));
     Assert.assertEquals(1481666448L, record.<Long>get("timestamp").longValue());
     Assert.assertEquals(186.66f, record.get("weight"), 0.0001f);
-  }
-
-  @Test
-  public void testOutputSchemaGeneration() throws Exception {
-    String[] commands = new String[]{
-      "parse-as-csv :body ,",
-      "drop :body",
-      "set-headers :decimal_col,:name,:timestamp,:weight,:date",
-      "set-type :timestamp double",
-    };
-    Schema inputSchema = Schema.recordOf(
-      "input",
-      Schema.Field.of("body", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("decimal_col", Schema.decimalOf(10, 2))
-    );
-    Schema expectedSchema = Schema.recordOf(
-      "expected",
-      Schema.Field.of("decimal_col", Schema.nullableOf(Schema.decimalOf(10, 2))),
-      Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
-      Schema.Field.of("timestamp", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
-      Schema.Field.of("weight", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
-      Schema.Field.of("date", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
-    );
-    List<Row> inputRows = new ArrayList<>();
-    inputRows.add(new Row("body", "Larry,1481666448,01/01/2000").add("decimal_col", new BigDecimal("123.45")));
-    inputRows.add(new Row("body", "Barry,,172.3,05/01/2000").add("decimal_col", new BigDecimal("234235456.0000")));
-    ExecutorContext context = new TestingPipelineContext();
-    context.getTransientStore().set(
-      TransientVariableScope.GLOBAL, TransientStoreKeys.INPUT_SCHEMA, inputSchema);
-
-    TestingRig.execute(commands, inputRows, context);
-    Schema outputSchema = context.getTransientStore().get(TransientStoreKeys.OUTPUT_SCHEMA);
-
-    for (Schema.Field field : expectedSchema.getFields()) {
-      Assert.assertEquals(field.getName(), outputSchema.getField(field.getName()).getName());
-      Assert.assertEquals(field.getSchema(), outputSchema.getField(field.getName()).getSchema());
-    }
-  }
-
-  @Test
-  public void testOutputSchemaGeneration_doesNotDropNullColumn() throws Exception {
-    Schema inputSchema = Schema.recordOf(
-      "input",
-      Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("null_col", Schema.of(Schema.Type.STRING))
-    );
-    String[] commands = new String[]{"set-type :id int"};
-    Schema expectedSchema = Schema.recordOf(
-      "expected",
-      Schema.Field.of("id", Schema.nullableOf(Schema.of(Schema.Type.INT))),
-      Schema.Field.of("null_col", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
-    );
-    Row row = new Row();
-    row.add("id", "123");
-    row.add("null_col", null);
-
-    Schema outputSchema = TestingRig.executeAndGetSchema(commands, Collections.singletonList(row), inputSchema);
-
-    Assert.assertEquals(expectedSchema.getField("null_col").getSchema(), outputSchema.getField("null_col").getSchema());
-  }
-
-  @Test
-  public void testOutputSchemaGeneration_columnOrdering() throws Exception {
-    Schema inputSchema = Schema.recordOf(
-      "input",
-      Schema.Field.of("body", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("value", Schema.of(Schema.Type.INT))
-    );
-    String[] commands = new String[] {
-      "parse-as-json :body 1",
-      "set-type :value long"
-    };
-    List<Schema.Field> expectedFields = Arrays.asList(
-      Schema.Field.of("value", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
-      Schema.Field.of("body_A", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
-      Schema.Field.of("body_B", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
-      Schema.Field.of("body_C", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE)))
-    );
-    Row row1 = new Row().add("body", "{\"A\":1, \"B\":\"hello\"}").add("value", 10L);
-    Row row2 = new Row().add("body", "{\"C\":1.23, \"A\":1, \"B\":\"world\"}").add("value", 20L);
-    ExecutorContext context = new TestingPipelineContext();
-    context.getTransientStore().set(TransientVariableScope.GLOBAL, TransientStoreKeys.INPUT_SCHEMA, inputSchema);
-
-    TestingRig.execute(commands, Arrays.asList(row1, row2), context);
-    Schema outputSchema = context.getTransientStore().get(TransientStoreKeys.OUTPUT_SCHEMA);
-    List<Schema.Field> outputFields = outputSchema.getFields();
-
-    Assert.assertEquals(expectedFields.size(), outputFields.size());
-    for (int i = 0; i < expectedFields.size(); i++) {
-      Assert.assertEquals(expectedFields.get(i).getName(), outputFields.get(i).getName());
-      Assert.assertEquals(expectedFields.get(i).getSchema(), outputFields.get(i).getSchema());
-    }
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/wrangler/executor/SchemaGenerationTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/executor/SchemaGenerationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.executor;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.utils.RowHelper;
+import io.cdap.wrangler.utils.SchemaConverter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SchemaGenerationTest {
+  private static final SchemaConverter schemaConverter = new SchemaConverter();
+  @Test
+  public void testOutputSchemaGeneration_enabled() throws Exception {
+    String[] commands = new String[]{
+      "parse-as-csv :body ,",
+      "drop :body",
+      "set-headers :decimal_col,:all_nulls,:name,:timestamp,:weight",
+      "set-type :timestamp double",
+    };
+    Schema inputSchema = Schema.recordOf(
+      "input",
+      Schema.Field.of("body", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("decimal_col", Schema.decimalOf(10, 2)),
+      Schema.Field.of("null_col", Schema.of(Schema.Type.STRING))
+    );
+    Schema expectedSchema = Schema.recordOf(
+      "expected",
+      Schema.Field.of("decimal_col", Schema.nullableOf(Schema.decimalOf(10, 2))), // Precision and scale carried over
+      Schema.Field.of("all_nulls", Schema.nullableOf(Schema.of(Schema.Type.STRING))), // Null column not dropped
+      Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("timestamp", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+      Schema.Field.of("weight", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+    );
+    List<Row> inputRows = new ArrayList<>();
+    inputRows.add(new Row("body", "Larry,1481666448").add("decimal_col", new BigDecimal("3.5")).add("null_col", null));
+    inputRows.add(new Row("body", "Barry,,172.3").add("decimal_col", new BigDecimal("23456")).add("null_col", null));
+
+    Schema outputSchema = TestingRig.executeAndGetSchema(commands, inputRows, inputSchema);
+
+    for (Schema.Field field : expectedSchema.getFields()) {
+      Assert.assertEquals(field.getName(), outputSchema.getField(field.getName()).getName());
+      Assert.assertEquals(field.getSchema(), outputSchema.getField(field.getName()).getSchema());
+    }
+  }
+
+  @Test
+  public void testOutputSchemaGeneration_disabled() throws Exception {
+    String[] commands = new String[]{
+      "parse-as-csv :body ,",
+      "drop :body",
+      "set-headers :decimal_col,:all_nulls,:name,:timestamp,:weight",
+      "set-type :timestamp double",
+    };
+    Schema inputSchema = Schema.recordOf(
+      "input",
+      Schema.Field.of("body", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("decimal_col", Schema.decimalOf(10, 2)),
+      Schema.Field.of("null_col", Schema.of(Schema.Type.STRING))
+    );
+    Schema expectedSchema = Schema.recordOf(
+      "expected",
+      Schema.Field.of("decimal_col", Schema.nullableOf(Schema.decimalOf(38, 1))), // Default precision, scale inferred
+      // all_nulls column dropped
+      Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("timestamp", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+      Schema.Field.of("weight", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+      );
+    List<Row> inputRows = new ArrayList<>();
+    inputRows.add(new Row("body", "Larry,1481666448").add("decimal_col", new BigDecimal("3.5")).add("null_col", null));
+    inputRows.add(new Row("body", "Barry,,172.3").add("decimal_col", new BigDecimal("23456")).add("null_col", null));
+
+    List<Row> result = TestingRig.execute(commands, inputRows);
+
+    Schema outputSchema = result.isEmpty() ? null :
+      schemaConverter.toSchema("record", RowHelper.createMergedRow(result));
+
+    for (Schema.Field field : expectedSchema.getFields()) {
+      Assert.assertEquals(field.getName(), outputSchema.getField(field.getName()).getName());
+      Assert.assertEquals(field.getSchema(), outputSchema.getField(field.getName()).getSchema());
+    }
+  }
+
+  @Test
+  public void testOutputSchemaGeneration_columnOrdering() throws Exception {
+    Schema inputSchema = Schema.recordOf(
+      "input",
+      Schema.Field.of("body", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("value", Schema.of(Schema.Type.INT))
+    );
+    String[] commands = new String[] {
+      "parse-as-json :body 1",
+      "set-type :value long"
+    };
+    List<Schema.Field> expectedFields = Arrays.asList(
+      Schema.Field.of("value", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+      Schema.Field.of("body_A", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+      Schema.Field.of("body_B", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("body_C", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE)))
+    );
+    List<Row> inputRows = new ArrayList<>();
+    inputRows.add(new Row().add("body", "{\"A\":1, \"B\":\"hello\"}").add("value", 10L));
+    inputRows.add(new Row().add("body", "{\"C\":1.23, \"A\":1, \"B\":\"world\"}").add("value", 20L));
+
+    Schema outputSchema = TestingRig.executeAndGetSchema(commands, inputRows, inputSchema);
+
+    List<Schema.Field> outputFields = outputSchema.getFields();
+
+    Assert.assertEquals(expectedFields.size(), outputFields.size());
+    for (int i = 0; i < expectedFields.size(); i++) {
+      Assert.assertEquals(expectedFields.get(i).getName(), outputFields.get(i).getName());
+      Assert.assertEquals(expectedFields.get(i).getSchema(), outputFields.get(i).getSchema());
+    }
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/utils/RecordConvertorTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/utils/RecordConvertorTest.java
@@ -84,7 +84,7 @@ public class RecordConvertorTest {
     );
 
     rows = TestingRig.execute(directives, rows);
-    Row row = createUberRecord(rows);
+    Row row = RowHelper.createMergedRow(rows);
 
     SchemaConverter schemaConvertor = new SchemaConverter();
     RecordConvertor convertor = new RecordConvertor();
@@ -94,20 +94,6 @@ public class RecordConvertorTest {
 
     Assert.assertEquals(1, outputs.size());
     Assert.assertEquals(6, ((List) outputs.get(0).get("body_numbers")).size());
-  }
-
-  private static Row createUberRecord(List<Row> rows) {
-    Row uber = new Row();
-    for (Row row : rows) {
-      for (int i = 0; i < row.width(); ++i) {
-        Object o = row.getValue(i);
-        uber.addOrSet(row.getColumn(i), null);
-        if (o != null) {
-          uber.addOrSet(row.getColumn(i), o);
-        }
-      }
-    }
-    return uber;
   }
 
   @Test

--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -75,6 +75,11 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-features</artifactId>
+      <version>${cdap.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-system-app-api</artifactId>
       <version>${cdap.version}</version>
     </dependency>

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
@@ -71,6 +71,7 @@ import io.cdap.wrangler.registry.SystemDirectiveRegistry;
 import io.cdap.wrangler.registry.UserDirectiveRegistry;
 import io.cdap.wrangler.utils.ObjectSerDe;
 import io.cdap.wrangler.utils.ProjectInfo;
+import io.cdap.wrangler.utils.RowHelper;
 import io.cdap.wrangler.utils.SchemaConverter;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.slf4j.Logger;
@@ -645,7 +646,7 @@ public class DirectivesHandler extends AbstractDirectiveHandler {
 
       // generate a schema based upon the first record
       SchemaConverter schemaConvertor = new SchemaConverter();
-      Schema schema = schemaConvertor.toSchema("record", createUberRecord(rows));
+      Schema schema = schemaConvertor.toSchema("record", RowHelper.createMergedRow(rows));
       if (schema.getType() != Schema.Type.RECORD) {
         schema = Schema.recordOf("array", Schema.Field.of("value", schema));
       }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ServicePipelineContext.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/ServicePipelineContext.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.etl.api.Lookup;
 import io.cdap.cdap.etl.api.StageMetrics;
 import io.cdap.cdap.etl.common.DatasetContextLookupProvider;
 import io.cdap.cdap.etl.common.NoopMetrics;
+import io.cdap.cdap.features.Feature;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.TransientStore;
 
@@ -133,5 +134,13 @@ class ServicePipelineContext implements ExecutorContext {
   @Override
   public <T> Lookup<T> provide(String s, Map<String, String> map) {
     return lookupProvider.provide(s, map);
+  }
+
+  @Override
+  public boolean isSchemaManagementEnabled() {
+    if (systemAppTaskContext != null) {
+      return Feature.WRANGLER_SCHEMA_MANAGEMENT.isEnabled(systemAppTaskContext);
+    }
+    return Feature.WRANGLER_SCHEMA_MANAGEMENT.isEnabled(serviceContext);
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceUpgrader.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceUpgrader.java
@@ -47,6 +47,7 @@ import io.cdap.wrangler.store.upgrade.UpgradeState;
 import io.cdap.wrangler.store.upgrade.UpgradeStore;
 import io.cdap.wrangler.store.workspace.WorkspaceStore;
 import io.cdap.wrangler.utils.RecordConvertorException;
+import io.cdap.wrangler.utils.RowHelper;
 import io.cdap.wrangler.utils.SchemaConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -155,7 +156,7 @@ public class WorkspaceUpgrader {
           SchemaConverter schemaConvertor = new SchemaConverter();
           try {
             dbSchema = sample.isEmpty() ? null :
-                         schemaConvertor.toSchema("record", AbstractDirectiveHandler.createUberRecord(sample));
+                         schemaConvertor.toSchema("record", RowHelper.createMergedRow(sample));
           } catch (RecordConvertorException e) {
             LOG.warn("Unable to get the source schema for workspace {}, the generated spec will not contain schema.",
                      workspace.getName());


### PR DESCRIPTION
## Changes 
- PR in CDAP: https://github.com/cdapio/cdap/pull/15256
- `ExecutorContext` now has a new field to check whether schema handling is enabled (set as true in `ServicePipelineContext` and `TestingPipelineContext`)
- The feature flag is also checked if enabled in 
    - `AbstractDirectiveHandler` - UI display of types (execution response)
    - `WorkspaceHandler` - generating plugin output schema in specification
- If the feature flag is disabled, fallback to old schema inference logic
- Also fixes CDAP-20740
### Testing
- Moved createUberRecord from AbstractDirectiveHandler to a new RowHelper utility class to ensure the same method is used consistently (including in tests)
- Refactored existing schema tests
- Added an additional test to check output schema inference when schema management is disabled