### PR TITLE
Partially supported directives

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/directives/column/ChangeColCaseNames.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/ChangeColCaseNames.java
@@ -19,6 +19,11 @@ package io.cdap.directives.column;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.Expression;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -33,8 +38,11 @@ import io.cdap.wrangler.api.lineage.Mutation;
 import io.cdap.wrangler.api.parser.Identifier;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class <code>ChangeColCaseNames</code> converts the case of the columns
@@ -94,5 +102,29 @@ public class ChangeColCaseNames implements Directive, Lineage {
       .all(Many.of())
       .build();
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    java.util.Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    List<String> columnNames = SqlExpressionGenerator.generateListCols(relationalTranformContext);
+    Map<String, Expression> colmap = generateColumnCaseMap(columnNames, expressionFactory.get());
+    return relation.select(colmap);
+  }
+
+  private Map<String, Expression> generateColumnCaseMap(List<String> columns, ExpressionFactory<String> factory) {
+    Map<String, Expression> columnExpMap = new LinkedHashMap<>();
+    if (toLower) {
+      columns.forEach((colName) -> columnExpMap.put(colName.toLowerCase(), factory.compile(colName)));
+    } else {
+      columns.forEach((colName) -> columnExpMap.put(colName.toUpperCase(), factory.compile(colName)));
+    }
+    return columnExpMap;
+  }
+
 }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/column/ChangeColCaseNames.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/ChangeColCaseNames.java
@@ -111,7 +111,9 @@ public class ChangeColCaseNames implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
-    List<String> columnNames = SqlExpressionGenerator.generateListCols(relationalTranformContext);
+
+    // TODO: handle schema changes in relationalTranformContext for multiple directive execution
+    List<String> columnNames = SqlExpressionGenerator.generateColumnNameList(relationalTranformContext);
     Map<String, Expression> colmap = generateColumnCaseMap(columnNames, expressionFactory.get());
     return relation.select(colmap);
   }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/ChangeColCaseNames.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/ChangeColCaseNames.java
@@ -126,5 +126,10 @@ public class ChangeColCaseNames implements Directive, Lineage {
     return columnExpMap;
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/column/CleanseColumnNames.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/CleanseColumnNames.java
@@ -128,4 +128,9 @@ public final class CleanseColumnNames implements Directive, Lineage {
     return columnExpMap;
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/CleanseColumnNames.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/CleanseColumnNames.java
@@ -37,10 +37,9 @@ import io.cdap.wrangler.api.lineage.Mutation;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
 
 /**
  * A directive for cleanses columns names.
@@ -111,21 +110,12 @@ public final class CleanseColumnNames implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
-    List<String> columnNames = SqlExpressionGenerator.generateListCols(relationalTranformContext);
-    Map<String, Expression> colmap = generateCleanseColumnMap(columnNames, expressionFactory.get());
-    return relation.select(colmap);
-  }
 
-  public static Map<String, Expression> generateCleanseColumnMap(Collection columns,
-                                                                 ExpressionFactory<String> factory) {
-    Map<String, Expression> columnExpMap = new LinkedHashMap<>();
-    columns.forEach((colName)-> columnExpMap.put(String
-            .format(colName
-                    .toString()
-                    .toLowerCase()
-                    .replaceAll("[^a-zA-Z0-9_]", "_")), factory
-            .compile(colName.toString())));
-    return columnExpMap;
+    // TODO: handle schema changes in relationalTranformContext for multiple directive execution
+    List<String> columnNames = SqlExpressionGenerator.generateColumnNameList(relationalTranformContext);
+    Map<String, Expression> colmap = SqlExpressionGenerator
+            .generateCleanseColumnMap(columnNames, expressionFactory.get());
+    return relation.select(colmap);
   }
 
   @Override

--- a/wrangler-core/src/main/java/io/cdap/directives/column/CreateRecord.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/CreateRecord.java
@@ -120,4 +120,9 @@ public class CreateRecord implements Directive, Lineage {
             .format("struct(%s)", getColumnString)));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetHeader.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetHeader.java
@@ -123,5 +123,10 @@ public class SetHeader implements Directive, Lineage {
     return relation.select(columnExpMap);
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetHeader.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetHeader.java
@@ -110,18 +110,15 @@ public class SetHeader implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
-    List<String> columnNames = SqlExpressionGenerator.generateListCols(relationalTranformContext);
-    Map<String, Expression> columnExpMap = new LinkedHashMap<>();
 
-    IntStream.range(0, Math.min(columnNames.size(), columns.size()))
-            .forEach(i -> columnExpMap.put(columns.get(i), expressionFactory.get().compile(columnNames.get(i))));
-
-    if (columnNames.size() > columns.size()) {
-      IntStream.range(columns.size(), columnNames.size())
-          .forEach(i -> columnExpMap.put(columnNames.get(i), expressionFactory.get().compile(columnNames.get(i))));
-    }
+    // TODO: handle schema changes in relationalTranformContext for multiple directive execution
+    List<String> columnNames = SqlExpressionGenerator.generateColumnNameList(relationalTranformContext);
+    Map<String, Expression> columnExpMap = SqlExpressionGenerator
+            .generateHeaders(columnNames, columns, expressionFactory.get());
     return relation.select(columnExpMap);
   }
+
+
 
   @Override
   public boolean isSQLSupported() {

--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetHeader.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetHeader.java
@@ -19,6 +19,11 @@ package io.cdap.directives.column;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.Expression;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -32,9 +37,15 @@ import io.cdap.wrangler.api.lineage.Mutation;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * A directive for setting the columns obtained from wrangling.
@@ -90,5 +101,27 @@ public class SetHeader implements Directive, Lineage {
       .generate(Many.of(columns))
       .build();
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    List<String> columnNames = SqlExpressionGenerator.generateListCols(relationalTranformContext);
+    Map<String, Expression> columnExpMap = new LinkedHashMap<>();
+
+    IntStream.range(0, Math.min(columnNames.size(), columns.size()))
+            .forEach(i -> columnExpMap.put(columns.get(i), expressionFactory.get().compile(columnNames.get(i))));
+
+    if (columnNames.size() > columns.size()) {
+      IntStream.range(columns.size(), columnNames.size())
+          .forEach(i -> columnExpMap.put(columnNames.get(i), expressionFactory.get().compile(columnNames.get(i))));
+    }
+    return relation.select(columnExpMap);
+  }
+
 }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
@@ -19,6 +19,10 @@ package io.cdap.directives.column;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -36,6 +40,7 @@ import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 import io.cdap.wrangler.utils.ColumnConverter;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
 import java.math.RoundingMode;
 import java.util.List;
@@ -108,4 +113,17 @@ public final class SetType implements Directive, Lineage {
       .relation(col, col)
       .build();
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    java.util.Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    String expression = SqlExpressionGenerator.getColumnTypeExp(type, col, scale);
+    return relation.setColumn(col, expressionFactory.get().compile(expression));
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
@@ -126,4 +126,9 @@ public final class SetType implements Directive, Lineage {
     return relation.setColumn(col, expressionFactory.get().compile(expression));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
@@ -122,6 +122,9 @@ public final class SetType implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
+
+    // TODO: handle decimal casting and byte casting
+    //TODO: implement short data type in CDAP
     String expression = SqlExpressionGenerator.getColumnTypeExp(type, col, scale);
     return relation.setColumn(col, expressionFactory.get().compile(expression));
   }

--- a/wrangler-core/src/main/java/io/cdap/directives/column/Swap.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/Swap.java
@@ -114,4 +114,9 @@ public class Swap implements Directive, Lineage {
     tempRel = tempRel.setColumn(right, expressionFactory.get().compile(left));
     return tempRel.setColumn(left, expressionFactory.get().compile("tempColumn"));
   }
+
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/date/DiffDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/date/DiffDate.java
@@ -19,6 +19,10 @@ package io.cdap.directives.date;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -32,11 +36,13 @@ import io.cdap.wrangler.api.lineage.Mutation;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A directive for taking difference in Dates.
@@ -118,4 +124,17 @@ public class DiffDate implements Directive, Lineage {
       .relation(column2, column2)
       .build();
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    return relation.setColumn(destCol, expressionFactory.get()
+            .compile(String.format("datediff(millisecond, timestamp(%s), timestamp(%s))", column2, column1)));
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/date/DiffDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/date/DiffDate.java
@@ -133,6 +133,8 @@ public class DiffDate implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
+
+    // TODO: handle columns of data type timestamp_micros, this implementation is for string data type
     return relation.setColumn(destCol, expressionFactory.get()
             .compile(String.format("datediff(millisecond, timestamp(%s), timestamp(%s))", column2, column1)));
   }

--- a/wrangler-core/src/main/java/io/cdap/directives/date/DiffDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/date/DiffDate.java
@@ -137,4 +137,9 @@ public class DiffDate implements Directive, Lineage {
             .compile(String.format("datediff(millisecond, timestamp(%s), timestamp(%s))", column2, column1)));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/date/FormatDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/date/FormatDate.java
@@ -133,4 +133,9 @@ public class FormatDate implements Directive, Lineage {
             .compile(String.format("date_format(timestamp(%s), '%s')", column, format)));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/date/FormatDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/date/FormatDate.java
@@ -19,6 +19,10 @@ package io.cdap.directives.date;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -32,6 +36,7 @@ import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -40,6 +45,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A directive for managing date formats.
@@ -114,4 +120,17 @@ public class FormatDate implements Directive, Lineage {
       .relation(column, column)
       .build();
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    return relation.setColumn(column, expressionFactory.get()
+            .compile(String.format("date_format(timestamp(%s), '%s')", column, format)));
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/date/FormatDate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/date/FormatDate.java
@@ -129,6 +129,8 @@ public class FormatDate implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
+
+    // TODO: handle columns of data type timestamp_micros, this implementation is for string data type
     return relation.setColumn(column, expressionFactory.get()
             .compile(String.format("date_format(timestamp(%s), '%s')", column, format)));
   }

--- a/wrangler-core/src/main/java/io/cdap/directives/language/SetCharset.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/language/SetCharset.java
@@ -136,5 +136,10 @@ public class SetCharset implements Directive, Lineage {
     return relation.setColumn(column, expressionFactory.get().compile(String
             .format("decode(%s, '%s'))", column, charset)));
   }
+
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
   
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/language/SetCharset.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/language/SetCharset.java
@@ -19,6 +19,10 @@ package io.cdap.directives.language;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -33,6 +37,7 @@ import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -119,4 +124,17 @@ public class SetCharset implements Directive, Lineage {
       .relation(column, column)
       .build();
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    java.util.Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    return relation.setColumn(column, expressionFactory.get().compile(String
+            .format("decode(%s, '%s'))", column, charset)));
+  }
+  
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/FixedLengthParser.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/FixedLengthParser.java
@@ -182,4 +182,9 @@ public final class FixedLengthParser implements Directive, Lineage {
     return relation;
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
@@ -130,11 +130,12 @@ public class Fail implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
-
-    return relation.setColumn("tempColumn", expressionFactory.get().compile(
-            String.format("if(%s, raise_error(\"Condition '%s' evaluated to true. " +
+    String errorExp = String.format("if(%s, raise_error(\"Condition '%s' evaluated to true. " +
                     "Terminating processing.\"), %s)", el.getScriptParsedText(),
-                    el.getScriptParsedText(), el.getScriptParsedText())));
+            el.getScriptParsedText(), el.getScriptParsedText());
+
+    // TODO: handle cases where condition is not of ANSI SQL compatible syntax
+    return relation.setColumn("tempColumn", expressionFactory.get().compile(errorExp));
   }
 
   @Override

--- a/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
@@ -130,11 +130,11 @@ public class Fail implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
-    return relation.setColumn("tempColumn", expressionFactory.get()
-            .compile(String.format("CASE %s WHEN %s THEN raise_error(\"Condition %s evaluating to true. " +
-                    "Terminating process.\") END", el.getScriptParsedText(),
-                    el.getScriptParsedText(), el.getScriptParsedText())))
-            .dropColumn("tempColumn");
+
+    return relation.setColumn("tempColumn", expressionFactory.get().compile(
+            String.format("if(%s, raise_error(\"Condition '%s' evaluated to true. " +
+                    "Terminating processing.\"), %s)", el.getScriptParsedText(),
+                    el.getScriptParsedText(), el.getScriptParsedText())));
   }
 
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
@@ -137,4 +137,9 @@ public class Fail implements Directive, Lineage {
                     el.getScriptParsedText(), el.getScriptParsedText())));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/Fail.java
@@ -20,6 +20,10 @@ import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -37,6 +41,7 @@ import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
 import java.util.List;
 
@@ -116,4 +121,20 @@ public class Fail implements Directive, Lineage {
     EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    java.util.Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    return relation.setColumn("tempColumn", expressionFactory.get()
+            .compile(String.format("CASE %s WHEN %s THEN raise_error(\"Condition %s evaluating to true. " +
+                    "Terminating process.\") END", el.getScriptParsedText(),
+                    el.getScriptParsedText(), el.getScriptParsedText())))
+            .dropColumn("tempColumn");
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
@@ -20,6 +20,10 @@ import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -38,6 +42,7 @@ import io.cdap.wrangler.api.parser.UsageDefinition;
 import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -129,4 +134,16 @@ public class RecordConditionFilter implements Directive, Lineage {
     EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    java.util.Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    return relation.filter(expressionFactory.get().compile(el.getScriptParsedText()));
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
@@ -146,4 +146,9 @@ public class RecordConditionFilter implements Directive, Lineage {
     return relation.filter(expressionFactory.get().compile(el.getScriptParsedText()));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordConditionFilter.java
@@ -143,6 +143,8 @@ public class RecordConditionFilter implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
+
+    // TODO: handle cases where condition is not of ANSI SQL compatible syntax
     return relation.filter(expressionFactory.get().compile(el.getScriptParsedText()));
   }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/row/RecordRegexFilter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/RecordRegexFilter.java
@@ -164,5 +164,10 @@ public class RecordRegexFilter implements Directive, Lineage {
     }
     return relation.filter(expressionFactory.get().compile("rlike(" + column + ", '" + pattern + "')"));
   }
+
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
 }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SetRecordDelimiter.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SetRecordDelimiter.java
@@ -135,4 +135,9 @@ public class SetRecordDelimiter implements Directive, Lineage {
             String.format("explode(split(%s, \"%s\", %d))", column, delimiter, limit)));
     return relation.select(columnExpMap);
   }
+
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/row/SplitToRows.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/row/SplitToRows.java
@@ -129,5 +129,10 @@ public class SplitToRows implements Directive, Lineage {
     return relation.setColumn(column, expressionFactory.get()
             .compile(String.format("explode(split(%s, '%s'))", column, regex)));
   }
+
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
 }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
@@ -147,6 +147,8 @@ public class ColumnExpression implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
+
+    // TODO: handle cases where condition is not of ANSI SQL compatible syntax
     return relation.setColumn(column, expressionFactory.get().compile(el.getScriptParsedText()));
   }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
@@ -150,4 +150,9 @@ public class ColumnExpression implements Directive, Lineage {
     return relation.setColumn(column, expressionFactory.get().compile(el.getScriptParsedText()));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/ColumnExpression.java
@@ -20,6 +20,10 @@ import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -39,6 +43,7 @@ import io.cdap.wrangler.expression.EL;
 import io.cdap.wrangler.expression.ELContext;
 import io.cdap.wrangler.expression.ELException;
 import io.cdap.wrangler.expression.ELResult;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 
 import java.util.List;
 
@@ -133,4 +138,16 @@ public class ColumnExpression implements Directive, Lineage {
     EntityCountMetric jexlCategoryMetric = getJexlCategoryMetric(el.getScriptParsedText());
     return (jexlCategoryMetric == null) ? null : ImmutableList.of(jexlCategoryMetric);
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    java.util.Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    return relation.setColumn(column, expressionFactory.get().compile(el.getScriptParsedText()));
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
@@ -173,11 +173,11 @@ public class Decode implements Directive, Lineage {
     if (method.toString().equalsIgnoreCase("base64")) {
       return relation.setColumn(
           String.format("%s_decode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
-                      .get().compile("unbase64(" + column + ")"));
-    } else if (method.toString().equalsIgnoreCase("base32")) {
+                      .get().compile("string(unbase64(" + column + "))"));
+    } else if (method.toString().equalsIgnoreCase("hex")) {
       return relation.setColumn(
               String.format("%s_decode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
-                      .get().compile("unhex(" + column + ")"));
+                      .get().compile("string(unhex(" + column + "))"));
     } else {
       return new InvalidRelation(String.format("Decoding of type %s is not supported by " +
               "SQL execution currently", method.toString()));

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
@@ -19,6 +19,10 @@ package io.cdap.directives.transformation;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -32,6 +36,7 @@ import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.codec.binary.Base64;
@@ -40,6 +45,7 @@ import org.apache.commons.codec.binary.Hex;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * A directive that decodes a column that was encoded as base-32, base-64, or hex.
@@ -155,4 +161,27 @@ public class Decode implements Directive, Lineage {
       .relation(column, column)
       .build();
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    if (method.toString().equalsIgnoreCase("base64")) {
+      return relation.setColumn(
+          String.format("%s_decode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
+                      .get().compile("unbase64(" + column + ")"));
+    } else if (method.toString().equalsIgnoreCase("base32")) {
+      return relation.setColumn(
+              String.format("%s_decode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
+                      .get().compile("unhex(" + column + ")"));
+    } else {
+      return new InvalidRelation(String.format("Decoding of type %s is not supported by " +
+              "SQL execution currently", method.toString()));
+    }
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
@@ -184,4 +184,9 @@ public class Decode implements Directive, Lineage {
     }
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Decode.java
@@ -163,24 +163,26 @@ public class Decode implements Directive, Lineage {
   }
 
   @Override
-  public Relation transform(RelationalTranformContext relationalTranformContext,
-                            Relation relation) {
+  public Relation transform(RelationalTranformContext relationalTranformContext, Relation relation) {
     Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
             .getExpressionFactory(relationalTranformContext);
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
-    if (method.toString().equalsIgnoreCase("base64")) {
-      return relation.setColumn(
-          String.format("%s_decode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
-                      .get().compile("string(unbase64(" + column + "))"));
-    } else if (method.toString().equalsIgnoreCase("hex")) {
-      return relation.setColumn(
-              String.format("%s_decode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
-                      .get().compile("string(unhex(" + column + "))"));
-    } else {
-      return new InvalidRelation(String.format("Decoding of type %s is not supported by " +
-              "SQL execution currently", method.toString()));
+
+    switch (method.toString().toLowerCase()) {
+      case "base64": {
+        return relation.setColumn(String.format("%s_decode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)),
+                expressionFactory.get().compile("unbase64(" + column + ")"));
+      }
+      case "hex": {
+        return relation.setColumn(String.format("%s_decode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)),
+                expressionFactory.get().compile("unhex(" + column + ")"));
+      }
+      default: {
+        return new InvalidRelation(String.format("Decoding of type %s is not supported by " +
+                "SQL execution currently", method.toString()));
+      }
     }
   }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
@@ -158,24 +158,26 @@ public class Encode implements Directive, Lineage {
   }
 
   @Override
-  public Relation transform(RelationalTranformContext relationalTranformContext,
-                            Relation relation) {
+  public Relation transform(RelationalTranformContext relationalTranformContext, Relation relation) {
     Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
             .getExpressionFactory(relationalTranformContext);
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
-    if (method.toString().equalsIgnoreCase("base64")) {
-      return relation.setColumn(
-              String.format("%s_encode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
-                      .get().compile("base64(" + column + ")"));
-    } else if (method.toString().equalsIgnoreCase("hex")) {
-      return relation.setColumn(
-              String.format("%s_encode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
-                      .get().compile("hex(" + column + ")"));
-    } else {
-      return new InvalidRelation(String.format("Encoding of type %s is not supported by " +
+
+    switch (method.toString().toLowerCase()) {
+      case "base64": {
+        return relation.setColumn(String.format("%s_encode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)),
+                expressionFactory.get().compile("base64(" + column + ")"));
+      }
+      case "hex": {
+        return relation.setColumn(String.format("%s_encode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)),
+                expressionFactory.get().compile("hex(" + column + ")"));
+      }
+      default: {
+        return new InvalidRelation(String.format("Encoding of type %s is not supported by " +
               "SQL execution currently", method.toString()));
+      }
     }
   }
 

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
@@ -179,4 +179,9 @@ public class Encode implements Directive, Lineage {
     }
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
@@ -169,7 +169,7 @@ public class Encode implements Directive, Lineage {
       return relation.setColumn(
               String.format("%s_encode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
                       .get().compile("base64(" + column + ")"));
-    } else if (method.toString().equalsIgnoreCase("base32")) {
+    } else if (method.toString().equalsIgnoreCase("hex")) {
       return relation.setColumn(
               String.format("%s_encode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
                       .get().compile("hex(" + column + ")"));

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/Encode.java
@@ -19,6 +19,10 @@ package io.cdap.directives.transformation;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -32,6 +36,7 @@ import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
@@ -39,6 +44,7 @@ import org.apache.commons.codec.binary.Hex;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * A directive that encodes a column as base-32, base-64, or hex.
@@ -150,4 +156,27 @@ public class Encode implements Directive, Lineage {
       .relation(column, column)
       .build();
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    if (method.toString().equalsIgnoreCase("base64")) {
+      return relation.setColumn(
+              String.format("%s_encode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
+                      .get().compile("base64(" + column + ")"));
+    } else if (method.toString().equalsIgnoreCase("base32")) {
+      return relation.setColumn(
+              String.format("%s_encode_%s", column, method.toString().toLowerCase(Locale.ENGLISH)), expressionFactory
+                      .get().compile("hex(" + column + ")"));
+    } else {
+      return new InvalidRelation(String.format("Encoding of type %s is not supported by " +
+              "SQL execution currently", method.toString()));
+    }
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/FillNullOrEmpty.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/FillNullOrEmpty.java
@@ -123,4 +123,9 @@ public class FillNullOrEmpty implements Directive, Lineage {
             .format("nvl2(%s, if(length(%s) == 0, \"%s\", %s), \"%s\")",
              column, column, value, column, value)));
   }
+
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/GenerateUUID.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/GenerateUUID.java
@@ -107,4 +107,9 @@ public class GenerateUUID implements Directive, Lineage {
     return relation.setColumn(column, expressionFactory.get()
             .compile(String.format("uuid()")));
   }
+
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/SplitEmail.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/SplitEmail.java
@@ -155,4 +155,9 @@ public class SplitEmail implements Directive, Lineage {
             expressionFactory.get().compile(domainExpression));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/UrlDecode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/UrlDecode.java
@@ -120,4 +120,9 @@ public class UrlDecode implements Directive, Lineage {
                 String.format("reflect('java.net.URLDecoder', 'decode', %s, 'utf-8')", column)));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/transformation/UrlEncode.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/transformation/UrlEncode.java
@@ -119,4 +119,10 @@ public class UrlEncode implements Directive, Lineage {
             column, expressionFactory.get().compile(
                     String.format("reflect('java.net.URLEncoder', 'encode', %s, 'utf-8')", column)));
   }
+
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsCSV.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsCSV.java
@@ -118,7 +118,9 @@ public class WriteAsCSV implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
-    List<String> columnNames = SqlExpressionGenerator.generateListCols(relationalTranformContext);
+
+    // TODO: handle schema changes in relationalTranformContext for multiple directive execution
+    List<String> columnNames = SqlExpressionGenerator.generateColumnNameList(relationalTranformContext);
     return relation.setColumn(column, expressionFactory.get().compile(String
             .format("to_csv(struct(%s))", String.join(",", columnNames))));
   }

--- a/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsCSV.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsCSV.java
@@ -123,4 +123,9 @@ public class WriteAsCSV implements Directive, Lineage {
             .format("to_csv(struct(%s))", String.join(",", columnNames))));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsCSV.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsCSV.java
@@ -19,6 +19,11 @@ package io.cdap.directives.writer;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.Expression;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -32,6 +37,7 @@ import io.cdap.wrangler.api.lineage.Mutation;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.utils.SqlExpressionGenerator;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 
@@ -41,6 +47,8 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * A step to write the record fields as CSV.
@@ -101,4 +109,18 @@ public class WriteAsCSV implements Directive, Lineage {
       .generate(Many.of(column))
       .build();
   }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+                            Relation relation) {
+    Optional<ExpressionFactory<String>> expressionFactory = SqlExpressionGenerator
+            .getExpressionFactory(relationalTranformContext);
+    if (!expressionFactory.isPresent()) {
+      return new InvalidRelation("Cannot find an Expression Factory");
+    }
+    List<String> columnNames = SqlExpressionGenerator.generateListCols(relationalTranformContext);
+    return relation.setColumn(column, expressionFactory.get().compile(String
+            .format("to_csv(struct(%s))", String.join(",", columnNames))));
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsJsonMap.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsJsonMap.java
@@ -108,4 +108,9 @@ public class WriteAsJsonMap implements Directive, Lineage {
             .format("to_json(struct(%s))", String.join(",", columnNames))));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsJsonMap.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsJsonMap.java
@@ -103,7 +103,9 @@ public class WriteAsJsonMap implements Directive, Lineage {
     if (!expressionFactory.isPresent()) {
       return new InvalidRelation("Cannot find an Expression Factory");
     }
-    List<String> columnNames = SqlExpressionGenerator.generateListCols(relationalTranformContext);
+
+    // TODO: handle schema changes in relationalTranformContext for multiple directive execution
+    List<String> columnNames = SqlExpressionGenerator.generateColumnNameList(relationalTranformContext);
     return relation.setColumn(column, expressionFactory.get().compile(String
             .format("to_json(struct(%s))", String.join(",", columnNames))));
   }

--- a/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsJsonObject.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/writer/WriteAsJsonObject.java
@@ -134,4 +134,9 @@ public class WriteAsJsonObject implements Directive, Lineage {
                     .compile(String.format("struct(%s)", getColumnString)));
   }
 
+  @Override
+  public boolean isSQLSupported() {
+    return true;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/SqlExpressionGenerator.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/SqlExpressionGenerator.java
@@ -16,15 +16,19 @@
 
 package io.cdap.wrangler.utils;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.relational.Expression;
 import io.cdap.cdap.etl.api.relational.ExpressionFactory;
 import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.cdap.etl.api.relational.StringExpressionFactoryType;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -105,4 +109,19 @@ public class SqlExpressionGenerator {
                 return column;
         }
     }
+
+    public static List<String> generateListCols(RelationalTranformContext relationalTranformContext) {
+        List<String> colnames = new ArrayList<String>();
+        Set<String> inputRelationNames = relationalTranformContext.getInputRelationNames();
+        for (String inputRelationName : inputRelationNames) {
+            Schema schema = relationalTranformContext.getInputSchema(inputRelationName);
+            List<Schema.Field> fields = schema.getFields();
+            for (Schema.Field field: fields) {
+                colnames.add(field.getName());
+            }
+        }
+        return colnames;
+    }
+
+
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/SqlExpressionGenerator.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/SqlExpressionGenerator.java
@@ -110,7 +110,7 @@ public class SqlExpressionGenerator {
         }
     }
 
-    public static List<String> generateListCols(RelationalTranformContext relationalTranformContext) {
+    public static List<String> generateColumnNameList(RelationalTranformContext relationalTranformContext) {
         List<String> colnames = new ArrayList<String>();
         Set<String> inputRelationNames = relationalTranformContext.getInputRelationNames();
         for (String inputRelationName : inputRelationNames) {
@@ -123,5 +123,28 @@ public class SqlExpressionGenerator {
         return colnames;
     }
 
+    public static Map<String, Expression> generateHeaders(List<String> columns, List<String> headers,
+                                                          ExpressionFactory<String> factory) {
+        Map<String, Expression> columnExpMap = new LinkedHashMap<>();
+        for (int i = 0; i < Math.min(columns.size(), headers.size()); i++) {
+            columnExpMap.put(headers.get(i), factory.compile(columns.get(i)));
+        }
+
+        if (columns.size() > headers.size()) {
+            for (int i = headers.size(); i < columns.size(); i++) {
+                columnExpMap.put(columns.get(i), factory.compile(columns.get(i)));
+            }
+        }
+        return columnExpMap;
+    }
+
+    public static Map<String, Expression> generateCleanseColumnMap(Collection columns,
+                                                                   ExpressionFactory<String> factory) {
+        Map<String, Expression> columnExpMap = new LinkedHashMap<>();
+        columns.forEach((colName)-> columnExpMap.put(String
+                .format(colName.toString().toLowerCase().replaceAll("[^a-zA-Z0-9_]", "_")), factory
+                .compile(colName.toString())));
+        return columnExpMap;
+    }
 
 }


### PR DESCRIPTION
Implements relational transform for the following directives:

- Change-column-case-names
- Quantization
- Cleanse-column-names
- Set-headers
- Set-type
- Diff-date
- Format-date
- Set-charset
- Fail
- Record-condition-filter
- Column-expression
- Decode
- Encode
- Write-as-CSV
- Write-as-JSON-Map