### PR TITLE
[PLUGIN-1778] Add schema management to remote task execution flow in Wrangler service

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/RemoteDirectiveResponse.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/RemoteDirectiveResponse.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.wrangler.api;
+
+import io.cdap.cdap.api.data.schema.Schema;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Response after executing directives remotely
+ * Please make sure all fields are registered with {@link io.cdap.wrangler.utils.KryoSerializer}
+ */
+public class RemoteDirectiveResponse implements Serializable {
+    private final List<Row> rows;
+    private final Schema outputSchema;
+
+    /**
+     * Only used by {@link io.cdap.wrangler.utils.KryoSerializer}
+    **/
+    private RemoteDirectiveResponse() {
+        this(null, null);
+    }
+
+    public RemoteDirectiveResponse(List<Row> rows, Schema outputSchema) {
+        this.rows = rows;
+        this.outputSchema = outputSchema;
+    }
+
+    public List<Row> getRows() {
+        return rows;
+    }
+
+    public Schema getOutputSchema() {
+        return outputSchema;
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/schema/TransientStoreKeys.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/schema/TransientStoreKeys.java
@@ -18,6 +18,7 @@ package io.cdap.wrangler.schema;
 
 /**
  * TransientStoreKeys for storing Workspace schema in TransientStore
+ * NOTE: Please add any needed value in {@link io.cdap.wrangler.api.RemoteDirectiveResponse}
  */
 public final class TransientStoreKeys {
   public static final String INPUT_SCHEMA = "ws_input_schema";

--- a/wrangler-core/src/main/java/io/cdap/wrangler/utils/SchemaConverter.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/utils/SchemaConverter.java
@@ -19,7 +19,6 @@ package io.cdap.wrangler.utils;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.data.schema.Schema.Field;
@@ -100,7 +99,7 @@ public final class SchemaConverter {
    * @param name name of the field
    * @param recordPrefix prefix to append at the beginning of a custom record
    * @return the schema of this object
-   * NOTE: ANY NEWLY SUPPORTED DATATYPE SHOULD ALSO BE REGISTERED IN {@link RowSerializer}
+   * NOTE: ANY NEWLY SUPPORTED DATATYPE SHOULD ALSO BE REGISTERED IN {@link KryoSerializer}
    */
   @Nullable
   public Schema getSchema(Object value, String name, @Nullable String recordPrefix) throws RecordConvertorException {

--- a/wrangler-core/src/test/java/io/cdap/wrangler/utils/ObjectSerDeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/utils/ObjectSerDeTest.java
@@ -17,6 +17,8 @@
 package io.cdap.wrangler.utils;
 
 import com.google.common.base.Charsets;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.wrangler.api.RemoteDirectiveResponse;
 import io.cdap.wrangler.api.Row;
 import org.junit.Assert;
 import org.junit.Test;
@@ -84,5 +86,21 @@ public class ObjectSerDeTest {
     bytes = objectSerDe.toByteArray(expectedRows);
     actualRows = objectSerDe.toObject(bytes);
     Assert.assertEquals(expectedRows.size(), actualRows.size());
+  }
+  @Test
+  public void testRemoteDirectiveResponseSerDe() throws Exception {
+    List<Row> expectedRows = new ArrayList<>();
+    Row firstRow = new Row();
+    firstRow.add("id", 1);
+    expectedRows.add(firstRow);
+    Schema expectedSchema = Schema.recordOf(Schema.Field.of("id", Schema.of(Schema.Type.INT)));
+    RemoteDirectiveResponse expectedResponse = new RemoteDirectiveResponse(expectedRows, expectedSchema);
+    ObjectSerDe<RemoteDirectiveResponse> objectSerDe = new ObjectSerDe<>();
+
+    byte[] bytes = objectSerDe.toByteArray(expectedResponse);
+    RemoteDirectiveResponse actualResponse = objectSerDe.toObject(bytes);
+
+    Assert.assertEquals(expectedResponse.getRows().size(), actualResponse.getRows().size());
+    Assert.assertEquals(expectedResponse.getOutputSchema(), actualResponse.getOutputSchema());
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RemoteDirectiveRequest.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RemoteDirectiveRequest.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.wrangler.service.directive;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.wrangler.parser.DirectiveClass;
 
 import java.util.HashMap;
@@ -29,13 +30,15 @@ public class RemoteDirectiveRequest {
   private final Map<String, DirectiveClass> systemDirectives;
   private final String pluginNameSpace;
   private final byte[] data;
+  private final Schema inputSchema;
 
   RemoteDirectiveRequest(String recipe, Map<String, DirectiveClass> systemDirectives,
-                         String pluginNameSpace, byte[] data) {
+                         String pluginNameSpace, byte[] data, Schema inputSchema) {
     this.recipe = recipe;
     this.systemDirectives = new HashMap<>(systemDirectives);
     this.pluginNameSpace = pluginNameSpace;
     this.data = data;
+    this.inputSchema = inputSchema;
   }
 
   public String getRecipe() {
@@ -52,5 +55,9 @@ public class RemoteDirectiveRequest {
 
   public String getPluginNameSpace() {
     return pluginNameSpace;
+  }
+
+  public Schema getInputSchema() {
+    return inputSchema;
   }
 }


### PR DESCRIPTION
## Changes
- Add new inputSchema field to `RemoteDirectiveRequest`
- Set the inputSchema obtained from request in `TransientStore` created in `RemoteExecutionTask`
- Add a new `RemoteDirectiveResponse` class that wraps the output rows and output schema together for returning from RemoteExecutionTask