### PR TITLE
[PLUGIN-1856] Error management for Wrangler plugin

### DIFF
--- a/wrangler-transform/src/main/java/io/cdap/wrangler/WranglerErrorUtil.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/WranglerErrorUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
+import io.cdap.cdap.api.exception.ProgramFailureException;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveLoadException;
+import io.cdap.wrangler.api.DirectiveNotFoundException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.RecipeException;
+import io.cdap.wrangler.expression.ELException;
+import io.cdap.wrangler.utils.RecordConvertorException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Error util file to handle exceptions caught in Wrangler plugin
+ */
+public final class WranglerErrorUtil {
+
+
+  private static final Map<String, String> TERMINAL_EXCEPTIONS = ImmutableMap.<String, String>builder()
+      .put(DirectiveParseException.class.getName(), "Parsing-Directive")
+      .put(PreconditionException.class.getName(), "Precondition")
+      .put(DirectiveExecutionException.class.getName(), "Executing-Directive")
+      .put(DirectiveLoadException.class.getName(), "Loading-Directive")
+      .put(DirectiveNotFoundException.class.getName(), "Directive-Not-Found")
+      .put(RecordConvertorException.class.getName(), "Record-Conversion")
+      .put(ELException.class.getName(), "ExpressionLanguage-Parsing").build();
+
+  private static final Map<String, String> NON_TERMINAL_EXCEPTIONS = ImmutableMap.<String, String>builder()
+      .put(RecipeException.class.getName(), "Executing-Recipe").build();
+
+  /**
+   * Private constructor to prevent instantiation of this utility class.
+   * <p>
+   * This class is designed to contain only static utility methods for handling exceptions and
+   * should not be instantiated. Any attempt to create an instance of this class will result in an
+   * {@link IllegalStateException}.
+   */
+  private WranglerErrorUtil() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  /**
+   * Traverses the causal chain of the given Throwable to find specific exceptions. If a terminal
+   * exception is found, it returns a corresponding ProgramFailureException. If a non-terminal
+   * exception is found, it is stored as a fallback. Otherwise, a generic ProgramFailureException is
+   * returned.
+   *
+   * @param e            the Throwable to analyze
+   * @param errorReason  the error reason to tell the cause of error
+   * @param errorMessage default error message if no terminal exception is found
+   * @param errorType    the error type to categorize the failure
+   * @return a ProgramFailureException with specific or generic error details
+   */
+  public static ProgramFailureException getProgramFailureExceptionDetailsFromChain(Throwable e,
+      String errorReason, String errorMessage, ErrorType errorType) {
+    List<Throwable> causalChain = Throwables.getCausalChain(e);
+    Throwable nonTerminalException = null;
+    for (Throwable t : causalChain) {
+      if (t instanceof ProgramFailureException) {
+        return null; // Avoid multiple wrap
+      }
+      if (NON_TERMINAL_EXCEPTIONS.containsKey(t.getClass().getName())) {
+        nonTerminalException = t; // Store non-terminal exception as fallback
+        continue;
+      }
+      String errorSubCategory = TERMINAL_EXCEPTIONS.get(t.getClass().getName());
+      if (errorSubCategory != null) {
+        return getProgramFailureException(t, errorReason, errorSubCategory);
+      }
+    }
+
+    if (nonTerminalException != null) {
+      return getProgramFailureException(nonTerminalException, errorReason,
+          NON_TERMINAL_EXCEPTIONS.get(nonTerminalException.getClass().getName()));
+    }
+
+    return ErrorUtils.getProgramFailureException(
+        new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN), errorReason, errorMessage,
+        errorType, false, e);
+  }
+
+  /**
+   * Constructs a ProgramFailureException using the provided exception details.
+   *
+   * @param exception        the exception to wrap
+   * @param errorSubCategory specific subcategory of the error
+   * @return a new ProgramFailureException with the extracted details
+   */
+  private static ProgramFailureException getProgramFailureException(Throwable exception,
+      String errorReason, String errorSubCategory) {
+    String errorMessage = exception.getMessage();
+    return ErrorUtils.getProgramFailureException(
+        new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN, errorSubCategory), errorReason,
+        errorMessage, ErrorType.USER, false, exception);
+  }
+}


### PR DESCRIPTION
https://cdap.atlassian.net/browse/PLUGIN-1856


![image](https://github.com/user-attachments/assets/c22d2511-8d8d-4689-b357-47c1e8f4bf34)



```json
[
  {
    "stageName": "Wrangler",
    "errorCategory": "Plugin-'Wrangler'",
    "errorReason": "Error in stage 'Wrangler'. Format of output schema specified is invalid. Please check the format. com.google.gson.stream.MalformedJsonException: Unterminated object at line 3 column 4 path $.type",
    "errorMessage": "Error in stage 'Wrangler'. Format of output schema specified is invalid. Please check the format. com.google.gson.stream.MalformedJsonException: Unterminated object at line 3 column 4 path $.type",
    "errorType": "USER",
    "dependency": "false"
  }
]

```


```
2025-01-30 12:36:48,237 - ERROR [spark-submitter-phase-1-bfc7d018-ded8-11ef-8496-0000009adf90:o.a.s.i.i.SparkHadoopWriter@98] - Aborting job job_202501301236463168859500037448187_0005.
org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0) (192.168.1.100 executor driver): org.apache.spark.SparkException: Task failed while writing rows
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:163)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.util.concurrent.ExecutionException: Error when transforming stage Wrangler: com.google.common.util.concurrent.UncheckedExecutionException: io.cdap.cdap.api.exception.WrappedStageException: Stage 'Wrangler' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error in stage 'Wrangler'. Format of output schema specified is invalid. Please check the format. com.google.gson.stream.MalformedJsonException: Unterminated object at line 3 column 4 path $.type
	at io.cdap.cdap.etl.spark.function.TransformFunction.call(TransformFunction.java:61)
	at org.apache.spark.api.java.JavaRDDLike.$anonfun$flatMap$1(JavaRDDLike.scala:125)
	at scala.collection.Iterator$$anon$11.nextCur(Iterator.scala:486)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:492)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:491)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:491)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$1(SparkHadoopWriter.scala:136)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1538)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	... 9 more
```


```
Loading Directive exception:
```
![image](https://github.com/user-attachments/assets/6b548f34-a05f-4fbf-bc1a-8f39b091cace)
![image](https://github.com/user-attachments/assets/48a89690-85cb-47e2-9b9f-c262d633c591)

```
Precondition excdeption:
```
![Screenshot from 2025-02-10 10-45-02](https://github.com/user-attachments/assets/a04722dd-7652-436d-ac96-3b16d647ec88)


```
Directive Parsing Exception
```
![Screenshot from 2025-02-10 11-02-06](https://github.com/user-attachments/assets/0431ba9c-772e-44f0-b444-8eb07f06ed5f)

```
RecordConvertorException
```
![Screenshot from 2025-02-10 13-05-49](https://github.com/user-attachments/assets/2fcd1709-bb06-4514-90e3-0d6b7cabec23)



