### PR TITLE
CDAP-21024: Return null when there is no outputfield

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/wrangler/schema/DirectiveOutputSchemaGenerator.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/schema/DirectiveOutputSchemaGenerator.java
@@ -103,6 +103,9 @@ public class DirectiveOutputSchemaGenerator {
         outputFields.add(Schema.Field.of(fieldName, Schema.of(Schema.Type.NULL)));
       }
     }
+    if (outputFields.isEmpty()) {
+      return null;
+    }
     return Schema.recordOf("output", outputFields);
   }
 


### PR DESCRIPTION
`io.cdap.wrangler.schema.DirectiveOutputSchemaGenerator#generateDirectiveOutputSchema` was trying to process empty `outputFieldMap`. 
This can happen when there is a failure to process a directive or there is no filed ( when all columns are dropped
Rather than trying to create a schema from empty list of records we are returning null.