### PR TITLE
[CDAP-15361] Fix set-type directive for decimal when scale is null (part II)

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/SetType.java
@@ -115,6 +115,9 @@ public final class SetType implements Directive, Lineage {
   @Override
   public Schema getOutputSchema(SchemaResolutionContext context) {
     Schema inputSchema = context.getInputSchema();
+    if (type.equalsIgnoreCase("decimal") && scale == null) {
+      return null;
+    }
     return Schema.recordOf(
       "outputSchema",
       inputSchema.getFields().stream()

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/ColumnConverter.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/ColumnConverter.java
@@ -317,7 +317,6 @@ public final class ColumnConverter {
     type = type.toUpperCase();
     if (type.equals(ColumnTypeNames.DECIMAL)) {
       // TODO make set-type support setting decimal precision
-      scale = scale != null ? scale : 38;
       typeSchema = Schema.nullableOf(Schema.decimalOf(77, scale));
     } else {
       if (!SCHEMA_TYPE_MAP.containsKey(type)) {

--- a/wrangler-core/src/test/java/io/cdap/directives/column/SetTypeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/column/SetTypeTest.java
@@ -224,7 +224,7 @@ public class SetTypeTest {
 
     Schema expectedSchema = Schema.recordOf(
         "expectedSchema",
-        Schema.Field.of("scale_2", Schema.decimalOf(77, 38))
+        Schema.Field.of("scale_2", Schema.decimalOf(38, 2))
     );
 
     List<Row> results = TestingRig.execute(directives, rows);


### PR DESCRIPTION
Modifying getOutputSchema in set type to use default getOutputSchema when type=decimal, scale= null