### PR TITLE
[CDAP-15361] Fix set-type directive for decimal when scale is null

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/ColumnConverter.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/ColumnConverter.java
@@ -317,7 +317,8 @@ public final class ColumnConverter {
     type = type.toUpperCase();
     if (type.equals(ColumnTypeNames.DECIMAL)) {
       // TODO make set-type support setting decimal precision
-      typeSchema = Schema.nullableOf(Schema.decimalOf(38, scale));
+      scale = scale != null ? scale : 38;
+      typeSchema = Schema.nullableOf(Schema.decimalOf(76, scale));
     } else {
       if (!SCHEMA_TYPE_MAP.containsKey(type)) {
         throw new DirectiveParseException(String.format("'%s' is an unsupported type. " +

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/ColumnConverter.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/ColumnConverter.java
@@ -318,7 +318,7 @@ public final class ColumnConverter {
     if (type.equals(ColumnTypeNames.DECIMAL)) {
       // TODO make set-type support setting decimal precision
       scale = scale != null ? scale : 38;
-      typeSchema = Schema.nullableOf(Schema.decimalOf(76, scale));
+      typeSchema = Schema.nullableOf(Schema.decimalOf(77, scale));
     } else {
       if (!SCHEMA_TYPE_MAP.containsKey(type)) {
         throw new DirectiveParseException(String.format("'%s' is an unsupported type. " +

--- a/wrangler-core/src/test/java/io/cdap/directives/column/SetTypeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/SetTypeTest.java
@@ -217,11 +217,30 @@ public class SetTypeTest {
   public void testToDecimalScaleIsNull() throws Exception {
     List<Row> rows = Collections.singletonList(new Row("scale_2", "125.45"));
     String[] directives = new String[] {"set-type scale_2 decimal"};
+    Schema inputSchema = Schema.recordOf(
+        "inputSchema",
+        Schema.Field.of("scale_2", Schema.of(Schema.Type.DOUBLE))
+    );
+
+    Schema expectedSchema = Schema.recordOf(
+        "expectedSchema",
+        Schema.Field.of("scale_2", Schema.decimalOf(77, 38))
+    );
+
     List<Row> results = TestingRig.execute(directives, rows);
+    Schema outputSchema = TestingRig.executeAndGetSchema(directives, rows, inputSchema);
     Row row = results.get(0);
+    Schema.Field outputSchemaField = expectedSchema.getFields().get(0);
 
     Assert.assertTrue(row.getValue(0) instanceof BigDecimal);
     Assert.assertEquals(row.getValue(0), new BigDecimal("125.45"));
+
+    Assert.assertEquals(outputSchemaField.getSchema().getType(),
+        outputSchema.getField(outputSchemaField.getName()).getSchema().getNonNullable().getType());
+    Assert.assertEquals(outputSchemaField.getSchema().getPrecision(),
+        outputSchema.getField(outputSchemaField.getName()).getSchema().getNonNullable().getPrecision());
+    Assert.assertEquals(outputSchemaField.getSchema().getScale(),
+        outputSchema.getField(outputSchemaField.getName()).getSchema().getNonNullable().getScale());
   }
 
   @Test

--- a/wrangler-core/src/test/java/io/cdap/directives/column/SetTypeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/SetTypeTest.java
@@ -214,6 +214,17 @@ public class SetTypeTest {
   }
 
   @Test
+  public void testToDecimalScaleIsNull() throws Exception {
+    List<Row> rows = Collections.singletonList(new Row("scale_2", "125.45"));
+    String[] directives = new String[] {"set-type scale_2 decimal"};
+    List<Row> results = TestingRig.execute(directives, rows);
+    Row row = results.get(0);
+
+    Assert.assertTrue(row.getValue(0) instanceof BigDecimal);
+    Assert.assertEquals(row.getValue(0), new BigDecimal("125.45"));
+  }
+
+  @Test
   public void testToBoolean() throws Exception {
     List<Row> trueRows = Collections.singletonList(
       new Row("str_1", "true").add("str_2", "True").add("str_3", "TRUE")


### PR DESCRIPTION
Fix set-type directive for decimal by adding a default value for scale in case it is null/not provided.