### PR TITLE
[CDAP-20839] Fix grammar to identify and tokenize negative numbers

### DIFF
--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -304,7 +304,7 @@ Space
  ;
 
 fragment Int
- : [1-9] Digit* [L]*
+ : '-'? [1-9] Digit* [L]*
  | '0'
  ;
 

--- a/wrangler-core/src/test/java/io/cdap/directives/column/SetTypeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/SetTypeTest.java
@@ -188,6 +188,17 @@ public class SetTypeTest {
     Assert.assertEquals(row.getValue(1), new BigDecimal("456"));
   }
 
+  @Test
+  public void testToDecimalNegativeScale() throws Exception {
+    List<Row> rows = Collections.singletonList(new Row("scale_2", "125.45"));
+    String[] directives = new String[] {"set-type scale_2 decimal -1 'HALF_UP'"};
+    List<Row> results = TestingRig.execute(directives, rows);
+    Row row = results.get(0);
+
+    Assert.assertTrue(row.getValue(0) instanceof BigDecimal);
+    Assert.assertEquals(row.getValue(0), new BigDecimal("1.3E+2"));
+  }
+
   @Test(expected = RecipeException.class)
   public void testToDecimalRoundingRequired() throws Exception {
     List<Row> rows = Collections.singletonList(new Row("scale_2", "123.45"));


### PR DESCRIPTION
## Issue:
Wrangler's grammar does not recognize negative numbers, ex. unable to use negative number while incrementing a variable:

![image](https://github.com/data-integrations/wrangler/assets/45899028/1157f1a0-9332-47f2-ba0d-e6412157b124)

## Fix:
- Add '-' to the INT token
- Add test for negative scale in set-type to decimal directive

![image](https://github.com/data-integrations/wrangler/assets/45899028/f7c0c08f-c629-4c93-bbbc-b4de8f1704f3)
 