### PR TITLE
Add custom schema handling logic to directives that rename columns

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/directives/column/ChangeColCaseNames.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/ChangeColCaseNames.java
@@ -19,6 +19,7 @@ package io.cdap.directives.column;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -26,6 +27,7 @@ import io.cdap.wrangler.api.DirectiveParseException;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.SchemaResolutionContext;
 import io.cdap.wrangler.api.annotations.Categories;
 import io.cdap.wrangler.api.lineage.Lineage;
 import io.cdap.wrangler.api.lineage.Many;
@@ -35,6 +37,7 @@ import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This class <code>ChangeColCaseNames</code> converts the case of the columns
@@ -94,5 +97,20 @@ public class ChangeColCaseNames implements Directive, Lineage {
       .all(Many.of())
       .build();
   }
-}
 
+  @Override
+  public Schema getOutputSchema(SchemaResolutionContext context) {
+    Schema inputSchema = context.getInputSchema();
+    return Schema.recordOf(
+      "outputSchema",
+      inputSchema.getFields().stream()
+        .map(
+          field -> {
+            String fieldName = toLower ? field.getName().toLowerCase() : field.getName().toUpperCase();
+            return Schema.Field.of(fieldName, field.getSchema());
+          }
+        )
+        .collect(Collectors.toList())
+    );
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/column/Copy.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/Copy.java
@@ -19,6 +19,7 @@ package io.cdap.directives.column;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -26,15 +27,16 @@ import io.cdap.wrangler.api.DirectiveParseException;
 import io.cdap.wrangler.api.ExecutorContext;
 import io.cdap.wrangler.api.Optional;
 import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.SchemaResolutionContext;
 import io.cdap.wrangler.api.annotations.Categories;
 import io.cdap.wrangler.api.lineage.Lineage;
-import io.cdap.wrangler.api.lineage.Many;
 import io.cdap.wrangler.api.lineage.Mutation;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.TokenType;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A directive for copying value of one column to another.
@@ -109,5 +111,19 @@ public class Copy implements Directive, Lineage {
       .readable("Copied value from column '%s' to '%s'", source.value(), destination.value())
       .conditional(source.value(), destination.value())
       .build();
+  }
+
+  @Override
+  public Schema getOutputSchema(SchemaResolutionContext context) {
+    Schema inputSchema = context.getInputSchema();
+    return Schema.recordOf(
+      "outputSchema",
+      inputSchema.getFields().stream()
+        .map(
+          field -> field.getName().equals(destination.value()) ?
+            Schema.Field.of(destination.value(), inputSchema.getField(source.value()).getSchema()) : field
+        )
+        .collect(Collectors.toList())
+    );
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/column/ChangeColCaseNamesTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/ChangeColCaseNamesTest.java
@@ -16,12 +16,15 @@
 
 package io.cdap.directives.column;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.wrangler.TestingRig;
 import io.cdap.wrangler.api.Row;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -43,5 +46,36 @@ public class ChangeColCaseNamesTest {
 
     Assert.assertTrue(rows.size() == 1);
     Assert.assertEquals("url", rows.get(0).getColumn(0));
+  }
+
+  @Test
+  public void testGetOutputSchemaForCaseChangedCols() throws Exception {
+    String[] directives = new String[] {
+      "change-column-case lower",
+    };
+    List<Row> rows = Collections.singletonList(
+      new Row("ALL_CAPS", 1).add("MiXeD_CAse", "random").add("all_lower", new BigDecimal("143235.016"))
+    );
+    Schema inputSchema = Schema.recordOf(
+      "inputSchema",
+      Schema.Field.of("ALL_CAPS", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("MiXeD_CAse", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("all_lower", Schema.decimalOf(10, 3))
+    );
+    Schema expectedSchema = Schema.recordOf(
+      "expectedSchema",
+      Schema.Field.of("all_caps", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("mixed_case", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("all_lower", Schema.decimalOf(10, 3))
+    );
+
+    Schema outputSchema = TestingRig.executeAndGetSchema(directives, rows, inputSchema);
+
+    Assert.assertEquals(outputSchema.getFields().size(), expectedSchema.getFields().size());
+    for (Schema.Field expectedField : expectedSchema.getFields()) {
+      Assert.assertEquals(
+        outputSchema.getField(expectedField.getName()).getSchema().getType(), expectedField.getSchema().getType()
+      );
+    }
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/column/ColumnsReplaceTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/ColumnsReplaceTest.java
@@ -16,13 +16,16 @@
 
 package io.cdap.directives.column;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.wrangler.TestingRig;
 import io.cdap.wrangler.api.RecipeException;
 import io.cdap.wrangler.api.Row;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -64,5 +67,37 @@ public class ColumnsReplaceTest {
     );
 
     TestingRig.execute(directives, rows);
+  }
+  @Test
+  public void testGetOutputSchemaForReplacedColumnNames() throws Exception {
+    String[] directives = new String[] {
+      "columns-replace s/^data_//g",
+    };
+    List<Row> rows = Collections.singletonList(
+      new Row("data_a", 1).add("data_data_confuse", "ABC").add("no_data", null).add("random", new BigDecimal("12.44"))
+    );
+    Schema inputSchema = Schema.recordOf(
+      "inputSchema",
+      Schema.Field.of("data_a", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("data_data_confuse", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("no_data", Schema.of(Schema.Type.DOUBLE)),
+      Schema.Field.of("random", Schema.decimalOf(10, 3))
+    );
+    Schema expectedSchema = Schema.recordOf(
+      "expectedSchema",
+      Schema.Field.of("a", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("data_confuse", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("no_data", Schema.of(Schema.Type.DOUBLE)),
+      Schema.Field.of("random", Schema.decimalOf(10, 3))
+    );
+
+    Schema outputSchema = TestingRig.executeAndGetSchema(directives, rows, inputSchema);
+
+    Assert.assertEquals(outputSchema.getFields().size(), expectedSchema.getFields().size());
+    for (Schema.Field expectedField : expectedSchema.getFields()) {
+      Assert.assertEquals(
+        outputSchema.getField(expectedField.getName()).getSchema().getType(), expectedField.getSchema().getType()
+      );
+    }
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/column/CopyTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/CopyTest.java
@@ -100,7 +100,7 @@ public class CopyTest {
   }
 
   @Test
-  public void testGetOutputSchemaForCopiedColumn() throws Exception {
+  public void testGetOutputSchemaForForceCopiedColumn() throws Exception {
     String[] directives = new String[] {
       "copy :col_B :col_A true",
     };
@@ -128,4 +128,31 @@ public class CopyTest {
     }
   }
 
+  @Test
+  public void testGetOutputSchemaForCopiedColumn() throws Exception {
+    String[] directives = new String[] {
+      "copy :col_A :col_B",
+    };
+    List<Row> rows = Collections.singletonList(
+      new Row("col_A", new BigDecimal("143235.016"))
+    );
+    Schema inputSchema = Schema.recordOf(
+      "inputSchema",
+      Schema.Field.of("col_A", Schema.decimalOf(10, 3))
+    );
+    Schema expectedSchema = Schema.recordOf(
+      "expectedSchema",
+      Schema.Field.of("col_A", Schema.decimalOf(10, 3)),
+      Schema.Field.of("col_B", Schema.decimalOf(10, 3))
+    );
+
+    Schema outputSchema = TestingRig.executeAndGetSchema(directives, rows, inputSchema);
+
+    Assert.assertEquals(outputSchema.getFields().size(), expectedSchema.getFields().size());
+    for (Schema.Field expectedField : expectedSchema.getFields()) {
+      Assert.assertEquals(
+        outputSchema.getField(expectedField.getName()).getSchema().getType(), expectedField.getSchema().getType()
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Changes
These directives perform a "rename"-like operation in the following ways:
- `columns-replace` modifies column names in bulk based on a sed expression
- `change-column-case` changes the case of column names
- `copy`: the copied data has the same schema as the original data

Hence, the `getOutputSchema` method is overriden with custom logic to carry over the original schema to the renamed/copied columns