### PR TITLE
Bump snapshot version for Wrangler 4.8 submodules

### DIFF
--- a/wrangler-api/pom.xml
+++ b/wrangler-api/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.8.2</version>
+    <version>4.8.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.8.2</version>
+    <version>4.8.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-proto/pom.xml
+++ b/wrangler-proto/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.8.2</version>
+    <version>4.8.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.8.2</version>
+    <version>4.8.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-storage/pom.xml
+++ b/wrangler-storage/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.8.2</version>
+    <version>4.8.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-test/pom.xml
+++ b/wrangler-test/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.8.2</version>
+    <version>4.8.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wrangler-transform/pom.xml
+++ b/wrangler-transform/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>wrangler</artifactId>
     <groupId>io.cdap.wrangler</groupId>
-    <version>4.8.2</version>
+    <version>4.8.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Bump snapshot version for Wrangler 4.8 submodules from 4.8.2 to 4.8.3-SNAPSHOT.