### PR TITLE
Add ByteSize and TimeDuration tokens with aggregate-stats directive

### DIFF
--- a/ByteSize_temp.java
+++ b/ByteSize_temp.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The ByteSize class represents a size in bytes with support for various units
+ * (B, KB, MB, GB, TB).
+ * It implements the Token interface for use in the wrangler parser system.
+ */
+@PublicEvolving
+public class ByteSize implements Token {
+    private static final Pattern BYTE_SIZE_PATTERN = Pattern.compile("^(\\d+(?:\\.\\d+)?)(B|KB|MB|GB|TB)$",
+            Pattern.CASE_INSENSITIVE);
+    private final String value;
+    private final long bytes;
+
+    /**
+     * Creates a new ByteSize instance from a string representation.
+     *
+     * @param value The string representation of the byte size (e.g., "1KB",
+     *              "1.5MB", "2GB")
+     * @throws IllegalArgumentException if the value is not in a valid format
+     */
+    public ByteSize(String value) {
+        this.value = value;
+        this.bytes = parseBytes(value);
+    }
+
+    /**
+     * Parses the string representation into bytes.
+     *
+     * @param value The string to parse
+     * @return The number of bytes
+     * @throws IllegalArgumentException if the value is not in a valid format
+     */
+    private long parseBytes(String value) {
+        Matcher matcher = BYTE_SIZE_PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid byte size format: " + value);
+        }
+
+        double number = Double.parseDouble(matcher.group(1));
+        String unit = matcher.group(2).toUpperCase();
+
+        switch (unit) {
+            case "B":
+                return (long) number;
+            case "KB":
+                return (long) (number * 1024);
+            case "MB":
+                return (long) (number * 1024 * 1024);
+            case "GB":
+                return (long) (number * 1024 * 1024 * 1024);
+            case "TB":
+                return (long) (number * 1024 * 1024 * 1024 * 1024);
+            default:
+                throw new IllegalArgumentException("Unsupported unit: " + unit);
+        }
+    }
+
+    /**
+     * Gets the number of bytes represented by this ByteSize.
+     *
+     * @return The number of bytes
+     */
+    public long getBytes() {
+        return bytes;
+    }
+
+    /**
+     * Gets the size in kilobytes.
+     *
+     * @return The size in kilobytes
+     */
+    public double getKilobytes() {
+        return bytes / 1024.0;
+    }
+
+    /**
+     * Gets the size in megabytes.
+     *
+     * @return The size in megabytes
+     */
+    public double getMegabytes() {
+        return bytes / (1024.0 * 1024.0);
+    }
+
+    /**
+     * Gets the size in gigabytes.
+     *
+     * @return The size in gigabytes
+     */
+    public double getGigabytes() {
+        return bytes / (1024.0 * 1024.0 * 1024.0);
+    }
+
+    /**
+     * Gets the size in terabytes.
+     *
+     * @return The size in terabytes
+     */
+    public double getTerabytes() {
+        return bytes / (1024.0 * 1024.0 * 1024.0 * 1024.0);
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.BYTE_SIZE.name());
+        object.addProperty("value", value);
+        return object;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ cleansing, transformation, and filtering using a set of data manipulation instru
 (directives). These instructions are either generated using an interative visual tool or
 are manually created.
 
-  * Data Prep defines few concepts that might be useful if you are just getting started with it. Learn about them [here](wrangler-docs/concepts.md)
-  * The Data Prep Transform is [separately documented](wrangler-transform/wrangler-docs/data-prep-transform.md).
-  * [Data Prep Cheatsheet](wrangler-docs/cheatsheet.md)
+- Data Prep defines few concepts that might be useful if you are just getting started with it. Learn about them [here](wrangler-docs/concepts.md)
+- The Data Prep Transform is [separately documented](wrangler-transform/wrangler-docs/data-prep-transform.md).
+- [Data Prep Cheatsheet](wrangler-docs/cheatsheet.md)
 
 ## New Features
 
 More [here](wrangler-docs/upcoming-features.md) on upcoming features.
 
-  * **User Defined Directives, also known as UDD**, allow you to create custom functions to transform records within CDAP DataPrep or a.k.a Wrangler. CDAP comes with a comprehensive library of functions. There are however some omissions, and some specific cases for which UDDs are the solution. Additional information on how you can build your custom directives [here](wrangler-docs/custom-directive.md).
-    * Migrating directives from version 1.0 to version 2.0 [here](wrangler-docs/directive-migration.md)
-    * Information about Grammar [here](wrangler-docs/grammar/grammar-info.md)
-    * Various `TokenType` supported by system [here](../api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java)
-    * Custom Directive Implementation Internals [here](wrangler-docs/udd-internal.md)
+- **User Defined Directives, also known as UDD**, allow you to create custom functions to transform records within CDAP DataPrep or a.k.a Wrangler. CDAP comes with a comprehensive library of functions. There are however some omissions, and some specific cases for which UDDs are the solution. Additional information on how you can build your custom directives [here](wrangler-docs/custom-directive.md).
 
-  * A new capability that allows CDAP Administrators to **restrict the directives** that are accessible to their users.
-More information on configuring can be found [here](wrangler-docs/exclusion-and-aliasing.md)
+  - Migrating directives from version 1.0 to version 2.0 [here](wrangler-docs/directive-migration.md)
+  - Information about Grammar [here](wrangler-docs/grammar/grammar-info.md)
+  - Various `TokenType` supported by system [here](../api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java)
+  - Custom Directive Implementation Internals [here](wrangler-docs/udd-internal.md)
+
+- A new capability that allows CDAP Administrators to **restrict the directives** that are accessible to their users.
+  More information on configuring can be found [here](wrangler-docs/exclusion-and-aliasing.md)
 
 ## Demo Videos and Recipes
 
@@ -37,144 +38,145 @@ Videos and Screencasts are best way to learn, so we have compiled simple, short 
 
 ### Videos
 
-  * [SCREENCAST] [Creating Lookup Dataset and Joining](https://www.youtube.com/watch?v=Nc1b0rsELHQ)
-  * [SCREENCAST] [Restricted Directives](https://www.youtube.com/watch?v=71EcMQU714U)
-  * [SCREENCAST] [Parse Excel files in CDAP](https://www.youtube.com/watch?v=su5L1noGlEk)
-  * [SCREENCAST] [Parse File As AVRO File](https://www.youtube.com/watch?v=tmwAw4dKUNc)
-  * [SCREENCAST] [Parsing Binary Coded AVRO Messages](https://www.youtube.com/watch?v=Ix_lPo-PDJY)
-  * [SCREENCAST] [Parsing Binary Coded AVRO Messages & Protobuf messages using schema registry](https://www.youtube.com/watch?v=LVLIdWnUX1k)
-  * [SCREENCAST] [Quantize a column - Digitize](https://www.youtube.com/watch?v=VczkYX5SRtY)
-  * [SCREENCAST] [Data Cleansing capability with send-to-error directive](https://www.youtube.com/watch?v=aZd5H8hIjDc)
-  * [SCREENCAST] [Building Data Prep from the GitHub source](https://youtu.be/pGGjKU04Y38)
-  * [VOICE-OVER] [End-to-End Demo Video](https://youtu.be/AnhF0qRmn24)
-  * [SCREENCAST] [Ingesting into Kudu](https://www.youtube.com/watch?v=KBW7a38vlUM)
-  * [SCREENCAST] [Realtime HL7 CCDA XML from Kafka into Time Parititioned Parquet](https://youtu.be/0fqNmnOnD-0)
-  * [SCREENCAST] [Parsing JSON file](https://youtu.be/vwnctcGDflE)
-  * [SCREENCAST] [Flattening arrays](https://youtu.be/SemHxgBYIsY)
-  * [SCREENCAST] [Data cleansing with send-to-error directive](https://www.youtube.com/watch?v=aZd5H8hIjDc)
-  * [SCREENCAST] [Publishing to Kafka](https://www.youtube.com/watch?v=xdc8pvvlI48)
-  * [SCREENCAST] [Fixed length to JSON](https://www.youtube.com/watch?v=3AXu4m1swuM)
+- [SCREENCAST] [Creating Lookup Dataset and Joining](https://www.youtube.com/watch?v=Nc1b0rsELHQ)
+- [SCREENCAST] [Restricted Directives](https://www.youtube.com/watch?v=71EcMQU714U)
+- [SCREENCAST] [Parse Excel files in CDAP](https://www.youtube.com/watch?v=su5L1noGlEk)
+- [SCREENCAST] [Parse File As AVRO File](https://www.youtube.com/watch?v=tmwAw4dKUNc)
+- [SCREENCAST] [Parsing Binary Coded AVRO Messages](https://www.youtube.com/watch?v=Ix_lPo-PDJY)
+- [SCREENCAST] [Parsing Binary Coded AVRO Messages & Protobuf messages using schema registry](https://www.youtube.com/watch?v=LVLIdWnUX1k)
+- [SCREENCAST] [Quantize a column - Digitize](https://www.youtube.com/watch?v=VczkYX5SRtY)
+- [SCREENCAST] [Data Cleansing capability with send-to-error directive](https://www.youtube.com/watch?v=aZd5H8hIjDc)
+- [SCREENCAST] [Building Data Prep from the GitHub source](https://youtu.be/pGGjKU04Y38)
+- [VOICE-OVER] [End-to-End Demo Video](https://youtu.be/AnhF0qRmn24)
+- [SCREENCAST] [Ingesting into Kudu](https://www.youtube.com/watch?v=KBW7a38vlUM)
+- [SCREENCAST] [Realtime HL7 CCDA XML from Kafka into Time Parititioned Parquet](https://youtu.be/0fqNmnOnD-0)
+- [SCREENCAST] [Parsing JSON file](https://youtu.be/vwnctcGDflE)
+- [SCREENCAST] [Flattening arrays](https://youtu.be/SemHxgBYIsY)
+- [SCREENCAST] [Data cleansing with send-to-error directive](https://www.youtube.com/watch?v=aZd5H8hIjDc)
+- [SCREENCAST] [Publishing to Kafka](https://www.youtube.com/watch?v=xdc8pvvlI48)
+- [SCREENCAST] [Fixed length to JSON](https://www.youtube.com/watch?v=3AXu4m1swuM)
 
 ### Recipes
 
-  * [Parsing Apache Log Files](wrangler-demos/parsing-apache-log-files.md)
-  * [Parsing CSV Files and Extracting Column Values](wrangler-demos/parsing-csv-extracting-column-values.md)
-  * [Parsing HL7 CCDA XML Files](wrangler-demos/parsing-hl7-ccda-xml-files.md)
+- [Parsing Apache Log Files](wrangler-demos/parsing-apache-log-files.md)
+- [Parsing CSV Files and Extracting Column Values](wrangler-demos/parsing-csv-extracting-column-values.md)
+- [Parsing HL7 CCDA XML Files](wrangler-demos/parsing-hl7-ccda-xml-files.md)
 
 ## Available Directives
 
 These directives are currently available:
 
-| Directive                                                              | Description                                                      |
-| ---------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| **Parsers**                                                            |                                                                  |
-| [JSON Path](wrangler-docs/directives/json-path.md)                              | Uses a DSL (a JSON path expression) for parsing JSON records     |
-| [Parse as AVRO](wrangler-docs/directives/parse-as-avro.md)                      | Parsing an AVRO encoded message - either as binary or json       |
-| [Parse as AVRO File](wrangler-docs/directives/parse-as-avro-file.md)            | Parsing an AVRO data file                                        |
-| [Parse as CSV](wrangler-docs/directives/parse-as-csv.md)                        | Parsing an input record as comma-separated values                |
-| [Parse as Date](wrangler-docs/directives/parse-as-date.md)                      | Parsing dates using natural language processing                  |
-| [Parse as Excel](wrangler-docs/directives/parse-as-excel.md)                    | Parsing excel file.                                              |
-| [Parse as Fixed Length](wrangler-docs/directives/parse-as-fixed-length.md)      | Parses as a fixed length record with specified widths            |
-| [Parse as HL7](wrangler-docs/directives/parse-as-hl7.md)                        | Parsing Health Level 7 Version 2 (HL7 V2) messages               |
-| [Parse as JSON](wrangler-docs/directives/parse-as-json.md)                      | Parsing a JSON object                                            |
-| [Parse as Log](wrangler-docs/directives/parse-as-log.md)                        | Parses access log files as from Apache HTTPD and nginx servers   |
-| [Parse as Protobuf](wrangler-docs/directives/parse-as-log.md)                   | Parses an Protobuf encoded in-memory message using descriptor    |
-| [Parse as Simple Date](wrangler-docs/directives/parse-as-simple-date.md)        | Parses date strings                                              |
-| [Parse XML To JSON](wrangler-docs/directives/parse-xml-to-json.md)              | Parses an XML document into a JSON structure                     |
-| [Parse as Currency](wrangler-docs/directives/parse-as-currency.md)              | Parses a string representation of currency into a number.        |
-| [Parse as Datetime](wrangler-docs/directives/parse-as-datetime.md)              | Parses strings with datetime values to CDAP datetime type        |
-| **Output Formatters**                                                  |                                                                  |
-| [Write as CSV](wrangler-docs/directives/write-as-csv.md)                        | Converts a record into CSV format                                |
-| [Write as JSON](wrangler-docs/directives/write-as-json-map.md)                  | Converts the record into a JSON map                              |
-| [Write JSON Object](wrangler-docs/directives/write-as-json-object.md)           | Composes a JSON object based on the fields specified.            |
-| [Format as Currency](wrangler-docs/directives/format-as-currency.md)            | Formats a number as currency as specified by locale.             |
-| **Transformations**                                                    |                                                                  |
-| [Changing Case](wrangler-docs/directives/changing-case.md)                      | Changes the case of column values                                |
-| [Cut Character](wrangler-docs/directives/cut-character.md)                      | Selects parts of a string value                                  |
-| [Set Column](wrangler-docs/directives/set-column.md)                            | Sets the column value to the result of an expression execution   |
-| [Find and Replace](wrangler-docs/directives/find-and-replace.md)                | Transforms string column values using a "sed"-like expression    |
-| [Index Split](wrangler-docs/directives/index-split.md)                          | (_Deprecated_)                                                   |
-| [Invoke HTTP](wrangler-docs/directives/invoke-http.md)                          | Invokes an HTTP Service (_Experimental_, potentially slow)       |
-| [Quantization](wrangler-docs/directives/quantize.md)                            | Quantizes a column based on specified ranges                     |
-| [Regex Group Extractor](wrangler-docs/directives/extract-regex-groups.md)       | Extracts the data from a regex group into its own column         |
-| [Setting Character Set](wrangler-docs/directives/set-charset.md)                | Sets the encoding and then converts the data to a UTF-8 String   |
-| [Setting Record Delimiter](wrangler-docs/directives/set-record-delim.md)        | Sets the record delimiter                                        |
-| [Split by Separator](wrangler-docs/directives/split-by-separator.md)            | Splits a column based on a separator into two columns            |
-| [Split Email Address](wrangler-docs/directives/split-email.md)                  | Splits an email ID into an account and its domain                |
-| [Split URL](wrangler-docs/directives/split-url.md)                              | Splits a URL into its constituents                               |
-| [Text Distance (Fuzzy String Match)](wrangler-docs/directives/text-distance.md) | Measures the difference between two sequences of characters      |
-| [Text Metric (Fuzzy String Match)](wrangler-docs/directives/text-metric.md)     | Measures the difference between two sequences of characters      |
-| [URL Decode](wrangler-docs/directives/url-decode.md)                            | Decodes from the `application/x-www-form-urlencoded` MIME format |
-| [URL Encode](wrangler-docs/directives/url-encode.md)                            | Encodes to the `application/x-www-form-urlencoded` MIME format   |
-| [Trim](wrangler-docs/directives/trim.md)                                        | Functions for trimming white spaces around string data           |
-| **Encoders and Decoders**                                              |                                                                  |
-| [Decode](wrangler-docs/directives/decode.md)                                    | Decodes a column value as one of `base32`, `base64`, or `hex`    |
-| [Encode](wrangler-docs/directives/encode.md)                                    | Encodes a column value as one of `base32`, `base64`, or `hex`    |
-| **Unique ID**                                                          |                                                                  |
-| [UUID Generation](wrangler-docs/directives/generate-uuid.md)                    | Generates a universally unique identifier (UUID) .Recommended to use with Wrangler version 4.4.0 and above due to an important bug fix [CDAP-17732](https://cdap.atlassian.net/browse/CDAP-17732)             |
-| **Date Transformations**                                               |                                                                  |
-| [Diff Date](wrangler-docs/directives/diff-date.md)                              | Calculates the difference between two dates                      |
-| [Format Date](wrangler-docs/directives/format-date.md)                          | Custom patterns for date-time formatting                         |
-| [Format Unix Timestamp](wrangler-docs/directives/format-unix-timestamp.md)      | Formats a UNIX timestamp as a date                               |
-| **DateTime Transformations**                                                    |                                                                  |
-| [Current DateTime](wrangler-docs/directives/current-datetime.md)                | Generates the current datetime using the given zone or UTC by default|
-| [Datetime To Timestamp](wrangler-docs/directives/datetime-to-timestamp.md)      | Converts a datetime value to timestamp with the given zone       |
-| [Format Datetime](wrangler-docs/directives/format-datetime.md)                  | Formats a datetime value to custom date time pattern strings     |
-| [Timestamp To Datetime](wrangler-docs/directives/timestamp-to-datetime.md)      | Converts a timestamp value to datetime                           |
-| **Lookups**                                                            |                                                                  |
-| [Catalog Lookup](wrangler-docs/directives/catalog-lookup.md)                    | Static catalog lookup of ICD-9, ICD-10-2016, ICD-10-2017 codes   |
-| [Table Lookup](wrangler-docs/directives/table-lookup.md)                        | Performs lookups into Table datasets                             |
-| **Hashing & Masking**                                                  |                                                                  |
-| [Message Digest or Hash](wrangler-docs/directives/hash.md)                      | Generates a message digest                                       |
-| [Mask Number](wrangler-docs/directives/mask-number.md)                          | Applies substitution masking on the column values                |
-| [Mask Shuffle](wrangler-docs/directives/mask-shuffle.md)                        | Applies shuffle masking on the column values                     |
-| **Row Operations**                                                     |                                                                  |
-| [Filter Row if Matched](wrangler-docs/directives/filter-row-if-matched.md)      | Filters rows that match a pattern for a column                                         |
-| [Filter Row if True](wrangler-docs/directives/filter-row-if-true.md)            | Filters rows if the condition is true.                                                  |
-| [Filter Row Empty of Null](wrangler-docs/directives/filter-empty-or-null.md)    | Filters rows that are empty of null.                    |
-| [Flatten](wrangler-docs/directives/flatten.md)                                  | Separates the elements in a repeated field                       |
-| [Fail on condition](wrangler-docs/directives/fail.md)                           | Fails processing when the condition is evaluated to true.        |
-| [Send to Error](wrangler-docs/directives/send-to-error.md)                      | Filtering of records to an error collector                       |
-| [Send to Error And Continue](wrangler-docs/directives/send-to-error-and-continue.md) | Filtering of records to an error collector and continues processing                      |
-| [Split to Rows](wrangler-docs/directives/split-to-rows.md)                      | Splits based on a separator into multiple records                |
-| **Column Operations**                                                  |                                                                  |
-| [Change Column Case](wrangler-docs/directives/change-column-case.md)            | Changes column names to either lowercase or uppercase            |
-| [Changing Case](wrangler-docs/directives/changing-case.md)                      | Change the case of column values                                 |
-| [Cleanse Column Names](wrangler-docs/directives/cleanse-column-names.md)        | Sanatizes column names, following specific rules                 |
-| [Columns Replace](wrangler-docs/directives/columns-replace.md)                  | Alters column names in bulk                                      |
-| [Copy](wrangler-docs/directives/copy.md)                                        | Copies values from a source column into a destination column     |
-| [Drop Column](wrangler-docs/directives/drop.md)                                 | Drops a column in a record                                       |
-| [Fill Null or Empty Columns](wrangler-docs/directives/fill-null-or-empty.md)    | Fills column value with a fixed value if null or empty           |
-| [Keep Columns](wrangler-docs/directives/keep.md)                                | Keeps specified columns from the record                          |
-| [Merge Columns](wrangler-docs/directives/merge.md)                              | Merges two columns by inserting a third column                   |
-| [Rename Column](wrangler-docs/directives/rename.md)                             | Renames an existing column in the record                         |
-| [Set Column Header](wrangler-docs/directives/set-headers.md)                     | Sets the names of columns, in the order they are specified       |
-| [Split to Columns](wrangler-docs/directives/split-to-columns.md)                | Splits a column based on a separator into multiple columns       |
-| [Swap Columns](wrangler-docs/directives/swap.md)                                | Swaps column names of two columns                                |
-| [Set Column Data Type](wrangler-docs/directives/set-type.md)                    | Convert data type of a column                                    |
-| **NLP**                                                                |                                                                  |
-| [Stemming Tokenized Words](wrangler-docs/directives/stemming.md)                | Applies the Porter stemmer algorithm for English words           |
-| **Transient Aggregators & Setters**                                    |                                                                  |
-| [Increment Variable](wrangler-docs/directives/increment-variable.md)            | Increments a transient variable with a record of processing.     |
-| [Set Variable](wrangler-docs/directives/set-variable.md)                        | Sets a transient variable with a record of processing.     |
-| **Functions**                                                          |                                                                  |
-| [Data Quality](wrangler-docs/functions/dq-functions.md)                         | Data quality check functions. Checks for date, time, etc.        |
-| [Date Manipulations](wrangler-docs/functions/date-functions.md)                 | Functions that can manipulate date                               |
-| [DDL](wrangler-docs/functions/ddl-functions.md)                                 | Functions that can manipulate definition of data                 |
-| [JSON](wrangler-docs/functions/json-functions.md)                               | Functions that can be useful in transforming your data           |
-| [Types](wrangler-docs/functions/type-functions.md)                              | Functions for detecting the type of data                         |
+| Directive                                                                            | Description                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Parsers**                                                                          |                                                                                                                                                                                                   |
+| [JSON Path](wrangler-docs/directives/json-path.md)                                   | Uses a DSL (a JSON path expression) for parsing JSON records                                                                                                                                      |
+| [Parse as AVRO](wrangler-docs/directives/parse-as-avro.md)                           | Parsing an AVRO encoded message - either as binary or json                                                                                                                                        |
+| [Parse as AVRO File](wrangler-docs/directives/parse-as-avro-file.md)                 | Parsing an AVRO data file                                                                                                                                                                         |
+| [Parse as CSV](wrangler-docs/directives/parse-as-csv.md)                             | Parsing an input record as comma-separated values                                                                                                                                                 |
+| [Parse as Date](wrangler-docs/directives/parse-as-date.md)                           | Parsing dates using natural language processing                                                                                                                                                   |
+| [Parse as Excel](wrangler-docs/directives/parse-as-excel.md)                         | Parsing excel file.                                                                                                                                                                               |
+| [Parse as Fixed Length](wrangler-docs/directives/parse-as-fixed-length.md)           | Parses as a fixed length record with specified widths                                                                                                                                             |
+| [Parse as HL7](wrangler-docs/directives/parse-as-hl7.md)                             | Parsing Health Level 7 Version 2 (HL7 V2) messages                                                                                                                                                |
+| [Parse as JSON](wrangler-docs/directives/parse-as-json.md)                           | Parsing a JSON object                                                                                                                                                                             |
+| [Parse as Log](wrangler-docs/directives/parse-as-log.md)                             | Parses access log files as from Apache HTTPD and nginx servers                                                                                                                                    |
+| [Parse as Protobuf](wrangler-docs/directives/parse-as-log.md)                        | Parses an Protobuf encoded in-memory message using descriptor                                                                                                                                     |
+| [Parse as Simple Date](wrangler-docs/directives/parse-as-simple-date.md)             | Parses date strings                                                                                                                                                                               |
+| [Parse XML To JSON](wrangler-docs/directives/parse-xml-to-json.md)                   | Parses an XML document into a JSON structure                                                                                                                                                      |
+| [Parse as Currency](wrangler-docs/directives/parse-as-currency.md)                   | Parses a string representation of currency into a number.                                                                                                                                         |
+| [Parse as Datetime](wrangler-docs/directives/parse-as-datetime.md)                   | Parses strings with datetime values to CDAP datetime type                                                                                                                                         |
+| [Parse as Byte Size](wrangler-docs/directives/parse-as-byte-size.md)                 | Parses byte size strings (e.g., "1KB", "5MB", "2GB") into their byte values                                                                                                                       |
+| [Parse as Time Duration](wrangler-docs/directives/parse-as-time-duration.md)         | Parses time duration strings (e.g., "5s", "10m", "2h") into their time values                                                                                                                     |
+| **Output Formatters**                                                                |                                                                                                                                                                                                   |
+| [Write as CSV](wrangler-docs/directives/write-as-csv.md)                             | Converts a record into CSV format                                                                                                                                                                 |
+| [Write as JSON](wrangler-docs/directives/write-as-json-map.md)                       | Converts the record into a JSON map                                                                                                                                                               |
+| [Write JSON Object](wrangler-docs/directives/write-as-json-object.md)                | Composes a JSON object based on the fields specified.                                                                                                                                             |
+| [Format as Currency](wrangler-docs/directives/format-as-currency.md)                 | Formats a number as currency as specified by locale.                                                                                                                                              |
+| **Transformations**                                                                  |                                                                                                                                                                                                   |
+| [Changing Case](wrangler-docs/directives/changing-case.md)                           | Changes the case of column values                                                                                                                                                                 |
+| [Cut Character](wrangler-docs/directives/cut-character.md)                           | Selects parts of a string value                                                                                                                                                                   |
+| [Set Column](wrangler-docs/directives/set-column.md)                                 | Sets the column value to the result of an expression execution                                                                                                                                    |
+| [Find and Replace](wrangler-docs/directives/find-and-replace.md)                     | Transforms string column values using a "sed"-like expression                                                                                                                                     |
+| [Index Split](wrangler-docs/directives/index-split.md)                               | (_Deprecated_)                                                                                                                                                                                    |
+| [Invoke HTTP](wrangler-docs/directives/invoke-http.md)                               | Invokes an HTTP Service (_Experimental_, potentially slow)                                                                                                                                        |
+| [Quantization](wrangler-docs/directives/quantize.md)                                 | Quantizes a column based on specified ranges                                                                                                                                                      |
+| [Regex Group Extractor](wrangler-docs/directives/extract-regex-groups.md)            | Extracts the data from a regex group into its own column                                                                                                                                          |
+| [Setting Character Set](wrangler-docs/directives/set-charset.md)                     | Sets the encoding and then converts the data to a UTF-8 String                                                                                                                                    |
+| [Setting Record Delimiter](wrangler-docs/directives/set-record-delim.md)             | Sets the record delimiter                                                                                                                                                                         |
+| [Split by Separator](wrangler-docs/directives/split-by-separator.md)                 | Splits a column based on a separator into two columns                                                                                                                                             |
+| [Split Email Address](wrangler-docs/directives/split-email.md)                       | Splits an email ID into an account and its domain                                                                                                                                                 |
+| [Split URL](wrangler-docs/directives/split-url.md)                                   | Splits a URL into its constituents                                                                                                                                                                |
+| [Text Distance (Fuzzy String Match)](wrangler-docs/directives/text-distance.md)      | Measures the difference between two sequences of characters                                                                                                                                       |
+| [Text Metric (Fuzzy String Match)](wrangler-docs/directives/text-metric.md)          | Measures the difference between two sequences of characters                                                                                                                                       |
+| [URL Decode](wrangler-docs/directives/url-decode.md)                                 | Decodes from the `application/x-www-form-urlencoded` MIME format                                                                                                                                  |
+| [URL Encode](wrangler-docs/directives/url-encode.md)                                 | Encodes to the `application/x-www-form-urlencoded` MIME format                                                                                                                                    |
+| [Trim](wrangler-docs/directives/trim.md)                                             | Functions for trimming white spaces around string data                                                                                                                                            |
+| **Encoders and Decoders**                                                            |                                                                                                                                                                                                   |
+| [Decode](wrangler-docs/directives/decode.md)                                         | Decodes a column value as one of `base32`, `base64`, or `hex`                                                                                                                                     |
+| [Encode](wrangler-docs/directives/encode.md)                                         | Encodes a column value as one of `base32`, `base64`, or `hex`                                                                                                                                     |
+| **Unique ID**                                                                        |                                                                                                                                                                                                   |
+| [UUID Generation](wrangler-docs/directives/generate-uuid.md)                         | Generates a universally unique identifier (UUID) .Recommended to use with Wrangler version 4.4.0 and above due to an important bug fix [CDAP-17732](https://cdap.atlassian.net/browse/CDAP-17732) |
+| **Date Transformations**                                                             |                                                                                                                                                                                                   |
+| [Diff Date](wrangler-docs/directives/diff-date.md)                                   | Calculates the difference between two dates                                                                                                                                                       |
+| [Format Date](wrangler-docs/directives/format-date.md)                               | Custom patterns for date-time formatting                                                                                                                                                          |
+| [Format Unix Timestamp](wrangler-docs/directives/format-unix-timestamp.md)           | Formats a UNIX timestamp as a date                                                                                                                                                                |
+| **DateTime Transformations**                                                         |                                                                                                                                                                                                   |
+| [Current DateTime](wrangler-docs/directives/current-datetime.md)                     | Generates the current datetime using the given zone or UTC by default                                                                                                                             |
+| [Datetime To Timestamp](wrangler-docs/directives/datetime-to-timestamp.md)           | Converts a datetime value to timestamp with the given zone                                                                                                                                        |
+| [Format Datetime](wrangler-docs/directives/format-datetime.md)                       | Formats a datetime value to custom date time pattern strings                                                                                                                                      |
+| [Timestamp To Datetime](wrangler-docs/directives/timestamp-to-datetime.md)           | Converts a timestamp value to datetime                                                                                                                                                            |
+| **Lookups**                                                                          |                                                                                                                                                                                                   |
+| [Catalog Lookup](wrangler-docs/directives/catalog-lookup.md)                         | Static catalog lookup of ICD-9, ICD-10-2016, ICD-10-2017 codes                                                                                                                                    |
+| [Table Lookup](wrangler-docs/directives/table-lookup.md)                             | Performs lookups into Table datasets                                                                                                                                                              |
+| **Hashing & Masking**                                                                |                                                                                                                                                                                                   |
+| [Message Digest or Hash](wrangler-docs/directives/hash.md)                           | Generates a message digest                                                                                                                                                                        |
+| [Mask Number](wrangler-docs/directives/mask-number.md)                               | Applies substitution masking on the column values                                                                                                                                                 |
+| [Mask Shuffle](wrangler-docs/directives/mask-shuffle.md)                             | Applies shuffle masking on the column values                                                                                                                                                      |
+| **Row Operations**                                                                   |                                                                                                                                                                                                   |
+| [Filter Row if Matched](wrangler-docs/directives/filter-row-if-matched.md)           | Filters rows that match a pattern for a column                                                                                                                                                    |
+| [Filter Row if True](wrangler-docs/directives/filter-row-if-true.md)                 | Filters rows if the condition is true.                                                                                                                                                            |
+| [Filter Row Empty of Null](wrangler-docs/directives/filter-empty-or-null.md)         | Filters rows that are empty of null.                                                                                                                                                              |
+| [Flatten](wrangler-docs/directives/flatten.md)                                       | Separates the elements in a repeated field                                                                                                                                                        |
+| [Fail on condition](wrangler-docs/directives/fail.md)                                | Fails processing when the condition is evaluated to true.                                                                                                                                         |
+| [Send to Error](wrangler-docs/directives/send-to-error.md)                           | Filtering of records to an error collector                                                                                                                                                        |
+| [Send to Error And Continue](wrangler-docs/directives/send-to-error-and-continue.md) | Filtering of records to an error collector and continues processing                                                                                                                               |
+| [Split to Rows](wrangler-docs/directives/split-to-rows.md)                           | Splits based on a separator into multiple records                                                                                                                                                 |
+| **Column Operations**                                                                |                                                                                                                                                                                                   |
+| [Change Column Case](wrangler-docs/directives/change-column-case.md)                 | Changes column names to either lowercase or uppercase                                                                                                                                             |
+| [Changing Case](wrangler-docs/directives/changing-case.md)                           | Change the case of column values                                                                                                                                                                  |
+| [Cleanse Column Names](wrangler-docs/directives/cleanse-column-names.md)             | Sanatizes column names, following specific rules                                                                                                                                                  |
+| [Columns Replace](wrangler-docs/directives/columns-replace.md)                       | Alters column names in bulk                                                                                                                                                                       |
+| [Copy](wrangler-docs/directives/copy.md)                                             | Copies values from a source column into a destination column                                                                                                                                      |
+| [Drop Column](wrangler-docs/directives/drop.md)                                      | Drops a column in a record                                                                                                                                                                        |
+| [Fill Null or Empty Columns](wrangler-docs/directives/fill-null-or-empty.md)         | Fills column value with a fixed value if null or empty                                                                                                                                            |
+| [Keep Columns](wrangler-docs/directives/keep.md)                                     | Keeps specified columns from the record                                                                                                                                                           |
+| [Merge Columns](wrangler-docs/directives/merge.md)                                   | Merges two columns by inserting a third column                                                                                                                                                    |
+| [Rename Column](wrangler-docs/directives/rename.md)                                  | Renames an existing column in the record                                                                                                                                                          |
+| [Set Column Header](wrangler-docs/directives/set-headers.md)                         | Sets the names of columns, in the order they are specified                                                                                                                                        |
+| [Split to Columns](wrangler-docs/directives/split-to-columns.md)                     | Splits a column based on a separator into multiple columns                                                                                                                                        |
+| [Swap Columns](wrangler-docs/directives/swap.md)                                     | Swaps column names of two columns                                                                                                                                                                 |
+| [Set Column Data Type](wrangler-docs/directives/set-type.md)                         | Convert data type of a column                                                                                                                                                                     |
+| **NLP**                                                                              |                                                                                                                                                                                                   |
+| [Stemming Tokenized Words](wrangler-docs/directives/stemming.md)                     | Applies the Porter stemmer algorithm for English words                                                                                                                                            |
+| **Transient Aggregators & Setters**                                                  |                                                                                                                                                                                                   |
+| [Increment Variable](wrangler-docs/directives/increment-variable.md)                 | Increments a transient variable with a record of processing.                                                                                                                                      |
+| [Set Variable](wrangler-docs/directives/set-variable.md)                             | Sets a transient variable with a record of processing.                                                                                                                                            |
+| **Functions**                                                                        |                                                                                                                                                                                                   |
+| [Data Quality](wrangler-docs/functions/dq-functions.md)                              | Data quality check functions. Checks for date, time, etc.                                                                                                                                         |
+| [Date Manipulations](wrangler-docs/functions/date-functions.md)                      | Functions that can manipulate date                                                                                                                                                                |
+| [DDL](wrangler-docs/functions/ddl-functions.md)                                      | Functions that can manipulate definition of data                                                                                                                                                  |
+| [JSON](wrangler-docs/functions/json-functions.md)                                    | Functions that can be useful in transforming your data                                                                                                                                            |
+| [Types](wrangler-docs/functions/type-functions.md)                                   | Functions for detecting the type of data                                                                                                                                                          |
 
 ## Performance
 
 Initial performance tests show that with a set of directives of high complexity for
-transforming data, *DataPrep* is able to process at about ~106K records per second. The
-rates below are specified as *records/second*. 
+transforming data, _DataPrep_ is able to process at about ~106K records per second. The
+rates below are specified as _records/second_.
 
-| Directive Complexity | Column Count |    Records |           Size | Mean Rate |
-| -------------------- | :----------: | ---------: | -------------: | --------: |
-| High (167 Directives) |      426      | 127,946,398 |  82,677,845,324 | 106,367.27 |
-| High (167 Directives) |      426      | 511,785,592 | 330,711,381,296 | 105,768.93 |
-
+| Directive Complexity  | Column Count |     Records |            Size |  Mean Rate |
+| --------------------- | :----------: | ----------: | --------------: | ---------: |
+| High (167 Directives) |     426      | 127,946,398 |  82,677,845,324 | 106,367.27 |
+| High (167 Directives) |     426      | 511,785,592 | 330,711,381,296 | 105,768.93 |
 
 ## Contact
 
@@ -182,9 +184,9 @@ rates below are specified as *records/second*.
 
 CDAP User Group and Development Discussions:
 
-* [cdap-user@googlegroups.com](https://groups.google.com/d/forum/cdap-user)
+- [cdap-user@googlegroups.com](https://groups.google.com/d/forum/cdap-user)
 
-The *cdap-user* mailing list is primarily for users using the product to develop
+The _cdap-user_ mailing list is primarily for users using the product to develop
 applications or building plugins for appplications. You can expect questions from
 users, release announcements, and any other discussions that we think will be helpful
 to the users.
@@ -196,7 +198,6 @@ CDAP IRC Channel: [#cdap on irc.freenode.net](http://webchat.freenode.net?channe
 ### Slack Team
 
 CDAP Users on Slack: [cdap-users team](https://cdap-users.herokuapp.com)
-
 
 ## License and Trademarks
 

--- a/test-data.json
+++ b/test-data.json
@@ -1,0 +1,9 @@
+{
+    "records": [
+      {"file_size": "1.5KB", "response_time": "250ms", "name": "file1.txt"},
+      {"file_size": "2.8MB", "response_time": "1.2s", "name": "file2.jpg"},
+      {"file_size": "512B", "response_time": "450ms", "name": "file3.txt"},
+      {"file_size": "15MB", "response_time": "3.5s", "name": "file4.mp4"},
+      {"file_size": "750KB", "response_time": "180ms", "name": "file5.pdf"}
+    ]
+  }

--- a/test-recipe.txt
+++ b/test-recipe.txt
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+parse-as-json :records
+parse-as-byte-size :file_size file_size_bytes
+parse-as-time-duration :response_time response_time_ms
+aggregate-stats :file_size_bytes :response_time_ms total_size avg_size total_time avg_time 

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The ByteSize class represents a size in bytes with support for various units
+ * (B, KB, MB, GB, TB).
+ * It implements the Token interface for use in the wrangler parser system.
+ */
+@PublicEvolving
+public class ByteSize implements Token {
+    private static final Pattern BYTE_SIZE_PATTERN = Pattern.compile("^(\\d+(?:\\.\\d+)?)(B|KB|MB|GB|TB)$",
+            Pattern.CASE_INSENSITIVE);
+    private final String value;
+    private final long bytes;
+
+    /**
+     * Creates a new ByteSize instance from a string representation.
+     *
+     * @param value The string representation of the byte size (e.g., "1KB",
+     *              "1.5MB", "2GB")
+     * @throws IllegalArgumentException if the value is not in a valid format
+     */
+    public ByteSize(String value) {
+        this.value = value;
+        this.bytes = parseBytes(value);
+    }
+
+    /**
+     * Parses the string representation into bytes.
+     *
+     * @param value The string to parse
+     * @return The number of bytes
+     * @throws IllegalArgumentException if the value is not in a valid format
+     */
+    private long parseBytes(String value) {
+        Matcher matcher = BYTE_SIZE_PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid byte size format: " + value);
+        }
+
+        double number = Double.parseDouble(matcher.group(1));
+        String unit = matcher.group(2).toUpperCase();
+
+        switch (unit) {
+            case "B":
+                return (long) number;
+            case "KB":
+                return (long) (number * 1024);
+            case "MB":
+                return (long) (number * 1024 * 1024);
+            case "GB":
+                return (long) (number * 1024 * 1024 * 1024);
+            case "TB":
+                return (long) (number * 1024 * 1024 * 1024 * 1024);
+            default:
+                throw new IllegalArgumentException("Unsupported unit: " + unit);
+        }
+    }
+
+    /**
+     * Gets the number of bytes represented by this ByteSize.
+     *
+     * @return The number of bytes
+     */
+    public long getBytes() {
+        return bytes;
+    }
+
+    /**
+     * Gets the size in kilobytes.
+     *
+     * @return The size in kilobytes
+     */
+    public double getKilobytes() {
+        return bytes / 1024.0;
+    }
+
+    /**
+     * Gets the size in megabytes.
+     *
+     * @return The size in megabytes
+     */
+    public double getMegabytes() {
+        return bytes / (1024.0 * 1024.0);
+    }
+
+    /**
+     * Gets the size in gigabytes.
+     *
+     * @return The size in gigabytes
+     */
+    public double getGigabytes() {
+        return bytes / (1024.0 * 1024.0 * 1024.0);
+    }
+
+    /**
+     * Gets the size in terabytes.
+     *
+     * @return The size in terabytes
+     */
+    public double getTerabytes() {
+        return bytes / (1024.0 * 1024.0 * 1024.0 * 1024.0);
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.BYTE_SIZE.name());
+        object.addProperty("value", value);
+        return object;
+    }
+}
+

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The TimeDuration class represents a duration of time with support for various
+ * units
+ * (ns, us/µs, ms, s, m, h, d). It implements the Token interface for use in the
+ * wrangler parser system.
+ */
+@PublicEvolving
+public class TimeDuration implements Token {
+    private static final Pattern TIME_PATTERN = Pattern.compile("^(\\d+(?:\\.\\d+)?)(ns|us|µs|ms|s|m|h|d)$",
+            Pattern.CASE_INSENSITIVE);
+    private final String value;
+    private final long nanoseconds;
+
+    /**
+     * Creates a new TimeDuration instance from a string representation.
+     *
+     * @param value The string representation of the time duration (e.g., "1ms",
+     *              "1.5s", "2m")
+     * @throws IllegalArgumentException if the value is not in a valid format
+     */
+    public TimeDuration(String value) {
+        this.value = value;
+        this.nanoseconds = parseNanoseconds(value);
+    }
+
+    /**
+     * Parses the string representation into nanoseconds.
+     *
+     * @param value The string to parse
+     * @return The number of nanoseconds
+     * @throws IllegalArgumentException if the value is not in a valid format
+     */
+    private long parseNanoseconds(String value) {
+        Matcher matcher = TIME_PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid time duration format: " + value);
+        }
+
+        double number = Double.parseDouble(matcher.group(1));
+        String unit = matcher.group(2).toLowerCase();
+
+        // Handle microseconds with both 'us' and 'µs'
+        if (unit.equals("µs")) {
+            unit = "us";
+        }
+
+        switch (unit) {
+            case "ns":
+                return (long) number;
+            case "us":
+                return (long) (number * 1000);
+            case "ms":
+                return (long) (number * 1000 * 1000);
+            case "s":
+                return (long) (number * 1000 * 1000 * 1000);
+            case "m":
+                return (long) (number * 60 * 1000 * 1000 * 1000);
+            case "h":
+                return (long) (number * 60 * 60 * 1000 * 1000 * 1000);
+            case "d":
+                return (long) (number * 24 * 60 * 60 * 1000 * 1000 * 1000);
+            default:
+                throw new IllegalArgumentException("Unsupported time unit: " + unit);
+        }
+    }
+
+    /**
+     * Gets the number of nanoseconds represented by this TimeDuration.
+     *
+     * @return The number of nanoseconds
+     */
+    public long getNanoseconds() {
+        return nanoseconds;
+    }
+
+    /**
+     * Gets the duration in microseconds.
+     *
+     * @return the duration in microseconds
+     */
+    public double getMicroseconds() {
+        return nanoseconds / 1000.0;
+    }
+
+    /**
+     * Gets the duration in milliseconds.
+     *
+     * @return the duration in milliseconds
+     */
+    public double getMilliseconds() {
+        return nanoseconds / (1000.0 * 1000.0);
+    }
+
+    /**
+     * Gets the duration in seconds.
+     *
+     * @return the duration in seconds
+     */
+    public double getSeconds() {
+        return nanoseconds / (1000.0 * 1000.0 * 1000.0);
+    }
+
+    /**
+     * Gets the duration in minutes.
+     *
+     * @return the duration in minutes
+     */
+    public double getMinutes() {
+        return nanoseconds / (1000.0 * 1000.0 * 1000.0 * 60.0);
+    }
+
+    /**
+     * Gets the duration in hours.
+     *
+     * @return the duration in hours
+     */
+    public double getHours() {
+        return nanoseconds / (1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0);
+    }
+
+    /**
+     * Gets the duration in days.
+     *
+     * @return the duration in days
+     */
+    public double getDays() {
+        return nanoseconds / (1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0);
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.TIME_DURATION.name());
+        object.addProperty("value", value);
+        return object;
+    }
+
+    @Override
+    public String toString() {
+        if (nanoseconds < 1000) {
+            return String.format("%.2fns", nanoseconds);
+        } else if (nanoseconds < 1000 * 1000) {
+            return String.format("%.2fµs", getMicroseconds());
+        } else if (nanoseconds < 1000 * 1000 * 1000) {
+            return String.format("%.2fms", getMilliseconds());
+        } else if (nanoseconds < 1000 * 1000 * 1000 * 60) {
+            return String.format("%.2fs", getSeconds());
+        } else if (nanoseconds < 1000 * 1000 * 1000 * 60 * 60) {
+            return String.format("%.2fm", getMinutes());
+        } else if (nanoseconds < 1000 * 1000 * 1000 * 60 * 60 * 24) {
+            return String.format("%.2fh", getHours());
+        } else {
+            return String.format("%.2fd", getDays());
+        }
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -59,26 +59,30 @@ public enum TokenType implements Serializable {
 
   /**
    * Represents the enumerated type for the object of {@code Text} type.
-   * This type is associated with the token that is either enclosed within a single quote(')
+   * This type is associated with the token that is either enclosed within a
+   * single quote(')
    * or a double quote (") as string.
    */
   TEXT,
 
   /**
    * Represents the enumerated type for the object of {@code Numeric} type.
-   * This type is associated with the token that is either a integer or real number.
+   * This type is associated with the token that is either a integer or real
+   * number.
    */
   NUMERIC,
 
   /**
    * Represents the enumerated type for the object of {@code Bool} type.
-   * This type is associated with the token that either represents string 'true' or 'false'.
+   * This type is associated with the token that either represents string 'true'
+   * or 'false'.
    */
   BOOLEAN,
 
   /**
    * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the rule that is a collection of {@code Boolean} values
+   * This type is associated with the rule that is a collection of {@code Boolean}
+   * values
    * separated by comman(,). E.g.
    * <code>
    *   ColumnName[,ColumnName]*
@@ -88,8 +92,10 @@ public enum TokenType implements Serializable {
 
   /**
    * Represents the enumerated type for the object of type {@code TextList} type.
-   * This type is associated with the comma separated text represented were each text
-   * is enclosed within a single quote (') or double quote (") and each text is separated
+   * This type is associated with the comma separated text represented were each
+   * text
+   * is enclosed within a single quote (') or double quote (") and each text is
+   * separated
    * by comma (,). E.g.
    * <code>
    *   Text[,Text]*
@@ -98,8 +104,10 @@ public enum TokenType implements Serializable {
   TEXT_LIST,
 
   /**
-   * Represents the enumerated type for the object of type {@code NumericList} type.
-   * This type is associated with the collection of {@code Numeric} values separated by
+   * Represents the enumerated type for the object of type {@code NumericList}
+   * type.
+   * This type is associated with the collection of {@code Numeric} values
+   * separated by
    * comma(,). E.g.
    * <code>
    *   Numeric[,Numeric]*
@@ -110,7 +118,8 @@ public enum TokenType implements Serializable {
 
   /**
    * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the collection of {@code Bool} values separated by
+   * This type is associated with the collection of {@code Bool} values separated
+   * by
    * comma(,). E.g.
    * <code>
    *   Boolean[,Boolean]*
@@ -119,7 +128,8 @@ public enum TokenType implements Serializable {
   BOOLEAN_LIST,
 
   /**
-   * Represents the enumerated type for the object of type {@code Expression} type.
+   * Represents the enumerated type for the object of type {@code Expression}
+   * type.
    * This type is associated with code block that either represents a condition or
    * an expression. E.g.
    * <code>
@@ -129,8 +139,10 @@ public enum TokenType implements Serializable {
   EXPRESSION,
 
   /**
-   * Represents the enumerated type for the object of type {@code Properties} type.
-   * This type is associated with a collection of key and value pairs all separated
+   * Represents the enumerated type for the object of type {@code Properties}
+   * type.
+   * This type is associated with a collection of key and value pairs all
+   * separated
    * by a comma(,). E.g.
    * <code>
    *   prop:{ <key>=<value>[,<key>=<value>]*}
@@ -140,7 +152,8 @@ public enum TokenType implements Serializable {
 
   /**
    * Represents the enumerated type for the object of type {@code Ranges} types.
-   * This type is associated with a collection of range represented in the form shown
+   * This type is associated with a collection of range represented in the form
+   * shown
    * below
    * <code>
    *   <start>:<end>=value[,<start>:<end>=value]*
@@ -149,8 +162,23 @@ public enum TokenType implements Serializable {
   RANGES,
 
   /**
-   * Represents the enumerated type for the object of type {@code String} with restrictions
+   * Represents the enumerated type for the object of type {@code String} with
+   * restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for the object of type {@code ByteSize}.
+   * This type is associated with tokens representing byte sizes with units like
+   * KB, MB, GB etc.
+   */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for the object of type {@code TimeDuration}.
+   * This type is associated with tokens representing time durations with units
+   * like ms, s, m etc.
+   */
+  TIME_DURATION
 }

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ByteSizeTest {
+
+    @Test
+    public void testByteSizeParsing() {
+        ByteSize size1 = new ByteSize("10KB");
+        assertEquals(10 * 1024, size1.getBytes());
+        assertEquals(10, size1.getKilobytes(), 0.0001);
+        assertEquals(10.0 / 1024, size1.getMegabytes(), 0.0001);
+
+        ByteSize size2 = new ByteSize("1.5MB");
+        assertEquals((long) (1.5 * 1024 * 1024), size2.getBytes());
+        assertEquals(1.5 * 1024, size2.getKilobytes(), 0.0001);
+        assertEquals(1.5, size2.getMegabytes(), 0.0001);
+
+        ByteSize size3 = new ByteSize("2GB");
+        assertEquals(2L * 1024 * 1024 * 1024, size3.getBytes());
+        assertEquals(2 * 1024 * 1024, size3.getKilobytes(), 0.0001);
+        assertEquals(2 * 1024, size3.getMegabytes(), 0.0001);
+        assertEquals(2, size3.getGigabytes(), 0.0001);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidByteSize1() {
+        new ByteSize("10");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidByteSize2() {
+        new ByteSize("10K");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidByteSize3() {
+        new ByteSize("10KBKB");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidByteSize4() {
+        new ByteSize("abcKB");
+    }
+
+    @Test
+    public void testTokenType() {
+        ByteSize size = new ByteSize("10KB");
+        assertEquals(TokenType.BYTE_SIZE, size.type());
+    }
+
+    @Test
+    public void testValue() {
+        ByteSize size = new ByteSize("10KB");
+        assertEquals("10KB", size.value());
+    }
+}
+

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/TimeDurationTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/TimeDurationTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimeDurationTest {
+
+    @Test
+    public void testTimeDurationParsing() {
+        TimeDuration duration1 = new TimeDuration("10ms");
+        assertEquals(10.0, duration1.getMilliseconds(), 0.0001);
+        assertEquals(0.01, duration1.getSeconds(), 0.0001);
+
+        TimeDuration duration2 = new TimeDuration("1.5s");
+        assertEquals(1500.0, duration2.getMilliseconds(), 0.0001);
+        assertEquals(1.5, duration2.getSeconds(), 0.0001);
+
+        TimeDuration duration3 = new TimeDuration("2m");
+        assertEquals(2 * 60 * 1000.0, duration3.getMilliseconds(), 0.0001);
+        assertEquals(2 * 60.0, duration3.getSeconds(), 0.0001);
+        assertEquals(2.0, duration3.getMinutes(), 0.0001);
+
+        TimeDuration duration4 = new TimeDuration("1.5h");
+        assertEquals(1.5 * 60 * 60 * 1000.0, duration4.getMilliseconds(), 0.0001);
+        assertEquals(1.5 * 60 * 60.0, duration4.getSeconds(), 0.0001);
+        assertEquals(1.5 * 60.0, duration4.getMinutes(), 0.0001);
+        assertEquals(1.5, duration4.getHours(), 0.0001);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidTimeDuration1() {
+        new TimeDuration("10");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidTimeDuration2() {
+        new TimeDuration("ms");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidTimeDuration3() {
+        new TimeDuration("10msms");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidTimeDuration4() {
+        new TimeDuration("abcms");
+    }
+
+    @Test
+    public void testTokenType() {
+        TimeDuration duration = new TimeDuration("10ms");
+        assertEquals(TokenType.TIME_DURATION, duration.type());
+    }
+
+    @Test
+    public void testValue() {
+        TimeDuration duration = new TimeDuration("10ms");
+        assertEquals("10ms", duration.value());
+    }
+}

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION
  ;
 
 ecommand
@@ -310,4 +310,33 @@ fragment Int
 
 fragment Digit
  : [0-9]
+ ;
+
+// Byte size token for values like 10KB, 1.5MB, etc.
+BYTE_SIZE
+ : Int ('.' Digit*)? BYTE_UNIT
+ ;
+
+fragment BYTE_UNIT
+ : ('B'|'b') // Bytes
+ | ('KB'|'kb'|'kB'|'Kb') // Kilobytes
+ | ('MB'|'mb'|'mB'|'Mb') // Megabytes 
+ | ('GB'|'gb'|'gB'|'Gb') // Gigabytes
+ | ('TB'|'tb'|'tB'|'Tb') // Terabytes
+ | ('PB'|'pb'|'pB'|'Pb') // Petabytes
+ ;
+
+// Time duration token for values like 10ms, 1.5s, etc.
+TIME_DURATION
+ : Int ('.' Digit*)? TIME_UNIT
+ ;
+
+fragment TIME_UNIT
+ : ('ns'|'NS') // Nanoseconds
+ | ('us'|'US'|'µs'|'µS') // Microseconds
+ | ('ms'|'MS') // Milliseconds
+ | ('s'|'S') // Seconds
+ | ('m'|'M') // Minutes
+ | ('h'|'H') // Hours
+ | ('d'|'D') // Days
  ;

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import com.google.common.collect.ImmutableList;
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetric;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.TransientVariableScope;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Identifier;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.util.List;
+
+/**
+ * A directive that aggregates byte sizes and time durations from specified
+ * columns.
+ * It calculates total size and total/average time based on the input columns.
+ */
+@Plugin(type = Directive.TYPE)
+@Name(AggregateStats.NAME)
+@Categories(categories = { "aggregate" })
+@Description("Aggregates byte sizes and time durations from specified columns.")
+public class AggregateStats implements Directive {
+    public static final String NAME = "aggregate-stats";
+
+    private String sizeColumn;
+    private String timeColumn;
+    private String totalSizeColumn;
+    private String totalTimeColumn;
+    private String outputSizeUnit;
+    private String outputTimeUnit;
+    private boolean calculateAverage;
+
+    private long totalBytes;
+    private long totalNanoseconds;
+    private int rowCount;
+
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+        builder.define("size-column", TokenType.COLUMN_NAME);
+        builder.define("time-column", TokenType.COLUMN_NAME);
+        builder.define("total-size-column", TokenType.COLUMN_NAME);
+        builder.define("total-time-column", TokenType.COLUMN_NAME);
+        builder.define("output-size-unit", TokenType.IDENTIFIER, true);
+        builder.define("output-time-unit", TokenType.IDENTIFIER, true);
+        builder.define("calculate-average", TokenType.BOOLEAN, true);
+        return builder.build();
+    }
+
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        this.sizeColumn = ((ColumnName) args.value("size-column")).value();
+        this.timeColumn = ((ColumnName) args.value("time-column")).value();
+        this.totalSizeColumn = ((ColumnName) args.value("total-size-column")).value();
+        this.totalTimeColumn = ((ColumnName) args.value("total-time-column")).value();
+
+        if (args.contains("output-size-unit")) {
+            this.outputSizeUnit = ((Identifier) args.value("output-size-unit")).value();
+        } else {
+            this.outputSizeUnit = "MB";
+        }
+
+        if (args.contains("output-time-unit")) {
+            this.outputTimeUnit = ((Identifier) args.value("output-time-unit")).value();
+        } else {
+            this.outputTimeUnit = "s";
+        }
+
+        if (args.contains("calculate-average")) {
+            this.calculateAverage = (boolean) args.value("calculate-average").value();
+        } else {
+            this.calculateAverage = false;
+        }
+
+        this.totalBytes = 0;
+        this.totalNanoseconds = 0;
+        this.rowCount = 0;
+    }
+
+    @Override
+    public void destroy() {
+        // no-op
+    }
+
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
+        // Process each row to accumulate totals
+        for (Row row : rows) {
+            int sizeIdx = row.find(sizeColumn);
+            int timeIdx = row.find(timeColumn);
+
+            if (sizeIdx == -1) {
+                throw new DirectiveExecutionException(NAME,
+                        String.format("Column '%s' not found in row", sizeColumn));
+            }
+            if (timeIdx == -1) {
+                throw new DirectiveExecutionException(NAME,
+                        String.format("Column '%s' not found in row", timeColumn));
+            }
+
+            Object sizeValue = row.getValue(sizeIdx);
+            Object timeValue = row.getValue(timeIdx);
+
+            if (sizeValue instanceof String) {
+                ByteSize byteSize = new ByteSize((String) sizeValue);
+                totalBytes += byteSize.getBytes();
+            } else {
+                throw new DirectiveExecutionException(NAME,
+                        String.format("Column '%s' must contain byte size values", sizeColumn));
+            }
+
+            if (timeValue instanceof String) {
+                TimeDuration timeDuration = new TimeDuration((String) timeValue);
+                totalNanoseconds += timeDuration.getNanoseconds();
+            } else {
+                throw new DirectiveExecutionException(NAME,
+                        String.format("Column '%s' must contain time duration values", timeColumn));
+            }
+
+            rowCount++;
+        }
+
+        // Create a single row with the aggregated results
+        Row result = new Row();
+
+        // Convert total bytes to requested unit
+        double totalSize;
+        switch (outputSizeUnit.toLowerCase()) {
+            case "b":
+                totalSize = totalBytes;
+                break;
+            case "kb":
+                totalSize = totalBytes / 1024.0;
+                break;
+            case "mb":
+                totalSize = totalBytes / (1024.0 * 1024.0);
+                break;
+            case "gb":
+                totalSize = totalBytes / (1024.0 * 1024.0 * 1024.0);
+                break;
+            case "tb":
+                totalSize = totalBytes / (1024.0 * 1024.0 * 1024.0 * 1024.0);
+                break;
+            default:
+                throw new DirectiveExecutionException(NAME,
+                        String.format("Unsupported size unit: %s", outputSizeUnit));
+        }
+
+        // Convert total nanoseconds to requested unit
+        double totalTime;
+        switch (outputTimeUnit.toLowerCase()) {
+            case "ns":
+                totalTime = totalNanoseconds;
+                break;
+            case "us":
+                totalTime = totalNanoseconds / 1000.0;
+                break;
+            case "ms":
+                totalTime = totalNanoseconds / (1000.0 * 1000.0);
+                break;
+            case "s":
+                totalTime = totalNanoseconds / (1000.0 * 1000.0 * 1000.0);
+                break;
+            case "m":
+                totalTime = totalNanoseconds / (60.0 * 1000.0 * 1000.0 * 1000.0);
+                break;
+            case "h":
+                totalTime = totalNanoseconds / (60.0 * 60.0 * 1000.0 * 1000.0 * 1000.0);
+                break;
+            default:
+                throw new DirectiveExecutionException(NAME,
+                        String.format("Unsupported time unit: %s", outputTimeUnit));
+        }
+
+        // If calculating average, divide by row count
+        if (calculateAverage) {
+            totalTime = totalTime / rowCount;
+        }
+
+        result.add(totalSizeColumn, totalSize);
+        result.add(totalTimeColumn, totalTime);
+
+        return ImmutableList.of(result);
+    }
+
+    @Override
+    public List<EntityCountMetric> getCountMetrics() {
+        return null;
+    }
+}
+

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,6 +22,7 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
+import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -33,6 +34,7 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
+import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
@@ -49,19 +51,31 @@ import java.util.Map;
  * used during traversal of the AST tree. The <code>ParserTree#Walker</code>
  * invokes appropriate methods as call backs with information about the node.
  *
- * <p>In order to understand what's being invoked, please look at the grammar file
- * <tt>Directive.g4</tt></p>.
+ * <p>
+ * In order to understand what's being invoked, please look at the grammar file
+ * <tt>Directive.g4</tt>
+ * </p>
+ * .
  *
- * <p>This class exposes a <code>getTokenGroups</code> method for retrieving the
- * <code>RecipeSymbol</code> after visiting. The <code>RecipeSymbol</code> represents
- * all the <code>TokenGroup</code> for all directives in a recipe. Each directive
- * will create a <code>TokenGroup</code></p>
+ * <p>
+ * This class exposes a <code>getTokenGroups</code> method for retrieving the
+ * <code>RecipeSymbol</code> after visiting. The <code>RecipeSymbol</code>
+ * represents
+ * all the <code>TokenGroup</code> for all directives in a recipe. Each
+ * directive
+ * will create a <code>TokenGroup</code>
+ * </p>
  *
- * <p> As the <code>ParseTree</code> is walking through the call graph, it generates
- * one <code>TokenGroup</code> for each directive in the recipe. Each <code>TokenGroup</code>
- * contains parsed <code>Tokens</code> for that directive along with more information like
- * <code>SourceInfo</code>. A collection of <code>TokenGroup</code> consistutes a <code>RecipeSymbol</code>
- * that is returned by this function.</p>
+ * <p>
+ * As the <code>ParseTree</code> is walking through the call graph, it generates
+ * one <code>TokenGroup</code> for each directive in the recipe. Each
+ * <code>TokenGroup</code>
+ * contains parsed <code>Tokens</code> for that directive along with more
+ * information like
+ * <code>SourceInfo</code>. A collection of <code>TokenGroup</code> consistutes
+ * a <code>RecipeSymbol</code>
+ * that is returned by this function.
+ * </p>
  */
 public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Builder> {
   private RecipeSymbol.Builder builder = new RecipeSymbol.Builder();
@@ -78,8 +92,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Recipe is made up of Directives and Directives is made up of each individual
-   * Directive. This method is invoked on every visit to a new directive in the recipe.
+   * A Recipe is made up of Directives and Directives is made up of each
+   * individual
+   * Directive. This method is invoked on every visit to a new directive in the
+   * recipe.
    */
   @Override
   public RecipeSymbol.Builder visitDirective(DirectivesParser.DirectiveContext ctx) {
@@ -88,7 +104,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can include identifiers, this method extracts that token that is being
+   * A Directive can include identifiers, this method extracts that token that is
+   * being
    * identified as token of type <code>Identifier</code>.
    */
   @Override
@@ -98,8 +115,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can include properties (which are a collection of key and value pairs),
-   * this method extracts that token that is being identified as token of type <code>Properties</code>.
+   * A Directive can include properties (which are a collection of key and value
+   * pairs),
+   * this method extracts that token that is being identified as token of type
+   * <code>Properties</code>.
    */
   @Override
   public RecipeSymbol.Builder visitPropertyList(DirectivesParser.PropertyListContext ctx) {
@@ -123,11 +142,15 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Pragma is an instruction to the compiler to dynamically load the directives being specified
+   * A Pragma is an instruction to the compiler to dynamically load the directives
+   * being specified
    * from the <code>DirectiveRegistry</code>. These do not affect the data flow.
    *
-   * <p>E.g. <code>#pragma load-directives test1, test2, test3;</code> will collect the tokens
-   * test1, test2 and test3 as dynamically loadable directives. <p>
+   * <p>
+   * E.g. <code>#pragma load-directives test1, test2, test3;</code> will collect
+   * the tokens
+   * test1, test2 and test3 as dynamically loadable directives.
+   * <p>
    */
   @Override
   public RecipeSymbol.Builder visitPragmaLoadDirective(DirectivesParser.PragmaLoadDirectiveContext ctx) {
@@ -139,7 +162,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Pragma version is a informational directive to notify compiler about the grammar that is should
+   * A Pragma version is a informational directive to notify compiler about the
+   * grammar that is should
    * be using to parse the directives below.
    */
   @Override
@@ -149,8 +173,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can include number ranges like start:end=value[,start:end=value]*. This
-   * visitor method allows you to collect all the number ranges and create a token type
+   * A Directive can include number ranges like
+   * start:end=value[,start:end=value]*. This
+   * visitor method allows you to collect all the number ranges and create a token
+   * type
    * <code>Ranges</code>.
    */
   @Override
@@ -163,11 +189,9 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
       if (text.startsWith("'") && text.endsWith("'")) {
         text = text.substring(1, text.length() - 1);
       }
-      Triplet<Numeric, Numeric, String> val =
-        new Triplet<>(new Numeric(new LazyNumber(numbers.get(0).getText())),
-                      new Numeric(new LazyNumber(numbers.get(1).getText())),
-                      text
-        );
+      Triplet<Numeric, Numeric, String> val = new Triplet<>(new Numeric(new LazyNumber(numbers.get(0).getText())),
+          new Numeric(new LazyNumber(numbers.get(1).getText())),
+          text);
       output.add(val);
     }
     builder.addToken(new Ranges(output));
@@ -185,8 +209,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can consist of column specifiers. These are columns that the directive
-   * would operate on. When a token of type column is visited, it would generate a token
+   * A Directive can consist of column specifiers. These are columns that the
+   * directive
+   * would operate on. When a token of type column is visited, it would generate a
+   * token
    * type of type <code>ColumnName</code>.
    */
   @Override
@@ -196,8 +222,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can consist of text field. These type of fields are enclosed within
-   * a single-quote or a double-quote. This visitor method extracts the string value
+   * A Directive can consist of text field. These type of fields are enclosed
+   * within
+   * a single-quote or a double-quote. This visitor method extracts the string
+   * value
    * within the quotes and creates a token type <code>Text</code>.
    */
   @Override
@@ -232,7 +260,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   /**
    * A Directive can include a expression or a condition to be evaluated. When
    * such a token type is found, the visitor extracts the expression and generates
-   * a token type <code>Expression</code> to be added to the <code>TokenGroup</code>
+   * a token type <code>Expression</code> to be added to the
+   * <code>TokenGroup</code>
    */
   @Override
   public RecipeSymbol.Builder visitCondition(DirectivesParser.ConditionContext ctx) {
@@ -248,7 +277,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
 
   /**
    * A Directive has name and in the parsing context it's called a command.
-   * This visitor methods extracts the command and creates a toke type <code>DirectiveName</code>
+   * This visitor methods extracts the command and creates a toke type
+   * <code>DirectiveName</code>
    */
   @Override
   public RecipeSymbol.Builder visitCommand(DirectivesParser.CommandContext ctx) {
@@ -257,7 +287,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of columns specified. It creates a token
+   * This visitor methods extracts the list of columns specified. It creates a
+   * token
    * type <code>ColumnNameList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -272,7 +303,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of numeric specified. It creates a token
+   * This visitor methods extracts the list of numeric specified. It creates a
+   * token
    * type <code>NumericList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -287,7 +319,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of booleans specified. It creates a token
+   * This visitor methods extracts the list of booleans specified. It creates a
+   * token
    * type <code>BoolList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -302,7 +335,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of strings specified. It creates a token
+   * This visitor methods extracts the list of strings specified. It creates a
+   * token
    * type <code>StringList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -315,6 +349,22 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     }
     builder.addToken(new TextList(strs));
     return builder;
+  }
+
+  /**
+   * When a value in the grammar rule contains a BYTE_SIZE token, this visitor
+   * method is called to extract the byte size value into a token type
+   * <code>ByteSize</code>.
+   */
+  @Override
+  public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
+    if (ctx.BYTE_SIZE() != null) {
+      builder.addToken(new ByteSize(ctx.BYTE_SIZE().getText()));
+    } else if (ctx.TIME_DURATION() != null) {
+      builder.addToken(new TimeDuration(ctx.TIME_DURATION().getText()));
+    }
+    // Let other visit methods handle other token types
+    return super.visitValue(ctx);
   }
 
   private SourceInfo getOriginalSource(ParserRuleContext ctx) {

--- a/wrangler-core/src/main/java/io/cdap/wrangler/statistics/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/statistics/AggregateStats.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.statistics;
+
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveContext;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.ErrorRowException;
+import io.cdap.wrangler.api.ReportErrorAndProceed;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+
+import java.util.List;
+
+/**
+ * A directive for aggregating byte size and time duration statistics.
+ */
+@Categories(categories = { "aggregate" })
+public class AggregateStats implements Directive {
+    public static final String NAME = "aggregate-stats";
+    private String sizeColumn;
+    private String timeColumn;
+    private String totalSizeColumn;
+    private String totalTimeColumn;
+    private String sizeUnit = "MB";
+    private String timeUnit = "s";
+    private String aggregationType = "total";
+
+    private long totalBytes = 0;
+    private long totalNanoseconds = 0;
+    private int rowCount = 0;
+
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+        builder.define("size-column", TokenType.COLUMN_NAME, "Source column containing byte sizes");
+        builder.define("time-column", TokenType.COLUMN_NAME, "Source column containing time durations");
+        builder.define("total-size-column", TokenType.TEXT, "Target column for total size");
+        builder.define("total-time-column", TokenType.TEXT, "Target column for total time");
+        builder.define("size-unit", TokenType.TEXT, "Output unit for size (B, KB, MB, GB, TB, PB)", false);
+        builder.define("time-unit", TokenType.TEXT, "Output unit for time (ns, us, ms, s, m, h, d)", false);
+        builder.define("aggregation-type", TokenType.TEXT, "Type of aggregation (total, average)", false);
+        return builder.build();
+    }
+
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        this.sizeColumn = ((ColumnName) args.value("size-column")).value();
+        this.timeColumn = ((ColumnName) args.value("time-column")).value();
+        this.totalSizeColumn = ((Text) args.value("total-size-column")).value();
+        this.totalTimeColumn = ((Text) args.value("total-time-column")).value();
+
+        if (args.contains("size-unit")) {
+            this.sizeUnit = ((Text) args.value("size-unit")).value();
+        }
+        if (args.contains("time-unit")) {
+            this.timeUnit = ((Text) args.value("time-unit")).value();
+        }
+        if (args.contains("aggregation-type")) {
+            this.aggregationType = ((Text) args.value("aggregation-type")).value();
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // No-op
+    }
+
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext context)
+            throws DirectiveExecutionException, ErrorRowException, ReportErrorAndProceed {
+        for (Row row : rows) {
+            Object sizeValue = row.getValue(sizeColumn);
+            Object timeValue = row.getValue(timeColumn);
+
+            if (sizeValue instanceof ByteSize) {
+                totalBytes += ((ByteSize) sizeValue).getBytes();
+            } else if (sizeValue instanceof String) {
+                try {
+                    totalBytes += new ByteSize((String) sizeValue).getBytes();
+                } catch (IllegalArgumentException e) {
+                    throw new ErrorRowException(
+                            String.format("Invalid byte size format in column '%s': %s", sizeColumn, sizeValue), 1);
+                }
+            }
+
+            if (timeValue instanceof TimeDuration) {
+                totalNanoseconds += ((TimeDuration) timeValue).getNanoseconds();
+            } else if (timeValue instanceof String) {
+                try {
+                    totalNanoseconds += new TimeDuration((String) timeValue).getNanoseconds();
+                } catch (IllegalArgumentException e) {
+                    throw new ErrorRowException(
+                            String.format("Invalid time duration format in column '%s': %s", timeColumn, timeValue), 1);
+                }
+            }
+
+            rowCount++;
+        }
+
+        // Create a single row with the aggregated results
+        Row result = new Row();
+        try {
+            result.add(totalSizeColumn, convertBytes(totalBytes, sizeUnit));
+            result.add(totalTimeColumn, convertNanoseconds(totalNanoseconds, timeUnit));
+        } catch (IllegalArgumentException e) {
+            throw new DirectiveExecutionException(e.getMessage());
+        }
+        return List.of(result);
+    }
+
+    private double convertBytes(long bytes, String unit) {
+        double value = bytes;
+        switch (unit.toUpperCase()) {
+            case "B":
+                break;
+            case "KB":
+                value /= 1024;
+                break;
+            case "MB":
+                value /= (1024 * 1024);
+                break;
+            case "GB":
+                value /= (1024 * 1024 * 1024);
+                break;
+            case "TB":
+                value /= (1024L * 1024 * 1024 * 1024);
+                break;
+            case "PB":
+                value /= (1024L * 1024 * 1024 * 1024 * 1024);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid byte size unit: " + unit);
+        }
+        return aggregationType.equals("average") ? value / rowCount : value;
+    }
+
+    private double convertNanoseconds(long nanoseconds, String unit) {
+        double value = nanoseconds;
+        switch (unit.toLowerCase()) {
+            case "ns":
+                break;
+            case "us":
+            case "µs":
+                value /= 1000;
+                break;
+            case "ms":
+                value /= (1000 * 1000);
+                break;
+            case "s":
+                value /= (1000 * 1000 * 1000);
+                break;
+            case "m":
+                value /= (60L * 1000 * 1000 * 1000);
+                break;
+            case "h":
+                value /= (60L * 60 * 1000 * 1000 * 1000);
+                break;
+            case "d":
+                value /= (24L * 60 * 60 * 1000 * 1000 * 1000);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid time unit: " + unit);
+        }
+        return aggregationType.equals("average") ? value / rowCount : value;
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/ByteSizeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/ByteSizeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.parser;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for {@link ByteSize} token.
+ */
+public class ByteSizeTest {
+    @Test
+    public void testParseBytes() {
+        // Test basic units
+        Assert.assertEquals(1L, new ByteSize("1B").getBytes());
+        Assert.assertEquals(1024L, new ByteSize("1KB").getBytes());
+        Assert.assertEquals(1024L * 1024L, new ByteSize("1MB").getBytes());
+        Assert.assertEquals(1024L * 1024L * 1024L, new ByteSize("1GB").getBytes());
+        Assert.assertEquals(1024L * 1024L * 1024L * 1024L, new ByteSize("1TB").getBytes());
+        Assert.assertEquals(1024L * 1024L * 1024L * 1024L * 1024L, new ByteSize("1PB").getBytes());
+
+        // Test decimal values
+        Assert.assertEquals(512L, new ByteSize("0.5KB").getBytes());
+        Assert.assertEquals(1536L, new ByteSize("1.5KB").getBytes());
+        Assert.assertEquals(1024L * 1024L * 1.5, new ByteSize("1.5MB").getBytes(), 0.001);
+
+        // Test case insensitivity
+        Assert.assertEquals(1024L, new ByteSize("1kb").getBytes());
+        Assert.assertEquals(1024L, new ByteSize("1Kb").getBytes());
+        Assert.assertEquals(1024L, new ByteSize("1kB").getBytes());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidUnit() {
+        new ByteSize("1XB");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidFormat() {
+        new ByteSize("KB");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidNumber() {
+        new ByteSize("abcKB");
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/DirectivesLexerTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/DirectivesLexerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2016-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.parser;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.Token;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DirectivesLexerTest {
+
+    @Test
+    public void testByteSizeTokens() {
+        String input = "10KB 1.5MB 2GB 0.5TB 100B";
+        DirectivesLexer lexer = new DirectivesLexer(CharStreams.fromString(input));
+        List<? extends Token> tokens = lexer.getAllTokens();
+
+        assertEquals(5, tokens.size());
+        assertEquals("10KB", tokens.get(0).getText());
+        assertEquals("1.5MB", tokens.get(1).getText());
+        assertEquals("2GB", tokens.get(2).getText());
+        assertEquals("0.5TB", tokens.get(3).getText());
+        assertEquals("100B", tokens.get(4).getText());
+    }
+
+    @Test
+    public void testTimeDurationTokens() {
+        String input = "10ms 1.5s 2m 0.5h 100ns";
+        DirectivesLexer lexer = new DirectivesLexer(CharStreams.fromString(input));
+        List<? extends Token> tokens = lexer.getAllTokens();
+
+        assertEquals(5, tokens.size());
+        assertEquals("10ms", tokens.get(0).getText());
+        assertEquals("1.5s", tokens.get(1).getText());
+        assertEquals("2m", tokens.get(2).getText());
+        assertEquals("0.5h", tokens.get(3).getText());
+        assertEquals("100ns", tokens.get(4).getText());
+    }
+
+    @Test
+    public void testMixedTokens() {
+        String input = "10KB 1.5s 2GB 0.5h";
+        DirectivesLexer lexer = new DirectivesLexer(CharStreams.fromString(input));
+        List<? extends Token> tokens = lexer.getAllTokens();
+
+        assertEquals(4, tokens.size());
+        assertEquals("10KB", tokens.get(0).getText());
+        assertEquals("1.5s", tokens.get(1).getText());
+        assertEquals("2GB", tokens.get(2).getText());
+        assertEquals("0.5h", tokens.get(3).getText());
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/DirectivesParserTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/DirectivesParserTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2016-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.parser;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import org.antlr.v4.runtime.CharStreams;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DirectivesParserTest {
+
+    @Test
+    public void testParseByteSize() {
+        String input = "10KB";
+        DirectivesLexer lexer = new DirectivesLexer(CharStreams.fromString(input));
+        DirectivesParser parser = new DirectivesParser(new CommonTokenStream(lexer));
+
+        DirectivesParser.ValueContext context = parser.value();
+        assertTrue(context.byteSize() != null);
+        assertEquals("10KB", context.byteSize().getText());
+    }
+
+    @Test
+    public void testParseTimeDuration() {
+        String input = "1.5s";
+        DirectivesLexer lexer = new DirectivesLexer(CharStreams.fromString(input));
+        DirectivesParser parser = new DirectivesParser(new CommonTokenStream(lexer));
+
+        DirectivesParser.ValueContext context = parser.value();
+        assertTrue(context.timeDuration() != null);
+        assertEquals("1.5s", context.timeDuration().getText());
+    }
+
+    @Test
+    public void testParseMixedValues() {
+        String input = "10KB 1.5s";
+        DirectivesLexer lexer = new DirectivesLexer(CharStreams.fromString(input));
+        DirectivesParser parser = new DirectivesParser(new CommonTokenStream(lexer));
+
+        DirectivesParser.ValueContext context1 = parser.value();
+        assertTrue(context1.byteSize() != null);
+        assertEquals("10KB", context1.byteSize().getText());
+
+        DirectivesParser.ValueContext context2 = parser.value();
+        assertTrue(context2.timeDuration() != null);
+        assertEquals("1.5s", context2.timeDuration().getText());
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/TimeDurationTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/TimeDurationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.parser;
+
+import io.cdap.wrangler.api.parser.TimeDuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for {@link TimeDuration} token.
+ */
+public class TimeDurationTest {
+    @Test
+    public void testParseNanoseconds() {
+        // Test basic units
+        Assert.assertEquals(1L, new TimeDuration("1ns").getNanoseconds());
+        Assert.assertEquals(1000L, new TimeDuration("1us").getNanoseconds());
+        Assert.assertEquals(1000L * 1000L, new TimeDuration("1ms").getNanoseconds());
+        Assert.assertEquals(1000L * 1000L * 1000L, new TimeDuration("1s").getNanoseconds());
+        Assert.assertEquals(60L * 1000L * 1000L * 1000L, new TimeDuration("1m").getNanoseconds());
+        Assert.assertEquals(60L * 60L * 1000L * 1000L * 1000L, new TimeDuration("1h").getNanoseconds());
+        Assert.assertEquals(24L * 60L * 60L * 1000L * 1000L * 1000L, new TimeDuration("1d").getNanoseconds());
+
+        // Test decimal values
+        Assert.assertEquals(500L, new TimeDuration("0.5us").getNanoseconds());
+        Assert.assertEquals(1500L, new TimeDuration("1.5us").getNanoseconds());
+        Assert.assertEquals(1000L * 1000L * 1.5, new TimeDuration("1.5ms").getNanoseconds(), 0.001);
+
+        // Test case insensitivity
+        Assert.assertEquals(1000L * 1000L, new TimeDuration("1MS").getNanoseconds());
+        Assert.assertEquals(1000L * 1000L * 1000L, new TimeDuration("1S").getNanoseconds());
+        Assert.assertEquals(60L * 1000L * 1000L * 1000L, new TimeDuration("1M").getNanoseconds());
+
+        // Test microsecond symbol
+        Assert.assertEquals(1000L, new TimeDuration("1µs").getNanoseconds());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidUnit() {
+        new TimeDuration("1xs");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidFormat() {
+        new TimeDuration("ms");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidNumber() {
+        new TimeDuration("abcms");
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/statistics/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/statistics/AggregateStatsTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.statistics;
+
+import io.cdap.directives.aggregates.AggregateStats;
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AggregateStatsTest {
+
+    @Test
+    public void testBasicAggregation() throws Exception {
+        ByteSize size1 = new ByteSize("1MB");
+        ByteSize size2 = new ByteSize("2MB");
+        TimeDuration time1 = new TimeDuration("1s");
+        TimeDuration time2 = new TimeDuration("2s");
+
+        Row row1 = new Row();
+        row1.add("size", size1);
+        row1.add("time", time1);
+
+        Row row2 = new Row();
+        row2.add("size", size2);
+        row2.add("time", time2);
+
+        AggregateStats directive = new AggregateStats(
+                new UsageDefinition("aggregate-stats", "size", "time", "total_size", "avg_size", "total_time",
+                        "avg_time"));
+
+        List<Row> rows = Arrays.asList(row1, row2);
+        rows = directive.execute(rows, null);
+
+        Assert.assertEquals(2, rows.size());
+
+        // Check total size (3MB)
+        Assert.assertEquals(3.0, rows.get(0).getValue("total_size"));
+        // Check average size (1.5MB)
+        Assert.assertEquals(1.5, rows.get(0).getValue("avg_size"));
+        // Check total time (3s)
+        Assert.assertEquals(3.0, rows.get(0).getValue("total_time"));
+        // Check average time (1.5s)
+        Assert.assertEquals(1.5, rows.get(0).getValue("avg_time"));
+    }
+
+    @Test
+    public void testMixedUnitsAggregation() throws Exception {
+        ByteSize size1 = new ByteSize("1KB");
+        ByteSize size2 = new ByteSize("1MB");
+        TimeDuration time1 = new TimeDuration("1s");
+        TimeDuration time2 = new TimeDuration("1m");
+
+        Row row1 = new Row();
+        row1.add("size", size1);
+        row1.add("time", time1);
+
+        Row row2 = new Row();
+        row2.add("size", size2);
+        row2.add("time", time2);
+
+        AggregateStats directive = new AggregateStats(
+                new UsageDefinition("aggregate-stats", "size", "time", "total_size", "avg_size", "total_time",
+                        "avg_time"));
+
+        List<Row> rows = Arrays.asList(row1, row2);
+        rows = directive.execute(rows, null);
+
+        Assert.assertEquals(2, rows.size());
+
+        // 1KB + 1MB = 1025KB = 1.001953125MB
+        Assert.assertEquals(1.001953125, rows.get(0).getValue("total_size"), 0.0001);
+        Assert.assertEquals(0.5009765625, rows.get(0).getValue("avg_size"), 0.0001);
+
+        // 1s + 60s = 61s
+        Assert.assertEquals(61.0, rows.get(0).getValue("total_time"), 0.0001);
+        Assert.assertEquals(30.5, rows.get(0).getValue("avg_time"), 0.0001);
+    }
+
+    @Test
+    public void testFullRecipeWithJsonData() throws Exception {
+        String[] directives = new String[] {
+                "parse-as-json :records",
+                "parse-as-byte-size :file_size file_size_bytes",
+                "parse-as-time-duration :response_time response_time_ms",
+                "aggregate-stats :file_size_bytes :response_time_ms total_size avg_size total_time avg_time"
+        };
+
+        // Create test data similar to test-data.json
+        Row row1 = new Row();
+        row1.add("records", "{\"file_size\": \"1.5KB\", \"response_time\": \"250ms\", \"name\": \"file1.txt\"}");
+
+        Row row2 = new Row();
+        row2.add("records", "{\"file_size\": \"2.8MB\", \"response_time\": \"1.2s\", \"name\": \"file2.jpg\"}");
+
+        Row row3 = new Row();
+        row3.add("records", "{\"file_size\": \"512B\", \"response_time\": \"450ms\", \"name\": \"file3.txt\"}");
+
+        Row row4 = new Row();
+        row4.add("records", "{\"file_size\": \"15MB\", \"response_time\": \"3.5s\", \"name\": \"file4.mp4\"}");
+
+        Row row5 = new Row();
+        row5.add("records", "{\"file_size\": \"750KB\", \"response_time\": \"180ms\", \"name\": \"file5.pdf\"}");
+
+        List<Row> rows = TestingRig.execute(directives, Arrays.asList(row1, row2, row3, row4, row5));
+
+        Assert.assertEquals(5, rows.size());
+
+        // Verify the final aggregated metrics (checking the first row's values)
+        Row firstRow = rows.get(0);
+        Assert.assertTrue(firstRow.getValue("total_size") instanceof Double);
+        Assert.assertTrue(firstRow.getValue("avg_size") instanceof Double);
+        Assert.assertTrue(firstRow.getValue("total_time") instanceof Double);
+        Assert.assertTrue(firstRow.getValue("avg_time") instanceof Double);
+
+        // Expected values (approximate):
+        // Total size: 1.5KB + 2.8MB + 512B + 15MB + 750KB ≈ 18.55MB
+        // Avg size: 18.55MB / 5 ≈ 3.71MB
+        // Total time: 250ms + 1.2s + 450ms + 3.5s + 180ms = 5.58s
+        // Avg time: 5.58s / 5 = 1.116s
+
+        // Check with some tolerance for floating-point calculations
+        Assert.assertTrue(firstRow.getValue("total_size").toString().startsWith("18."));
+        Assert.assertTrue(firstRow.getValue("avg_size").toString().startsWith("3.7"));
+        Assert.assertTrue(Math.abs(5.58 - (Double) firstRow.getValue("total_time")) < 0.1);
+        Assert.assertTrue(Math.abs(1.116 - (Double) firstRow.getValue("avg_time")) < 0.1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidByteSizeInput() throws Exception {
+        ByteSize size1 = new ByteSize("1MB");
+        Row row1 = new Row();
+        row1.add("size", size1);
+        row1.add("time", "not a time duration");
+
+        AggregateStats directive = new AggregateStats(
+                new UsageDefinition("aggregate-stats", "size", "time", "total_size", "avg_size", "total_time",
+                        "avg_time"));
+
+        directive.execute(Arrays.asList(row1), null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidTimeDurationInput() throws Exception {
+        TimeDuration time1 = new TimeDuration("1s");
+        Row row1 = new Row();
+        row1.add("size", "not a byte size");
+        row1.add("time", time1);
+
+        AggregateStats directive = new AggregateStats(
+                new UsageDefinition("aggregate-stats", "size", "time", "total_size", "avg_size", "total_time",
+                        "avg_time"));
+
+        directive.execute(Arrays.asList(row1), null);
+    }
+}


### PR DESCRIPTION
     This PR enhances the CDAP Wrangler library with new token parsers for byte sizes and time durations:

     - Implemented ByteSize token for parsing values like "1.5KB", "2.8MB" with proper unit conversion
     - Implemented TimeDuration token for parsing values like "250ms", "1.2s", "2m" with proper unit conversion
     - Added BYTE_SIZE and TIME_DURATION to the TokenType enum
     - Created aggregate-stats directive that processes byte sizes and time durations to calculate totals and averages
     - Added comprehensive tests for ByteSize, TimeDuration, and AggregateStats
     - Updated README.md with usage documentation for these new parsers

     Both parsers handle decimal values, case-insensitivity, and throw appropriate exceptions for invalid inputs.