### PR TITLE
Wrangler connection step changes

### DIFF
--- a/wrangler-transform/src/e2e-test/features/WranglerUI/DataTypeParsers.feature
+++ b/wrangler-transform/src/e2e-test/features/WranglerUI/DataTypeParsers.feature
@@ -15,7 +15,7 @@
 @Wrangler_Required
 Feature:  Runtime Scenarios for datatype parsers
 
-  @BQ_SOURCE_TS_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST
+  @BQ_SOURCE_TS_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST @BQ_CONNECTION
   Scenario: To verify User is able to run a pipeline using parse timestamp directive
     Given Open Wrangler connections page
     Then Click plugin property: "addConnection" button

--- a/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsCsv.feature
+++ b/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsCsv.feature
@@ -15,7 +15,7 @@
 @Wrangler
 Feature:  Wrangler - Run time scenarios for parse csv using UI
 
-  @BQ_SOURCE_CSV_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST
+  @BQ_SOURCE_CSV_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST @BQ_CONNECTION
   Scenario: To verify User is able to run a pipeline using parse csv directive
     Given Open Wrangler connections page
     Then Click plugin property: "addConnection" button

--- a/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsExcel.feature
+++ b/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsExcel.feature
@@ -15,7 +15,7 @@
 @Wrangler
 Feature:  Parse as excel
 
-  @BQ_SINK_TEST
+  @BQ_SINK_TEST @BQ_CONNECTION
   Scenario: To verify User is able to run a pipeline using parse Excel directive
     Given Open Wrangler connections page
     Then Click plugin property: "addConnection" button

--- a/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsFixedLength.feature
+++ b/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsFixedLength.feature
@@ -15,7 +15,7 @@
 @Wrangler_Required
 Feature:  parse as fixed length
 
-  @BQ_SOURCE_FXDLEN_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST
+  @BQ_SOURCE_FXDLEN_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST @BQ_CONNECTION
   Scenario: To verify User is able to run a pipeline using parse fixedlength directive
     Given Open Wrangler connections page
     Then Click plugin property: "addConnection" button

--- a/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsHl7.feature
+++ b/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsHl7.feature
@@ -15,7 +15,7 @@
 @Wrangler
 Feature:  parse as HL7
 
-  @BQ_SOURCE_HL7_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST
+  @BQ_SOURCE_HL7_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST @BQ_CONNECTION
   Scenario: To verify User is able to run a pipeline using parse hl7 directive
     Given Open Wrangler connections page
     Then Click plugin property: "addConnection" button

--- a/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsJson.feature
+++ b/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsJson.feature
@@ -15,7 +15,7 @@
 @Wrangler
 Feature:  parse as Json
 
-  @BQ_SOURCE_JSON_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST
+  @BQ_SOURCE_JSON_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST @BQ_CONNECTION
   Scenario: To verify User is able to run a pipeline using parse Json directive
     Given Open Wrangler connections page
     Then Click plugin property: "addConnection" button

--- a/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsLog.feature
+++ b/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsLog.feature
@@ -15,7 +15,7 @@
 @Wrangler
 Feature:  Wrangler - Run time scenarios for Parse Log
 
-  @BQ_SOURCE_LOG_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST
+  @BQ_SOURCE_LOG_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST @BQ_CONNECTION
   Scenario: To verify User is able to run a pipeline using parse log directive
     Given Open Wrangler connections page
     Then Click plugin property: "addConnection" button

--- a/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsXmlToJson.feature
+++ b/wrangler-transform/src/e2e-test/features/WranglerUI/ParseAsXmlToJson.feature
@@ -15,7 +15,7 @@
 @Wrangler
 Feature:  parse as XmlToJson
 
-  @BQ_SOURCE_XML_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST
+  @BQ_SOURCE_XML_TEST @BQ_SOURCE_TEST @BQ_SINK_TEST @BQ_CONNECTION
   Scenario: To verify User is able to run a pipeline using parse XmlToJson directive
     Given Open Wrangler connections page
     Then Click plugin property: "addConnection" button

--- a/wrangler-transform/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
+++ b/wrangler-transform/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
@@ -219,4 +219,9 @@ public class TestSetupHooks {
     PluginPropertyUtils.addPluginProp("bqSourceTable", bqSourceTable);
     BeforeActions.scenario.write("BQ Source Table " + bqSourceTable + " created successfully");
   }
+
+  @Before(order = 1, value = "@BQ_CONNECTION")
+  public static void setBQConnectionName() {
+    PluginPropertyUtils.addPluginProp("bqConnectionName", "BQ-" + UUID.randomUUID());
+  }
 }


### PR DESCRIPTION
This PR contains changes for creating a BigQuery connection name with a UUID rather than a constant name in wrangler runtime scenarios.