### PR TITLE
Setup for Wrangler SQL Execution Support

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/Directive.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/Directive.java
@@ -16,6 +16,8 @@
 
 package io.cdap.wrangler.api;
 
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.parser.UsageDefinition;
 
 import java.util.List;
@@ -51,7 +53,8 @@ import java.util.List;
  *   }
  * </code>
  */
-public interface Directive extends Executor<List<Row>, List<Row>>, EntityMetrics {
+public interface Directive extends Executor<List<Row>, List<Row>>, EntityMetrics,
+    DirectiveRelationalTransform {
   /**
    * This defines a interface variable that is static and final for specify
    * the {@code type} of the plugin this interface would provide.
@@ -125,5 +128,12 @@ public interface Directive extends Executor<List<Row>, List<Row>>, EntityMetrics
   default List<EntityCountMetric> getCountMetrics() {
     // no op
     return null;
+  }
+
+  @Override
+  default Relation transform(RelationalTranformContext relationalTranformContext,
+      Relation relation) {
+    // no-op
+    return relation;
   }
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/DirectiveRelationalTransform.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/DirectiveRelationalTransform.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api;
+
+import io.cdap.cdap.etl.api.relational.InvalidRelation;
+import io.cdap.cdap.etl.api.relational.LinearRelationalTransform;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
+
+/**
+ * {@link DirectiveRelationalTransform} provides relational transform support for
+ * wrangler directives.
+ */
+public interface DirectiveRelationalTransform extends LinearRelationalTransform {
+
+  /**
+   * Implementation of linear relational transform for each supported directive.
+   *
+   * @param relationalTranformContext transformation context with engine, input and output parameters
+   * @param relation input relation upon which the transformation is applied.
+   * @return transformed relation as the output relation. By default, returns an Invalid relation
+   * for unsupported directives.
+   */
+  default Relation transform(RelationalTranformContext relationalTranformContext,
+      Relation relation) {
+    return new InvalidRelation("SQL execution for the directive is currently not supported.");
+  }
+
+  /**
+   * Indicates whether the directive is supported by relational transformation or not.
+   *
+   * @return boolean value for the directive SQL support.
+   * By default, returns false, indicating that the directive is currently not supported.
+   */
+  default boolean isSQLSupported() {
+    return false;
+  }
+
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/column/Drop.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/column/Drop.java
@@ -19,6 +19,8 @@ package io.cdap.directives.column;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 import io.cdap.wrangler.api.Arguments;
 import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.DirectiveExecutionException;
@@ -87,5 +89,19 @@ public class Drop implements Directive, Lineage {
       .readable("Dropped columns %s", columns)
       .drop(Many.of(columns))
       .build();
+  }
+
+  @Override
+  public Relation transform(RelationalTranformContext relationalTranformContext,
+      Relation relation) {
+    for (String col: columns) {
+      relation = relation.dropColumn(col);
+    }
+    return relation;
+  }
+
+  @Override
+  public boolean isSQLSupported() {
+    return true;
   }
 }

--- a/wrangler-transform/widgets/Wrangler-transform.json
+++ b/wrangler-transform/widgets/Wrangler-transform.json
@@ -38,6 +38,25 @@
           }
         },
         {
+          "widget-type": "radio-group",
+          "name": "sqlExecution",
+          "label": "Enable SQL Execution",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "no",
+            "options": [
+              {
+                "id": "yes",
+                "label": "Yes"
+              },
+              {
+                "id": "no",
+                "label": "No"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Precondition (JEXL)",
           "name": "precondition",
@@ -49,8 +68,8 @@
           "widget-type": "textbox",
           "label": "Precondition (SQL)",
           "name": "preconditionSQL",
-          "widget-attributes" : {
-            "default" : "false"
+          "widget-attributes": {
+            "default": "true"
           }
         }
       ]
@@ -106,9 +125,33 @@
   "emit-errors": true,
   "filters": [
     {
+      "name": "executionSQLEnabled",
+      "condition": {
+        "expression": "featureFlags['wrangler.execution.sql.enabled'] == true"
+      },
+      "show": [
+        {
+          "type": "properties",
+          "name": "sqlExecution"
+        }
+      ]
+    },
+    {
+      "name": "SQLExecutionDisabledPreconditionEnabled",
+      "condition": {
+        "expression": "featureFlags['wrangler.precondition.sql.enabled'] == true && featureFlags['wrangler.execution.sql.enabled'] == false"
+      },
+      "show": [
+        {
+          "type": "properties",
+          "name": "expressionLanguage"
+        }
+      ]
+    },
+    {
       "name": "PreconditionValueNotSQL",
       "condition": {
-        "expression": "expressionLanguage != 'sql'"
+        "expression": "expressionLanguage == 'jexl' && sqlExecution == 'no'"
       },
       "show": [
         {
@@ -120,24 +163,12 @@
     {
       "name": "preconditionValueSQL",
       "condition": {
-        "expression": "expressionLanguage == 'sql'"
+        "expression": "expressionLanguage == 'sql' || sqlExecution == 'yes'"
       },
       "show": [
         {
           "type": "properties",
           "name": "preconditionSQL"
-        }
-      ]
-    },
-    {
-      "name": "preconditionSQLEnabled",
-      "condition": {
-        "expression": "featureFlags['wrangler.precondition.sql.enabled'] == true"
-      },
-      "show": [
-        {
-          "type": "properties",
-          "name": "expressionLanguage"
         }
       ]
     }


### PR DESCRIPTION
This PR is responsible for the following:
1. Adding the initial setup for the SQL Execution support for Wrangler Directives using CDAP's relational API
2. Adding a UI toggle to enable this SQL Execution of directives

This includes implementation of sql support of `drop` directive as an example. Once this is merged, the SQL support for other directives can be extended in a similar way