### PR TITLE
fix github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -57,4 +57,4 @@ jobs:
         with:
           # GITHUB_TOKEN
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit: ${{ github.event.workflow_run.head_branch }}
+          commit: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
- Github action workflow is failing on PRs from external contributors.
- Need to fix similarly to https://github.com/data-integrations/google-cloud/blob/1c03c8b31f6e91e5b0a1869cc798616b075bd5e9/.github/workflows/build.yml#L35