### PR TITLE
[CDAP-20865] Fix copy directive schema generation bug

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/directives/column/Copy.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/Copy.java
@@ -118,18 +118,18 @@ public class Copy implements Directive, Lineage {
     Schema inputSchema = context.getInputSchema();
     List<Schema.Field> outputFields = new ArrayList<>();
     Schema sourceSchema = inputSchema.getField(source.value()).getSchema();
+    boolean destinationExists = inputSchema.getField(destination.value()) != null;
 
     for (Schema.Field field : inputSchema.getFields()) {
-      if (field.getName().equals(destination.value())) {
+      if (force && field.getName().equals(destination.value())) {
         outputFields.add(Schema.Field.of(destination.value(), sourceSchema));
       } else {
         outputFields.add(field);
       }
     }
-    if (!force) {
+    if (!destinationExists) {
       outputFields.add(Schema.Field.of(destination.value(), sourceSchema));
     }
-
     return Schema.recordOf("outputSchema", outputFields);
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/column/CopyTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/CopyTest.java
@@ -103,6 +103,7 @@ public class CopyTest {
   public void testGetOutputSchemaForForceCopiedColumn() throws Exception {
     String[] directives = new String[] {
       "copy :col_B :col_A true",
+      "copy :col_B :col_C true",
     };
     List<Row> rows = Collections.singletonList(
       new Row("col_A", 1).add("col_B", new BigDecimal("143235.016"))
@@ -115,7 +116,8 @@ public class CopyTest {
     Schema expectedSchema = Schema.recordOf(
       "expectedSchema",
       Schema.Field.of("col_A", Schema.decimalOf(10, 3)),
-      Schema.Field.of("col_B", Schema.decimalOf(10, 3))
+      Schema.Field.of("col_B", Schema.decimalOf(10, 3)),
+      Schema.Field.of("col_C", Schema.decimalOf(10, 3))
     );
 
     Schema outputSchema = TestingRig.executeAndGetSchema(directives, rows, inputSchema);


### PR DESCRIPTION
Fixes bug in existing copy directive's output schema generation when 'force' argument is true but a new column is specified. 