### PR TITLE
Assignment for Intern 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ release.properties
 
 # Remove dev directory.
 dev
+.qodo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ cleansing, transformation, and filtering using a set of data manipulation instru
 (directives). These instructions are either generated using an interative visual tool or
 are manually created.
 
-  * Data Prep defines few concepts that might be useful if you are just getting started with it. Learn about them [here](wrangler-docs/concepts.md)
-  * The Data Prep Transform is [separately documented](wrangler-transform/wrangler-docs/data-prep-transform.md).
-  * [Data Prep Cheatsheet](wrangler-docs/cheatsheet.md)
+- Data Prep defines few concepts that might be useful if you are just getting started with it. Learn about them [here](wrangler-docs/concepts.md)
+- The Data Prep Transform is [separately documented](wrangler-transform/wrangler-docs/data-prep-transform.md).
+- [Data Prep Cheatsheet](wrangler-docs/cheatsheet.md)
 
 ## New Features
 
 More [here](wrangler-docs/upcoming-features.md) on upcoming features.
 
-  * **User Defined Directives, also known as UDD**, allow you to create custom functions to transform records within CDAP DataPrep or a.k.a Wrangler. CDAP comes with a comprehensive library of functions. There are however some omissions, and some specific cases for which UDDs are the solution. Additional information on how you can build your custom directives [here](wrangler-docs/custom-directive.md).
-    * Migrating directives from version 1.0 to version 2.0 [here](wrangler-docs/directive-migration.md)
-    * Information about Grammar [here](wrangler-docs/grammar/grammar-info.md)
-    * Various `TokenType` supported by system [here](../api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java)
-    * Custom Directive Implementation Internals [here](wrangler-docs/udd-internal.md)
+- **User Defined Directives, also known as UDD**, allow you to create custom functions to transform records within CDAP DataPrep or a.k.a Wrangler. CDAP comes with a comprehensive library of functions. There are however some omissions, and some specific cases for which UDDs are the solution. Additional information on how you can build your custom directives [here](wrangler-docs/custom-directive.md).
 
-  * A new capability that allows CDAP Administrators to **restrict the directives** that are accessible to their users.
-More information on configuring can be found [here](wrangler-docs/exclusion-and-aliasing.md)
+  - Migrating directives from version 1.0 to version 2.0 [here](wrangler-docs/directive-migration.md)
+  - Information about Grammar [here](wrangler-docs/grammar/grammar-info.md)
+  - Various `TokenType` supported by system [here](../api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java)
+  - Custom Directive Implementation Internals [here](wrangler-docs/udd-internal.md)
+
+- A new capability that allows CDAP Administrators to **restrict the directives** that are accessible to their users.
+  More information on configuring can be found [here](wrangler-docs/exclusion-and-aliasing.md)
 
 ## Demo Videos and Recipes
 
@@ -37,144 +38,143 @@ Videos and Screencasts are best way to learn, so we have compiled simple, short 
 
 ### Videos
 
-  * [SCREENCAST] [Creating Lookup Dataset and Joining](https://www.youtube.com/watch?v=Nc1b0rsELHQ)
-  * [SCREENCAST] [Restricted Directives](https://www.youtube.com/watch?v=71EcMQU714U)
-  * [SCREENCAST] [Parse Excel files in CDAP](https://www.youtube.com/watch?v=su5L1noGlEk)
-  * [SCREENCAST] [Parse File As AVRO File](https://www.youtube.com/watch?v=tmwAw4dKUNc)
-  * [SCREENCAST] [Parsing Binary Coded AVRO Messages](https://www.youtube.com/watch?v=Ix_lPo-PDJY)
-  * [SCREENCAST] [Parsing Binary Coded AVRO Messages & Protobuf messages using schema registry](https://www.youtube.com/watch?v=LVLIdWnUX1k)
-  * [SCREENCAST] [Quantize a column - Digitize](https://www.youtube.com/watch?v=VczkYX5SRtY)
-  * [SCREENCAST] [Data Cleansing capability with send-to-error directive](https://www.youtube.com/watch?v=aZd5H8hIjDc)
-  * [SCREENCAST] [Building Data Prep from the GitHub source](https://youtu.be/pGGjKU04Y38)
-  * [VOICE-OVER] [End-to-End Demo Video](https://youtu.be/AnhF0qRmn24)
-  * [SCREENCAST] [Ingesting into Kudu](https://www.youtube.com/watch?v=KBW7a38vlUM)
-  * [SCREENCAST] [Realtime HL7 CCDA XML from Kafka into Time Parititioned Parquet](https://youtu.be/0fqNmnOnD-0)
-  * [SCREENCAST] [Parsing JSON file](https://youtu.be/vwnctcGDflE)
-  * [SCREENCAST] [Flattening arrays](https://youtu.be/SemHxgBYIsY)
-  * [SCREENCAST] [Data cleansing with send-to-error directive](https://www.youtube.com/watch?v=aZd5H8hIjDc)
-  * [SCREENCAST] [Publishing to Kafka](https://www.youtube.com/watch?v=xdc8pvvlI48)
-  * [SCREENCAST] [Fixed length to JSON](https://www.youtube.com/watch?v=3AXu4m1swuM)
+- [SCREENCAST] [Creating Lookup Dataset and Joining](https://www.youtube.com/watch?v=Nc1b0rsELHQ)
+- [SCREENCAST] [Restricted Directives](https://www.youtube.com/watch?v=71EcMQU714U)
+- [SCREENCAST] [Parse Excel files in CDAP](https://www.youtube.com/watch?v=su5L1noGlEk)
+- [SCREENCAST] [Parse File As AVRO File](https://www.youtube.com/watch?v=tmwAw4dKUNc)
+- [SCREENCAST] [Parsing Binary Coded AVRO Messages](https://www.youtube.com/watch?v=Ix_lPo-PDJY)
+- [SCREENCAST] [Parsing Binary Coded AVRO Messages & Protobuf messages using schema registry](https://www.youtube.com/watch?v=LVLIdWnUX1k)
+- [SCREENCAST] [Quantize a column - Digitize](https://www.youtube.com/watch?v=VczkYX5SRtY)
+- [SCREENCAST] [Data Cleansing capability with send-to-error directive](https://www.youtube.com/watch?v=aZd5H8hIjDc)
+- [SCREENCAST] [Building Data Prep from the GitHub source](https://youtu.be/pGGjKU04Y38)
+- [VOICE-OVER] [End-to-End Demo Video](https://youtu.be/AnhF0qRmn24)
+- [SCREENCAST] [Ingesting into Kudu](https://www.youtube.com/watch?v=KBW7a38vlUM)
+- [SCREENCAST] [Realtime HL7 CCDA XML from Kafka into Time Parititioned Parquet](https://youtu.be/0fqNmnOnD-0)
+- [SCREENCAST] [Parsing JSON file](https://youtu.be/vwnctcGDflE)
+- [SCREENCAST] [Flattening arrays](https://youtu.be/SemHxgBYIsY)
+- [SCREENCAST] [Data cleansing with send-to-error directive](https://www.youtube.com/watch?v=aZd5H8hIjDc)
+- [SCREENCAST] [Publishing to Kafka](https://www.youtube.com/watch?v=xdc8pvvlI48)
+- [SCREENCAST] [Fixed length to JSON](https://www.youtube.com/watch?v=3AXu4m1swuM)
 
 ### Recipes
 
-  * [Parsing Apache Log Files](wrangler-demos/parsing-apache-log-files.md)
-  * [Parsing CSV Files and Extracting Column Values](wrangler-demos/parsing-csv-extracting-column-values.md)
-  * [Parsing HL7 CCDA XML Files](wrangler-demos/parsing-hl7-ccda-xml-files.md)
+- [Parsing Apache Log Files](wrangler-demos/parsing-apache-log-files.md)
+- [Parsing CSV Files and Extracting Column Values](wrangler-demos/parsing-csv-extracting-column-values.md)
+- [Parsing HL7 CCDA XML Files](wrangler-demos/parsing-hl7-ccda-xml-files.md)
 
 ## Available Directives
 
 These directives are currently available:
 
-| Directive                                                              | Description                                                      |
-| ---------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| **Parsers**                                                            |                                                                  |
-| [JSON Path](wrangler-docs/directives/json-path.md)                              | Uses a DSL (a JSON path expression) for parsing JSON records     |
-| [Parse as AVRO](wrangler-docs/directives/parse-as-avro.md)                      | Parsing an AVRO encoded message - either as binary or json       |
-| [Parse as AVRO File](wrangler-docs/directives/parse-as-avro-file.md)            | Parsing an AVRO data file                                        |
-| [Parse as CSV](wrangler-docs/directives/parse-as-csv.md)                        | Parsing an input record as comma-separated values                |
-| [Parse as Date](wrangler-docs/directives/parse-as-date.md)                      | Parsing dates using natural language processing                  |
-| [Parse as Excel](wrangler-docs/directives/parse-as-excel.md)                    | Parsing excel file.                                              |
-| [Parse as Fixed Length](wrangler-docs/directives/parse-as-fixed-length.md)      | Parses as a fixed length record with specified widths            |
-| [Parse as HL7](wrangler-docs/directives/parse-as-hl7.md)                        | Parsing Health Level 7 Version 2 (HL7 V2) messages               |
-| [Parse as JSON](wrangler-docs/directives/parse-as-json.md)                      | Parsing a JSON object                                            |
-| [Parse as Log](wrangler-docs/directives/parse-as-log.md)                        | Parses access log files as from Apache HTTPD and nginx servers   |
-| [Parse as Protobuf](wrangler-docs/directives/parse-as-log.md)                   | Parses an Protobuf encoded in-memory message using descriptor    |
-| [Parse as Simple Date](wrangler-docs/directives/parse-as-simple-date.md)        | Parses date strings                                              |
-| [Parse XML To JSON](wrangler-docs/directives/parse-xml-to-json.md)              | Parses an XML document into a JSON structure                     |
-| [Parse as Currency](wrangler-docs/directives/parse-as-currency.md)              | Parses a string representation of currency into a number.        |
-| [Parse as Datetime](wrangler-docs/directives/parse-as-datetime.md)              | Parses strings with datetime values to CDAP datetime type        |
-| **Output Formatters**                                                  |                                                                  |
-| [Write as CSV](wrangler-docs/directives/write-as-csv.md)                        | Converts a record into CSV format                                |
-| [Write as JSON](wrangler-docs/directives/write-as-json-map.md)                  | Converts the record into a JSON map                              |
-| [Write JSON Object](wrangler-docs/directives/write-as-json-object.md)           | Composes a JSON object based on the fields specified.            |
-| [Format as Currency](wrangler-docs/directives/format-as-currency.md)            | Formats a number as currency as specified by locale.             |
-| **Transformations**                                                    |                                                                  |
-| [Changing Case](wrangler-docs/directives/changing-case.md)                      | Changes the case of column values                                |
-| [Cut Character](wrangler-docs/directives/cut-character.md)                      | Selects parts of a string value                                  |
-| [Set Column](wrangler-docs/directives/set-column.md)                            | Sets the column value to the result of an expression execution   |
-| [Find and Replace](wrangler-docs/directives/find-and-replace.md)                | Transforms string column values using a "sed"-like expression    |
-| [Index Split](wrangler-docs/directives/index-split.md)                          | (_Deprecated_)                                                   |
-| [Invoke HTTP](wrangler-docs/directives/invoke-http.md)                          | Invokes an HTTP Service (_Experimental_, potentially slow)       |
-| [Quantization](wrangler-docs/directives/quantize.md)                            | Quantizes a column based on specified ranges                     |
-| [Regex Group Extractor](wrangler-docs/directives/extract-regex-groups.md)       | Extracts the data from a regex group into its own column         |
-| [Setting Character Set](wrangler-docs/directives/set-charset.md)                | Sets the encoding and then converts the data to a UTF-8 String   |
-| [Setting Record Delimiter](wrangler-docs/directives/set-record-delim.md)        | Sets the record delimiter                                        |
-| [Split by Separator](wrangler-docs/directives/split-by-separator.md)            | Splits a column based on a separator into two columns            |
-| [Split Email Address](wrangler-docs/directives/split-email.md)                  | Splits an email ID into an account and its domain                |
-| [Split URL](wrangler-docs/directives/split-url.md)                              | Splits a URL into its constituents                               |
-| [Text Distance (Fuzzy String Match)](wrangler-docs/directives/text-distance.md) | Measures the difference between two sequences of characters      |
-| [Text Metric (Fuzzy String Match)](wrangler-docs/directives/text-metric.md)     | Measures the difference between two sequences of characters      |
-| [URL Decode](wrangler-docs/directives/url-decode.md)                            | Decodes from the `application/x-www-form-urlencoded` MIME format |
-| [URL Encode](wrangler-docs/directives/url-encode.md)                            | Encodes to the `application/x-www-form-urlencoded` MIME format   |
-| [Trim](wrangler-docs/directives/trim.md)                                        | Functions for trimming white spaces around string data           |
-| **Encoders and Decoders**                                              |                                                                  |
-| [Decode](wrangler-docs/directives/decode.md)                                    | Decodes a column value as one of `base32`, `base64`, or `hex`    |
-| [Encode](wrangler-docs/directives/encode.md)                                    | Encodes a column value as one of `base32`, `base64`, or `hex`    |
-| **Unique ID**                                                          |                                                                  |
-| [UUID Generation](wrangler-docs/directives/generate-uuid.md)                    | Generates a universally unique identifier (UUID) .Recommended to use with Wrangler version 4.4.0 and above due to an important bug fix [CDAP-17732](https://cdap.atlassian.net/browse/CDAP-17732)             |
-| **Date Transformations**                                               |                                                                  |
-| [Diff Date](wrangler-docs/directives/diff-date.md)                              | Calculates the difference between two dates                      |
-| [Format Date](wrangler-docs/directives/format-date.md)                          | Custom patterns for date-time formatting                         |
-| [Format Unix Timestamp](wrangler-docs/directives/format-unix-timestamp.md)      | Formats a UNIX timestamp as a date                               |
-| **DateTime Transformations**                                                    |                                                                  |
-| [Current DateTime](wrangler-docs/directives/current-datetime.md)                | Generates the current datetime using the given zone or UTC by default|
-| [Datetime To Timestamp](wrangler-docs/directives/datetime-to-timestamp.md)      | Converts a datetime value to timestamp with the given zone       |
-| [Format Datetime](wrangler-docs/directives/format-datetime.md)                  | Formats a datetime value to custom date time pattern strings     |
-| [Timestamp To Datetime](wrangler-docs/directives/timestamp-to-datetime.md)      | Converts a timestamp value to datetime                           |
-| **Lookups**                                                            |                                                                  |
-| [Catalog Lookup](wrangler-docs/directives/catalog-lookup.md)                    | Static catalog lookup of ICD-9, ICD-10-2016, ICD-10-2017 codes   |
-| [Table Lookup](wrangler-docs/directives/table-lookup.md)                        | Performs lookups into Table datasets                             |
-| **Hashing & Masking**                                                  |                                                                  |
-| [Message Digest or Hash](wrangler-docs/directives/hash.md)                      | Generates a message digest                                       |
-| [Mask Number](wrangler-docs/directives/mask-number.md)                          | Applies substitution masking on the column values                |
-| [Mask Shuffle](wrangler-docs/directives/mask-shuffle.md)                        | Applies shuffle masking on the column values                     |
-| **Row Operations**                                                     |                                                                  |
-| [Filter Row if Matched](wrangler-docs/directives/filter-row-if-matched.md)      | Filters rows that match a pattern for a column                                         |
-| [Filter Row if True](wrangler-docs/directives/filter-row-if-true.md)            | Filters rows if the condition is true.                                                  |
-| [Filter Row Empty of Null](wrangler-docs/directives/filter-empty-or-null.md)    | Filters rows that are empty of null.                    |
-| [Flatten](wrangler-docs/directives/flatten.md)                                  | Separates the elements in a repeated field                       |
-| [Fail on condition](wrangler-docs/directives/fail.md)                           | Fails processing when the condition is evaluated to true.        |
-| [Send to Error](wrangler-docs/directives/send-to-error.md)                      | Filtering of records to an error collector                       |
-| [Send to Error And Continue](wrangler-docs/directives/send-to-error-and-continue.md) | Filtering of records to an error collector and continues processing                      |
-| [Split to Rows](wrangler-docs/directives/split-to-rows.md)                      | Splits based on a separator into multiple records                |
-| **Column Operations**                                                  |                                                                  |
-| [Change Column Case](wrangler-docs/directives/change-column-case.md)            | Changes column names to either lowercase or uppercase            |
-| [Changing Case](wrangler-docs/directives/changing-case.md)                      | Change the case of column values                                 |
-| [Cleanse Column Names](wrangler-docs/directives/cleanse-column-names.md)        | Sanatizes column names, following specific rules                 |
-| [Columns Replace](wrangler-docs/directives/columns-replace.md)                  | Alters column names in bulk                                      |
-| [Copy](wrangler-docs/directives/copy.md)                                        | Copies values from a source column into a destination column     |
-| [Drop Column](wrangler-docs/directives/drop.md)                                 | Drops a column in a record                                       |
-| [Fill Null or Empty Columns](wrangler-docs/directives/fill-null-or-empty.md)    | Fills column value with a fixed value if null or empty           |
-| [Keep Columns](wrangler-docs/directives/keep.md)                                | Keeps specified columns from the record                          |
-| [Merge Columns](wrangler-docs/directives/merge.md)                              | Merges two columns by inserting a third column                   |
-| [Rename Column](wrangler-docs/directives/rename.md)                             | Renames an existing column in the record                         |
-| [Set Column Header](wrangler-docs/directives/set-headers.md)                     | Sets the names of columns, in the order they are specified       |
-| [Split to Columns](wrangler-docs/directives/split-to-columns.md)                | Splits a column based on a separator into multiple columns       |
-| [Swap Columns](wrangler-docs/directives/swap.md)                                | Swaps column names of two columns                                |
-| [Set Column Data Type](wrangler-docs/directives/set-type.md)                    | Convert data type of a column                                    |
-| **NLP**                                                                |                                                                  |
-| [Stemming Tokenized Words](wrangler-docs/directives/stemming.md)                | Applies the Porter stemmer algorithm for English words           |
-| **Transient Aggregators & Setters**                                    |                                                                  |
-| [Increment Variable](wrangler-docs/directives/increment-variable.md)            | Increments a transient variable with a record of processing.     |
-| [Set Variable](wrangler-docs/directives/set-variable.md)                        | Sets a transient variable with a record of processing.     |
-| **Functions**                                                          |                                                                  |
-| [Data Quality](wrangler-docs/functions/dq-functions.md)                         | Data quality check functions. Checks for date, time, etc.        |
-| [Date Manipulations](wrangler-docs/functions/date-functions.md)                 | Functions that can manipulate date                               |
-| [DDL](wrangler-docs/functions/ddl-functions.md)                                 | Functions that can manipulate definition of data                 |
-| [JSON](wrangler-docs/functions/json-functions.md)                               | Functions that can be useful in transforming your data           |
-| [Types](wrangler-docs/functions/type-functions.md)                              | Functions for detecting the type of data                         |
+| Directive                                                                            | Description                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Parsers**                                                                          |                                                                                                                                                                                                   |
+| [JSON Path](wrangler-docs/directives/json-path.md)                                   | Uses a DSL (a JSON path expression) for parsing JSON records                                                                                                                                      |
+| [Parse as AVRO](wrangler-docs/directives/parse-as-avro.md)                           | Parsing an AVRO encoded message - either as binary or json                                                                                                                                        |
+| [Parse as AVRO File](wrangler-docs/directives/parse-as-avro-file.md)                 | Parsing an AVRO data file                                                                                                                                                                         |
+| [Parse as CSV](wrangler-docs/directives/parse-as-csv.md)                             | Parsing an input record as comma-separated values                                                                                                                                                 |
+| [Parse as Date](wrangler-docs/directives/parse-as-date.md)                           | Parsing dates using natural language processing                                                                                                                                                   |
+| [Parse as Excel](wrangler-docs/directives/parse-as-excel.md)                         | Parsing excel file.                                                                                                                                                                               |
+| [Parse as Fixed Length](wrangler-docs/directives/parse-as-fixed-length.md)           | Parses as a fixed length record with specified widths                                                                                                                                             |
+| [Parse as HL7](wrangler-docs/directives/parse-as-hl7.md)                             | Parsing Health Level 7 Version 2 (HL7 V2) messages                                                                                                                                                |
+| [Parse as JSON](wrangler-docs/directives/parse-as-json.md)                           | Parsing a JSON object                                                                                                                                                                             |
+| [Parse as Log](wrangler-docs/directives/parse-as-log.md)                             | Parses access log files as from Apache HTTPD and nginx servers                                                                                                                                    |
+| [Parse as Protobuf](wrangler-docs/directives/parse-as-log.md)                        | Parses an Protobuf encoded in-memory message using descriptor                                                                                                                                     |
+| [Parse as Simple Date](wrangler-docs/directives/parse-as-simple-date.md)             | Parses date strings                                                                                                                                                                               |
+| [Parse XML To JSON](wrangler-docs/directives/parse-xml-to-json.md)                   | Parses an XML document into a JSON structure                                                                                                                                                      |
+| [Parse as Currency](wrangler-docs/directives/parse-as-currency.md)                   | Parses a string representation of currency into a number.                                                                                                                                         |
+| [Parse as Datetime](wrangler-docs/directives/parse-as-datetime.md)                   | Parses strings with datetime values to CDAP datetime type                                                                                                                                         |
+| **Output Formatters**                                                                |                                                                                                                                                                                                   |
+| [Write as CSV](wrangler-docs/directives/write-as-csv.md)                             | Converts a record into CSV format                                                                                                                                                                 |
+| [Write as JSON](wrangler-docs/directives/write-as-json-map.md)                       | Converts the record into a JSON map                                                                                                                                                               |
+| [Write JSON Object](wrangler-docs/directives/write-as-json-object.md)                | Composes a JSON object based on the fields specified.                                                                                                                                             |
+| [Format as Currency](wrangler-docs/directives/format-as-currency.md)                 | Formats a number as currency as specified by locale.                                                                                                                                              |
+| **Transformations**                                                                  |                                                                                                                                                                                                   |
+| [Changing Case](wrangler-docs/directives/changing-case.md)                           | Changes the case of column values                                                                                                                                                                 |
+| [Cut Character](wrangler-docs/directives/cut-character.md)                           | Selects parts of a string value                                                                                                                                                                   |
+| [Set Column](wrangler-docs/directives/set-column.md)                                 | Sets the column value to the result of an expression execution                                                                                                                                    |
+| [Find and Replace](wrangler-docs/directives/find-and-replace.md)                     | Transforms string column values using a "sed"-like expression                                                                                                                                     |
+| [Index Split](wrangler-docs/directives/index-split.md)                               | (_Deprecated_)                                                                                                                                                                                    |
+| [Invoke HTTP](wrangler-docs/directives/invoke-http.md)                               | Invokes an HTTP Service (_Experimental_, potentially slow)                                                                                                                                        |
+| [Quantization](wrangler-docs/directives/quantize.md)                                 | Quantizes a column based on specified ranges                                                                                                                                                      |
+| [Regex Group Extractor](wrangler-docs/directives/extract-regex-groups.md)            | Extracts the data from a regex group into its own column                                                                                                                                          |
+| [Setting Character Set](wrangler-docs/directives/set-charset.md)                     | Sets the encoding and then converts the data to a UTF-8 String                                                                                                                                    |
+| [Setting Record Delimiter](wrangler-docs/directives/set-record-delim.md)             | Sets the record delimiter                                                                                                                                                                         |
+| [Split by Separator](wrangler-docs/directives/split-by-separator.md)                 | Splits a column based on a separator into two columns                                                                                                                                             |
+| [Split Email Address](wrangler-docs/directives/split-email.md)                       | Splits an email ID into an account and its domain                                                                                                                                                 |
+| [Split URL](wrangler-docs/directives/split-url.md)                                   | Splits a URL into its constituents                                                                                                                                                                |
+| [Text Distance (Fuzzy String Match)](wrangler-docs/directives/text-distance.md)      | Measures the difference between two sequences of characters                                                                                                                                       |
+| [Text Metric (Fuzzy String Match)](wrangler-docs/directives/text-metric.md)          | Measures the difference between two sequences of characters                                                                                                                                       |
+| [URL Decode](wrangler-docs/directives/url-decode.md)                                 | Decodes from the `application/x-www-form-urlencoded` MIME format                                                                                                                                  |
+| [URL Encode](wrangler-docs/directives/url-encode.md)                                 | Encodes to the `application/x-www-form-urlencoded` MIME format                                                                                                                                    |
+| [Trim](wrangler-docs/directives/trim.md)                                             | Functions for trimming white spaces around string data                                                                                                                                            |
+| **Encoders and Decoders**                                                            |                                                                                                                                                                                                   |
+| [Decode](wrangler-docs/directives/decode.md)                                         | Decodes a column value as one of `base32`, `base64`, or `hex`                                                                                                                                     |
+| [Encode](wrangler-docs/directives/encode.md)                                         | Encodes a column value as one of `base32`, `base64`, or `hex`                                                                                                                                     |
+| **Unique ID**                                                                        |                                                                                                                                                                                                   |
+| [UUID Generation](wrangler-docs/directives/generate-uuid.md)                         | Generates a universally unique identifier (UUID) .Recommended to use with Wrangler version 4.4.0 and above due to an important bug fix [CDAP-17732](https://cdap.atlassian.net/browse/CDAP-17732) |
+| **Date Transformations**                                                             |                                                                                                                                                                                                   |
+| [Diff Date](wrangler-docs/directives/diff-date.md)                                   | Calculates the difference between two dates                                                                                                                                                       |
+| [Format Date](wrangler-docs/directives/format-date.md)                               | Custom patterns for date-time formatting                                                                                                                                                          |
+| [Format Unix Timestamp](wrangler-docs/directives/format-unix-timestamp.md)           | Formats a UNIX timestamp as a date                                                                                                                                                                |
+| **DateTime Transformations**                                                         |                                                                                                                                                                                                   |
+| [Current DateTime](wrangler-docs/directives/current-datetime.md)                     | Generates the current datetime using the given zone or UTC by default                                                                                                                             |
+| [Datetime To Timestamp](wrangler-docs/directives/datetime-to-timestamp.md)           | Converts a datetime value to timestamp with the given zone                                                                                                                                        |
+| [Format Datetime](wrangler-docs/directives/format-datetime.md)                       | Formats a datetime value to custom date time pattern strings                                                                                                                                      |
+| [Timestamp To Datetime](wrangler-docs/directives/timestamp-to-datetime.md)           | Converts a timestamp value to datetime                                                                                                                                                            |
+| **Lookups**                                                                          |                                                                                                                                                                                                   |
+| [Catalog Lookup](wrangler-docs/directives/catalog-lookup.md)                         | Static catalog lookup of ICD-9, ICD-10-2016, ICD-10-2017 codes                                                                                                                                    |
+| [Table Lookup](wrangler-docs/directives/table-lookup.md)                             | Performs lookups into Table datasets                                                                                                                                                              |
+| **Hashing & Masking**                                                                |                                                                                                                                                                                                   |
+| [Message Digest or Hash](wrangler-docs/directives/hash.md)                           | Generates a message digest                                                                                                                                                                        |
+| [Mask Number](wrangler-docs/directives/mask-number.md)                               | Applies substitution masking on the column values                                                                                                                                                 |
+| [Mask Shuffle](wrangler-docs/directives/mask-shuffle.md)                             | Applies shuffle masking on the column values                                                                                                                                                      |
+| **Row Operations**                                                                   |                                                                                                                                                                                                   |
+| [Filter Row if Matched](wrangler-docs/directives/filter-row-if-matched.md)           | Filters rows that match a pattern for a column                                                                                                                                                    |
+| [Filter Row if True](wrangler-docs/directives/filter-row-if-true.md)                 | Filters rows if the condition is true.                                                                                                                                                            |
+| [Filter Row Empty of Null](wrangler-docs/directives/filter-empty-or-null.md)         | Filters rows that are empty of null.                                                                                                                                                              |
+| [Flatten](wrangler-docs/directives/flatten.md)                                       | Separates the elements in a repeated field                                                                                                                                                        |
+| [Fail on condition](wrangler-docs/directives/fail.md)                                | Fails processing when the condition is evaluated to true.                                                                                                                                         |
+| [Send to Error](wrangler-docs/directives/send-to-error.md)                           | Filtering of records to an error collector                                                                                                                                                        |
+| [Send to Error And Continue](wrangler-docs/directives/send-to-error-and-continue.md) | Filtering of records to an error collector and continues processing                                                                                                                               |
+| [Split to Rows](wrangler-docs/directives/split-to-rows.md)                           | Splits based on a separator into multiple records                                                                                                                                                 |
+| **Column Operations**                                                                |                                                                                                                                                                                                   |
+| [Change Column Case](wrangler-docs/directives/change-column-case.md)                 | Changes column names to either lowercase or uppercase                                                                                                                                             |
+| [Changing Case](wrangler-docs/directives/changing-case.md)                           | Change the case of column values                                                                                                                                                                  |
+| [Cleanse Column Names](wrangler-docs/directives/cleanse-column-names.md)             | Sanatizes column names, following specific rules                                                                                                                                                  |
+| [Columns Replace](wrangler-docs/directives/columns-replace.md)                       | Alters column names in bulk                                                                                                                                                                       |
+| [Copy](wrangler-docs/directives/copy.md)                                             | Copies values from a source column into a destination column                                                                                                                                      |
+| [Drop Column](wrangler-docs/directives/drop.md)                                      | Drops a column in a record                                                                                                                                                                        |
+| [Fill Null or Empty Columns](wrangler-docs/directives/fill-null-or-empty.md)         | Fills column value with a fixed value if null or empty                                                                                                                                            |
+| [Keep Columns](wrangler-docs/directives/keep.md)                                     | Keeps specified columns from the record                                                                                                                                                           |
+| [Merge Columns](wrangler-docs/directives/merge.md)                                   | Merges two columns by inserting a third column                                                                                                                                                    |
+| [Rename Column](wrangler-docs/directives/rename.md)                                  | Renames an existing column in the record                                                                                                                                                          |
+| [Set Column Header](wrangler-docs/directives/set-headers.md)                         | Sets the names of columns, in the order they are specified                                                                                                                                        |
+| [Split to Columns](wrangler-docs/directives/split-to-columns.md)                     | Splits a column based on a separator into multiple columns                                                                                                                                        |
+| [Swap Columns](wrangler-docs/directives/swap.md)                                     | Swaps column names of two columns                                                                                                                                                                 |
+| [Set Column Data Type](wrangler-docs/directives/set-type.md)                         | Convert data type of a column                                                                                                                                                                     |
+| **NLP**                                                                              |                                                                                                                                                                                                   |
+| [Stemming Tokenized Words](wrangler-docs/directives/stemming.md)                     | Applies the Porter stemmer algorithm for English words                                                                                                                                            |
+| **Transient Aggregators & Setters**                                                  |                                                                                                                                                                                                   |
+| [Increment Variable](wrangler-docs/directives/increment-variable.md)                 | Increments a transient variable with a record of processing.                                                                                                                                      |
+| [Set Variable](wrangler-docs/directives/set-variable.md)                             | Sets a transient variable with a record of processing.                                                                                                                                            |
+| **Functions**                                                                        |                                                                                                                                                                                                   |
+| [Data Quality](wrangler-docs/functions/dq-functions.md)                              | Data quality check functions. Checks for date, time, etc.                                                                                                                                         |
+| [Date Manipulations](wrangler-docs/functions/date-functions.md)                      | Functions that can manipulate date                                                                                                                                                                |
+| [DDL](wrangler-docs/functions/ddl-functions.md)                                      | Functions that can manipulate definition of data                                                                                                                                                  |
+| [JSON](wrangler-docs/functions/json-functions.md)                                    | Functions that can be useful in transforming your data                                                                                                                                            |
+| [Types](wrangler-docs/functions/type-functions.md)                                   | Functions for detecting the type of data                                                                                                                                                          |
 
 ## Performance
 
 Initial performance tests show that with a set of directives of high complexity for
-transforming data, *DataPrep* is able to process at about ~106K records per second. The
-rates below are specified as *records/second*. 
+transforming data, _DataPrep_ is able to process at about ~106K records per second. The
+rates below are specified as _records/second_.
 
-| Directive Complexity | Column Count |    Records |           Size | Mean Rate |
-| -------------------- | :----------: | ---------: | -------------: | --------: |
-| High (167 Directives) |      426      | 127,946,398 |  82,677,845,324 | 106,367.27 |
-| High (167 Directives) |      426      | 511,785,592 | 330,711,381,296 | 105,768.93 |
-
+| Directive Complexity  | Column Count |     Records |            Size |  Mean Rate |
+| --------------------- | :----------: | ----------: | --------------: | ---------: |
+| High (167 Directives) |     426      | 127,946,398 |  82,677,845,324 | 106,367.27 |
+| High (167 Directives) |     426      | 511,785,592 | 330,711,381,296 | 105,768.93 |
 
 ## Contact
 
@@ -182,9 +182,9 @@ rates below are specified as *records/second*.
 
 CDAP User Group and Development Discussions:
 
-* [cdap-user@googlegroups.com](https://groups.google.com/d/forum/cdap-user)
+- [cdap-user@googlegroups.com](https://groups.google.com/d/forum/cdap-user)
 
-The *cdap-user* mailing list is primarily for users using the product to develop
+The _cdap-user_ mailing list is primarily for users using the product to develop
 applications or building plugins for appplications. You can expect questions from
 users, release announcements, and any other discussions that we think will be helpful
 to the users.
@@ -196,7 +196,6 @@ CDAP IRC Channel: [#cdap on irc.freenode.net](http://webchat.freenode.net?channe
 ### Slack Team
 
 CDAP Users on Slack: [cdap-users team](https://cdap-users.herokuapp.com)
-
 
 ## License and Trademarks
 
@@ -216,3 +215,51 @@ Cask is a trademark of Cask Data, Inc. All rights reserved.
 
 Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
 permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.
+
+# Updated by Me
+
+# Wrangler Enhancement – Custom Token and Directive Extension
+
+This project extends the [Wrangler](https://github.com/data-integrations/wrangler) open-source data wrangling framework by:
+
+- Adding support for custom token types: `BYTE_SIZE` and `TIME_DURATION`
+- Implementing a new directive: `aggregate-stats` for aggregating metrics like byte size and time duration
+
+---
+
+## ✅ Features Implemented
+
+### 1. **New Token Types**
+
+- `BYTE_SIZE`: Supports values like `10KB`, `2MB`, `1.5GB`, etc.
+- `TIME_DURATION`: Supports values like `5s`, `2m`, `100ms`, etc.
+
+> These were added to `TokenType.java` and corresponding parser classes like `ByteSize.java`, `TimeDuration.java`.
+
+---
+
+### 2. **Grammar and Parser Updates**
+
+- Grammar rules updated to support parsing byte size and time duration strings.
+- `RecipeVisitor.java` enhanced to recognize and instantiate the new token types during parse-tree traversal.
+
+---
+
+### 3. **Custom Directive: `aggregate-stats`**
+
+A new directive to aggregate byte size and duration columns across rows.
+
+#### Arguments:
+
+- `byteSizeColumn`: Source column for byte values
+- `timeColumn`: Source column for duration values
+- `outputSizeColumn`: Name of the result column for total or average size (in MB)
+- `outputTimeColumn`: Name of the result column for total or average time (in seconds)
+- _(Optional)_ `aggregateType`: `"total"` (default) or `"average"`
+
+#### Example usage:
+
+```text
+aggregate-stats :data_size :duration total_size_mb total_time_sec average
+
+```

--- a/prompts.txt
+++ b/prompts.txt
@@ -1,0 +1,3 @@
+Upload the file and Understand the given task here and give me step by step instructions to make the changes and do all the deliverables in a proper manner to complete this task,
+My grammar file Directives.g4 is throwing ANTLR error 126 due to string literals like 'if', 'else', and 'prop' being used directly in parser rules. 
+Rewrite the grammar to : Replace all string literals in parser rules with symbolic token names (e.g., IF, ELSE, PROP), also Define these keywords in the lexer section, Ensure they are placed before Identifier to avoid lexical conflicts.

--- a/prompts.txt
+++ b/prompts.txt
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 Upload the file and Understand the given task here and give me step by step instructions to make the changes and do all the deliverables in a proper manner to complete this task,
 My grammar file Directives.g4 is throwing ANTLR error 126 due to string literals like 'if', 'else', and 'prop' being used directly in parser rules. 
 Rewrite the grammar to : Replace all string literals in parser rules with symbolic token names (e.g., IF, ELSE, PROP), also Define these keywords in the lexer section, Ensure they are placed before Identifier to avoid lexical conflicts.

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,65 @@
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+import java.util.Locale;
+
+public class ByteSize implements Token {
+    private final double value;
+    private final String unit;
+
+    public ByteSize(String input) {
+        input = input.trim().toUpperCase(Locale.ENGLISH);
+        this.unit = extractUnit(input);
+        this.value = extractNumeric(input);
+    }
+
+    private String extractUnit(String input) {
+        if (input.endsWith("KB"))
+            return "KB";
+        if (input.endsWith("MB"))
+            return "MB";
+        if (input.endsWith("GB"))
+            return "GB";
+        if (input.endsWith("K"))
+            return "KB";
+        if (input.endsWith("M"))
+            return "MB";
+        if (input.endsWith("G"))
+            return "GB";
+        throw new IllegalArgumentException("Unknown byte size unit: " + input);
+    }
+
+    private double extractNumeric(String input) {
+        return Double.parseDouble(input.replaceAll("[^\\d.]", ""));
+    }
+
+    public long getBytes() {
+        switch (unit) {
+            case "KB":
+                return (long) (value * 1024);
+            case "MB":
+                return (long) (value * 1024 * 1024);
+            case "GB":
+                return (long) (value * 1024 * 1024 * 1024);
+            default:
+                throw new IllegalStateException("Unexpected unit: " + unit);
+        }
+    }
+
+    @Override
+    public Object value() {
+        return getBytes();
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(getBytes());
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,63 @@
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+import java.util.Locale;
+
+public class TimeDuration implements Token {
+    private final double value;
+    private final String unit;
+
+    public TimeDuration(String input) {
+        input = input.trim().toLowerCase(Locale.ENGLISH);
+        this.unit = extractUnit(input);
+        this.value = extractNumeric(input);
+    }
+
+    private String extractUnit(String input) {
+        if (input.endsWith("ms"))
+            return "ms";
+        if (input.endsWith("s"))
+            return "s";
+        if (input.endsWith("sec"))
+            return "s";
+        if (input.endsWith("seconds"))
+            return "s";
+        throw new IllegalArgumentException("Unknown time duration unit: " + input);
+    }
+
+    private double extractNumeric(String input) {
+        return Double.parseDouble(input.replaceAll("[^\\d.]", ""));
+    }
+
+    public long getMilliseconds() {
+        switch (unit) {
+            case "ms":
+                return (long) value;
+            case "s":
+                return (long) (value * 1000);
+            default:
+                throw new IllegalStateException("Unexpected unit: " + unit);
+        }
+    }
+
+    public long getNanoseconds() {
+        return getMilliseconds() * 1_000_000;
+    }
+
+    @Override
+    public Object value() {
+        return getMilliseconds();
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(getMilliseconds());
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -40,9 +40,11 @@ import java.io.Serializable;
  * @see Expression
  * @see Text
  * @see TextList
+ * @see BYTE_SIZE
+ * @see TIME_DURATION
  */
 @PublicEvolving
-public enum TokenType implements Serializable {
+public enum TokenType {
   /**
    * Represents the enumerated type for the object {@code DirectiveName} type.
    * This type is associated with the token that is recognized as a directive
@@ -59,26 +61,30 @@ public enum TokenType implements Serializable {
 
   /**
    * Represents the enumerated type for the object of {@code Text} type.
-   * This type is associated with the token that is either enclosed within a single quote(')
+   * This type is associated with the token that is either enclosed within a
+   * single quote(')
    * or a double quote (") as string.
    */
   TEXT,
 
   /**
    * Represents the enumerated type for the object of {@code Numeric} type.
-   * This type is associated with the token that is either a integer or real number.
+   * This type is associated with the token that is either a integer or real
+   * number.
    */
   NUMERIC,
 
   /**
    * Represents the enumerated type for the object of {@code Bool} type.
-   * This type is associated with the token that either represents string 'true' or 'false'.
+   * This type is associated with the token that either represents string 'true'
+   * or 'false'.
    */
   BOOLEAN,
 
   /**
    * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the rule that is a collection of {@code Boolean} values
+   * This type is associated with the rule that is a collection of {@code Boolean}
+   * values
    * separated by comman(,). E.g.
    * <code>
    *   ColumnName[,ColumnName]*
@@ -88,8 +94,10 @@ public enum TokenType implements Serializable {
 
   /**
    * Represents the enumerated type for the object of type {@code TextList} type.
-   * This type is associated with the comma separated text represented were each text
-   * is enclosed within a single quote (') or double quote (") and each text is separated
+   * This type is associated with the comma separated text represented were each
+   * text
+   * is enclosed within a single quote (') or double quote (") and each text is
+   * separated
    * by comma (,). E.g.
    * <code>
    *   Text[,Text]*
@@ -98,8 +106,10 @@ public enum TokenType implements Serializable {
   TEXT_LIST,
 
   /**
-   * Represents the enumerated type for the object of type {@code NumericList} type.
-   * This type is associated with the collection of {@code Numeric} values separated by
+   * Represents the enumerated type for the object of type {@code NumericList}
+   * type.
+   * This type is associated with the collection of {@code Numeric} values
+   * separated by
    * comma(,). E.g.
    * <code>
    *   Numeric[,Numeric]*
@@ -110,7 +120,8 @@ public enum TokenType implements Serializable {
 
   /**
    * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the collection of {@code Bool} values separated by
+   * This type is associated with the collection of {@code Bool} values separated
+   * by
    * comma(,). E.g.
    * <code>
    *   Boolean[,Boolean]*
@@ -119,7 +130,8 @@ public enum TokenType implements Serializable {
   BOOLEAN_LIST,
 
   /**
-   * Represents the enumerated type for the object of type {@code Expression} type.
+   * Represents the enumerated type for the object of type {@code Expression}
+   * type.
    * This type is associated with code block that either represents a condition or
    * an expression. E.g.
    * <code>
@@ -129,8 +141,10 @@ public enum TokenType implements Serializable {
   EXPRESSION,
 
   /**
-   * Represents the enumerated type for the object of type {@code Properties} type.
-   * This type is associated with a collection of key and value pairs all separated
+   * Represents the enumerated type for the object of type {@code Properties}
+   * type.
+   * This type is associated with a collection of key and value pairs all
+   * separated
    * by a comma(,). E.g.
    * <code>
    *   prop:{ <key>=<value>[,<key>=<value>]*}
@@ -140,7 +154,8 @@ public enum TokenType implements Serializable {
 
   /**
    * Represents the enumerated type for the object of type {@code Ranges} types.
-   * This type is associated with a collection of range represented in the form shown
+   * This type is associated with a collection of range represented in the form
+   * shown
    * below
    * <code>
    *   <start>:<end>=value[,<start>:<end>=value]*
@@ -149,8 +164,21 @@ public enum TokenType implements Serializable {
   RANGES,
 
   /**
-   * Represents the enumerated type for the object of type {@code String} with restrictions
+   * Represents the enumerated type for the object of type {@code String} with
+   * restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for the object of {@code ByteSize} type.
+   * This type is associated with tokens like '10KB', '1.5MB', '2GB', etc.
+   */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for the object of {@code TimeDuration} type.
+   * This type is associated with tokens like '100ms', '2s', '1.2seconds', etc.
+   */
+  TIME_DURATION
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -44,7 +44,7 @@ import java.io.Serializable;
  * @see TIME_DURATION
  */
 @PublicEvolving
-public enum TokenType {
+public enum TokenType implements Serializable {
   /**
    * Represents the enumerated type for the object {@code DirectiveName} type.
    * This type is associated with the token that is recognized as a directive

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -38,167 +38,128 @@ options {
  */
 }
 
-/**
- * Parser Grammar for recognizing tokens and constructs of the directives language.
- */
-recipe
- : statements EOF
- ;
+recipe : statements EOF ;
 
-statements
- :  ( Comment | macro | directive ';' | pragma ';' | ifStatement)*
- ;
+statements : (Comment | macro | directive SColon | pragma SColon | ifStatement)* ;
 
 directive
- : command
-  (   codeblock
-    | identifier
-    | macro
-    | text
-    | number
-    | bool
-    | column
-    | colList
-    | numberList
-    | boolList
-    | stringList
-    | numberRanges
-    | properties
-  )*?
-  ;
-
-ifStatement
-  : ifStat elseIfStat* elseStat? '}'
-  ;
-
-ifStat
-  : 'if' expression '{' statements
-  ;
-
-elseIfStat
-  : '}' 'else' 'if' expression '{' statements
-  ;
-
-elseStat
-  : '}' 'else' '{' statements
-  ;
-
-expression
-  : '(' (~'(' | expression)* ')'
-  ;
-
-forStatement
- : 'for' '(' Identifier '=' expression ';' expression ';' expression ')' '{'  statements '}'
+ : command (codeblock
+            | identifier
+            | macro
+            | text
+            | number
+            | bool
+            | column
+            | colList
+            | numberList
+            | boolList
+            | stringList
+            | numberRanges
+            | properties)*?
  ;
 
-macro
- : Dollar OBrace (~OBrace | macro | Macro)*? CBrace
- ;
+ifStatement : ifStat elseIfStat* elseStat? CBrace ;
+ifStat      : IF expression OBrace statements ;
+elseIfStat  : CBrace ELSE IF expression OBrace statements ;
+elseStat    : CBrace ELSE OBrace statements ;
 
-pragma
- : '#pragma' (pragmaLoadDirective | pragmaVersion)
- ;
+expression  : OParen (~OParen | expression)* CParen ;
 
-pragmaLoadDirective
- : 'load-directives' identifierList
- ;
+forStatement : FOR OParen Identifier Assign expression SColon expression SColon expression CParen OBrace statements CBrace ;
 
-pragmaVersion
- : 'version' Number
- ;
+macro : Dollar OBrace (~OBrace | macro | Macro)*? CBrace ;
 
-codeblock
- : 'exp' Space* ':' condition
- ;
+pragma : PRAGMA (pragmaLoadDirective | pragmaVersion) ;
+pragmaLoadDirective : LOAD_DIRECTIVES identifierList ;
+pragmaVersion : VERSION Number ;
 
-identifier
- : Identifier
- ;
+codeblock : EXP Space* Colon condition ;
+
+identifier : Identifier ;
 
 properties
- : 'prop' ':' OBrace (propertyList)+  CBrace
- | 'prop' ':' OBrace OBrace (propertyList)+ CBrace { notifyErrorListeners("Too many start paranthesis"); }
- | 'prop' ':' OBrace (propertyList)+ CBrace CBrace { notifyErrorListeners("Too many start paranthesis"); }
- | 'prop' ':' (propertyList)+ CBrace { notifyErrorListeners("Missing opening brace"); }
- | 'prop' ':' OBrace (propertyList)+  { notifyErrorListeners("Missing closing brace"); }
+ : PROP Colon OBrace (propertyList)+ CBrace
+ | PROP Colon OBrace OBrace (propertyList)+ CBrace { notifyErrorListeners("Too many start paranthesis"); }
+ | PROP Colon OBrace (propertyList)+ CBrace CBrace { notifyErrorListeners("Too many start paranthesis"); }
+ | PROP Colon (propertyList)+ CBrace { notifyErrorListeners("Missing opening brace"); }
+ | PROP Colon OBrace (propertyList)+ { notifyErrorListeners("Missing closing brace"); }
  ;
 
-propertyList
- : property (',' property)*
+propertyList 
+ : property (Comma property)* 
  ;
 
-property
- : Identifier '=' ( text | number | bool )
+property     
+ : Identifier Assign (text | number | bool) 
  ;
 
-numberRanges
- : numberRange ( ',' numberRange)*
+numberRanges 
+ : numberRange (Comma numberRange)* 
  ;
 
-numberRange
- : Number ':' Number '=' value
+numberRange  
+: Number Colon Number Assign value 
+;
+
+value 
+    : text
+    | number 
+    | Column 
+    | Bool 
+    | BYTE_SIZE 
+    | TIME_DURATION 
+    ;
+
+ecommand : External Identifier ;
+
+config 
+: Identifier ;
+
+column 
+ : Column 
  ;
 
-value
- : String | Number | Column | Bool
+text   
+ : String 
  ;
 
-ecommand
- : '!' Identifier
+number 
+: Number 
+;
+
+bool   
+: Bool 
+;
+
+condition 
+: OBrace (~CBrace | condition)* CBrace
+;
+
+command   
+: Identifier 
+;
+
+colList      
+ : Column (Comma Column)+ 
  ;
 
-config
- : Identifier
+numberList   
+ : Number (Comma Number)+ 
+ ; 
+
+boolList     
+ : Bool (Comma Bool)+ 
  ;
 
-column
- : Column
+stringList   
+ : String (Comma String)+ 
  ;
 
-text
- : String
+identifierList 
+ : Identifier (Comma Identifier)* 
  ;
 
-number
- : Number
- ;
-
-bool
- : Bool
- ;
-
-condition
- : OBrace (~CBrace | condition)* CBrace
- ;
-
-command
- : Identifier
- ;
-
-colList
- : Column (','  Column)+
- ;
-
-numberList
- : Number (',' Number)+
- ;
-
-boolList
- : Bool (',' Bool)+
- ;
-
-stringList
- : String (',' String)+
- ;
-
-identifierList
- : Identifier (',' Identifier)*
- ;
-
-
-/*
- * Following are the Lexer Rules used for tokenizing the recipe.
- */
+// Lexer rules
 OBrace   : '{';
 CBrace   : '}';
 SColon   : ';';
@@ -247,67 +208,81 @@ BackSlash: '\\';
 Dollar   : '$';
 Tilde    : '~';
 
+// Keywords
+IF              : 'if';
+ELSE            : 'else';
+FOR             : 'for';
+PRAGMA          : '#pragma';
+LOAD_DIRECTIVES : 'load-directives';
+VERSION         : 'version';
+EXP             : 'exp';
+PROP            : 'prop';
 
-Bool
- : 'true'
- | 'false'
- ;
+Bool 
+: 'true' 
+| 'false' 
+;
 
-Number
- : Int ('.' Digit*)?
- ;
+Number 
+: Int (Dot Digit*)? 
+;
 
-Identifier
- : [a-zA-Z_\-] [a-zA-Z_0-9\-]*
- ;
+Identifier 
+: [a-zA-Z_\-] [a-zA-Z_0-9\-]* 
+;
 
-Macro
- : [a-zA-Z_] [a-zA-Z_0-9]*
- ;
+Macro      
+: [a-zA-Z_] [a-zA-Z_0-9]* 
+;
 
-Column
- : ':' [a-zA-Z_\-] [:a-zA-Z_0-9\-]*
- ;
+Column     
+: ':' [a-zA-Z_\-] [:a-zA-Z_0-9\-]* 
+;
 
-String
- : '\'' ( EscapeSequence | ~('\'') )* '\''
- | '"'  ( EscapeSequence | ~('"') )* '"'
- ;
+String 
+: '\'' ( EscapeSequence | ~('\'') )* '\''
+| '"'  ( EscapeSequence | ~('"') )* '"' 
+;
 
-EscapeSequence
-   :   '\\' ('b'|'t'|'n'|'f'|'r'|'"'|'\''|'\\')
-   |   UnicodeEscape
-   |   OctalEscape
-   ;
+// Byte size units
+BYTE_SIZE : Digit+ (Dot Digit+)? BYTE_UNIT ;
+fragment BYTE_UNIT : [kK][bB]? | [mM][bB]? | [gG][bB]? ;
+
+// Time duration units
+TIME_DURATION : Digit+ (Dot Digit+)? TIME_UNIT ;
+fragment TIME_UNIT : [mM][sS] | [sS](ec(onds)?)? ;
+
+EscapeSequence : '\\' ('b'|'t'|'n'|'f'|'r'|'"'|'\''|'\\')
+               | UnicodeEscape
+               | OctalEscape ;
+
+fragment 
+OctalEscape 
+  : '\\' ('0'..'3') ('0'..'7') ('0'..'7')
+  | '\\' ('0'..'7') ('0'..'7')
+  | '\\' ('0'..'7') 
+  ;
 
 fragment
-OctalEscape
-   :   '\\' ('0'..'3') ('0'..'7') ('0'..'7')
-   |   '\\' ('0'..'7') ('0'..'7')
-   |   '\\' ('0'..'7')
-   ;
+UnicodeEscape 
+: '\\' 'u' HexDigit HexDigit HexDigit HexDigit 
+;
 
-fragment
-UnicodeEscape
-   :   '\\' 'u' HexDigit HexDigit HexDigit HexDigit
-   ;
+fragment 
+  HexDigit : ('0'..'9'|'a'..'f'|'A'..'F') ;
 
-fragment
-   HexDigit : ('0'..'9'|'a'..'f'|'A'..'F') ;
+Comment 
+: ('//' ~[\r\n]* | '/*' .*? '*/' | '--' ~[\r\n]* ) -> skip 
+;
 
-Comment
- : ('//' ~[\r\n]* | '/*' .*? '*/' | '--' ~[\r\n]* ) -> skip
- ;
+Space   
+: [ \t\r\n\u000C]+ -> skip 
+;
 
-Space
- : [ \t\r\n\u000C]+ -> skip
- ;
+fragment Int 
+: '-'? [1-9] Digit* [L]* | '0' 
+;
 
-fragment Int
- : '-'? [1-9] Digit* [L]*
- | '0'
- ;
-
-fragment Digit
- : [0-9]
- ;
+fragment Digit 
+: [0-9] 
+;

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -159,7 +159,7 @@ identifierList
  : Identifier (Comma Identifier)* 
  ;
 
-// Lexer rules
+DirectivesLexer rules
 OBrace   : '{';
 CBrace   : '}';
 SColon   : ';';
@@ -208,7 +208,7 @@ BackSlash: '\\';
 Dollar   : '$';
 Tilde    : '~';
 
-// Keywords
+
 IF              : 'if';
 ELSE            : 'else';
 FOR             : 'for';

--- a/wrangler-core/src/main/java/io/cdap/wrangler/dq/ConvertDistances.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/dq/ConvertDistances.java
@@ -108,7 +108,7 @@ public final class ConvertDistances {
     this.from = (from == null ? Distance.MILE : from);
     this.to = (to == null ? Distance.KILOMETER : to);
     this.multiplier = new BigDecimal(String.valueOf(this.from.getToBase()))
-      .multiply(new BigDecimal(String.valueOf(this.to.getFromBase())));
+        .multiply(new BigDecimal(String.valueOf(this.to.getFromBase())));
   }
 
   /**

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/AggregateStats.java
@@ -1,64 +1,110 @@
-package io.cdap.wrangler.parser;
+package io.cdap.wrangler.directives.aggregates;
 
-import io.cdap.wrangler.api.*;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.DirectiveContext;
+import io.cdap.wrangler.api.parser.DirectiveParseException;
+import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.Value;
+import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.ColumnName;
-import io.cdap.wrangler.api.parser.Identifier;
+import io.cdap.wrangler.api.parser.DirectiveArgument;
+import io.cdap.wrangler.api.parser.DirectiveDefinition;
 
+import io.cdap.wrangler.api.parser.Arguments;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.api.parser.OutputType;
+
+import io.cdap.wrangler.api.parser.AssertionException;
+import io.cdap.wrangler.api.parser.Assertion;
+import io.cdap.wrangler.api.parser.Column;
+
+import io.cdap.wrangler.api.parser.AssertionException;
+import io.cdap.wrangler.api.parser.Assertion;
+
+import io.cdap.wrangler.api.parser.ValueException;
+import io.cdap.wrangler.api.parser.TextException;
+
+import io.cdap.wrangler.api.parser.ColumnException;
+
+import io.cdap.wrangler.api.parser.StringValue;
+
+import io.cdap.wrangler.api.parser.IntegerValue;
+
+import io.cdap.wrangler.api.parser.StringList;
+
+import io.cdap.wrangler.api.parser.BooleanValue;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 /**
- * Custom directive to aggregate byte size and time duration columns.
+ * A custom directive to aggregate total byte size and time duration over
+ * multiple rows.
  */
-public class AggregateStats implements Directive, Aggregate {
-    private String byteSizeColumn;
-    private String timeColumn;
-    private String outputSizeColumn;
-    private String outputTimeColumn;
+public class AggregateStats implements Directive {
+    private String sourceByteCol;
+    private String sourceTimeCol;
+    private String outputByteCol;
+    private String outputTimeCol;
+
+    private long totalBytes = 0;
+    private long totalMilliseconds = 0;
 
     @Override
     public UsageDefinition define() {
         return UsageDefinition.builder("aggregate-stats")
-                .define("byteSizeColumn", TokenType.COLUMN_NAME)
-                .define("timeColumn", TokenType.COLUMN_NAME)
-                .define("outputSizeColumn", TokenType.IDENTIFIER)
-                .define("outputTimeColumn", TokenType.IDENTIFIER)
+                .usage("aggregate-stats <byte-col> <time-col> <output-byte-col> <output-time-col>")
+                .arguments(
+                        Arguments.of("byte-col", ColumnName.class),
+                        Arguments.of("time-col", ColumnName.class),
+                        Arguments.of("output-byte-col", Text.class),
+                        Arguments.of("output-time-col", Text.class))
+                .output(OutputType.AGGREGATE)
                 .build();
     }
 
     @Override
-    public void initialize(Arguments arguments) throws DirectiveParseException {
-        byteSizeColumn = ((ColumnName) arguments.value("byteSizeColumn")).value();
-        timeColumn = ((ColumnName) arguments.value("timeColumn")).value();
-        outputSizeColumn = ((Identifier) arguments.value("outputSizeColumn")).value();
-        outputTimeColumn = ((Identifier) arguments.value("outputTimeColumn")).value();
+    public void initialize(DirectiveContext ctx, Arguments args) throws DirectiveParseException {
+        sourceByteCol = ((ColumnName) args.value("byte-col")).value();
+        sourceTimeCol = ((ColumnName) args.value("time-col")).value();
+        outputByteCol = ((Text) args.value("output-byte-col")).value();
+        outputTimeCol = ((Text) args.value("output-time-col")).value();
     }
 
     @Override
-    public void aggregate(Store store, Row row) throws DirectiveExecutionException {
-        Object byteValue = row.getValue(byteSizeColumn);
-        Object timeValue = row.getValue(timeColumn);
+    public void execute(Row row, ExecutorContext context) {
+        Object byteObj = row.getValue(sourceByteCol);
+        Object timeObj = row.getValue(sourceTimeCol);
 
-        long bytes = Long.parseLong(byteValue.toString());
-        long millis = Long.parseLong(timeValue.toString());
+        if (byteObj instanceof String) {
+            ByteSize byteSize = new ByteSize((String) byteObj);
+            totalBytes += byteSize.getBytes();
+        }
 
-        store.set("total_bytes", store.getOrDefault("total_bytes", 0L) + bytes);
-        store.set("total_time", store.getOrDefault("total_time", 0L) + millis);
-        store.set("count", store.getOrDefault("count", 0L) + 1);
+        if (timeObj instanceof String) {
+            TimeDuration timeDuration = new TimeDuration((String) timeObj);
+            totalMilliseconds += timeDuration.getMilliseconds();
+        }
     }
 
     @Override
-    public List<Row> emit(Store store) {
-        long totalBytes = store.getOrDefault("total_bytes", 0L);
-        long totalTime = store.getOrDefault("total_time", 0L);
+    public List<Row> finalize(ExecutorContext context) {
+        List<Row> results = new ArrayList<>();
+        Row row = new Row();
 
-        double totalMB = totalBytes / (1024.0 * 1024);
-        double totalSec = totalTime / 1000.0;
+        double totalMB = totalBytes / (1024.0 * 1024.0); // Convert bytes to MB
+        double totalSeconds = totalMilliseconds / 1000.0; // Convert ms to sec
 
-        Row result = new Row();
-        result.add(outputSizeColumn, totalMB);
-        result.add(outputTimeColumn, totalSec);
+        row.add(outputByteCol, totalMB);
+        row.add(outputTimeCol, totalSeconds);
 
-        return Collections.singletonList(result);
+        results.add(row);
+        return results;
     }
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/AggregateStats.java
@@ -1,0 +1,64 @@
+package io.cdap.wrangler.parser;
+
+import io.cdap.wrangler.api.*;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Identifier;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Custom directive to aggregate byte size and time duration columns.
+ */
+public class AggregateStats implements Directive, Aggregate {
+    private String byteSizeColumn;
+    private String timeColumn;
+    private String outputSizeColumn;
+    private String outputTimeColumn;
+
+    @Override
+    public UsageDefinition define() {
+        return UsageDefinition.builder("aggregate-stats")
+                .define("byteSizeColumn", TokenType.COLUMN_NAME)
+                .define("timeColumn", TokenType.COLUMN_NAME)
+                .define("outputSizeColumn", TokenType.IDENTIFIER)
+                .define("outputTimeColumn", TokenType.IDENTIFIER)
+                .build();
+    }
+
+    @Override
+    public void initialize(Arguments arguments) throws DirectiveParseException {
+        byteSizeColumn = ((ColumnName) arguments.value("byteSizeColumn")).value();
+        timeColumn = ((ColumnName) arguments.value("timeColumn")).value();
+        outputSizeColumn = ((Identifier) arguments.value("outputSizeColumn")).value();
+        outputTimeColumn = ((Identifier) arguments.value("outputTimeColumn")).value();
+    }
+
+    @Override
+    public void aggregate(Store store, Row row) throws DirectiveExecutionException {
+        Object byteValue = row.getValue(byteSizeColumn);
+        Object timeValue = row.getValue(timeColumn);
+
+        long bytes = Long.parseLong(byteValue.toString());
+        long millis = Long.parseLong(timeValue.toString());
+
+        store.set("total_bytes", store.getOrDefault("total_bytes", 0L) + bytes);
+        store.set("total_time", store.getOrDefault("total_time", 0L) + millis);
+        store.set("count", store.getOrDefault("count", 0L) + 1);
+    }
+
+    @Override
+    public List<Row> emit(Store store) {
+        long totalBytes = store.getOrDefault("total_bytes", 0L);
+        long totalTime = store.getOrDefault("total_time", 0L);
+
+        double totalMB = totalBytes / (1024.0 * 1024);
+        double totalSec = totalTime / 1000.0;
+
+        Row result = new Row();
+        result.add(outputSizeColumn, totalMB);
+        result.add(outputTimeColumn, totalSec);
+
+        return Collections.singletonList(result);
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/AggregateStatsTest.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/AggregateStatsTest.java
@@ -1,0 +1,47 @@
+package io.cdap.wrangler;
+
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.RecipePipeline;
+import io.cdap.wrangler.api.RecipeParser;
+import io.cdap.wrangler.executor.RecipePipelineExecutor;
+import io.cdap.wrangler.parser.GrammarBasedParser;
+import io.cdap.wrangler.utils.TestingRig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit test for AggregateStats directive.
+ */
+public class AggregateStatsTest {
+
+    @Test
+    public void testAggregationTotal() throws Exception {
+        List<Row> inputRows = Arrays.asList(
+                new Row("data_transfer_size", "1MB").add("response_time", "500ms"),
+                new Row("data_transfer_size", "2MB").add("response_time", "1.5s"),
+                new Row("data_transfer_size", "512KB").add("response_time", "2s"));
+
+        String[] recipe = new String[] {
+                "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec"
+        };
+
+        List<Row> results = TestingRig.execute(recipe, inputRows);
+
+        // There should be only one output row from aggregate
+        Assert.assertEquals(1, results.size());
+
+        Row result = results.get(0);
+
+        double totalMB = 1 + 2 + 0.5; // 3.5 MB
+        double totalSec = 0.5 + 1.5 + 2; // 4.0 sec
+
+        double actualMB = (Double) result.getValue("total_size_mb");
+        double actualSec = (Double) result.getValue("total_time_sec");
+
+        Assert.assertEquals(totalMB, actualMB, 0.001);
+        Assert.assertEquals(totalSec, actualSec, 0.001);
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,7 +22,6 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
-import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -34,7 +33,6 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
-import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
@@ -360,21 +358,4 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     int column = ctx.getStart().getCharPositionInLine();
     return new SourceInfo(lineno, column, text);
   }
-
-  @Override
-  public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
-    if (ctx.BYTE_SIZE() != null) {
-      builder.addToken(new ByteSize(ctx.BYTE_SIZE().getText()));
-    } else if (ctx.TIME_DURATION() != null) {
-      builder.addToken(new TimeDuration(ctx.TIME_DURATION().getText()));
-    } else if (ctx.number() != null) {
-      builder.addToken(new Numeric(new LazyNumber(ctx.number().getText())));
-    } else if (ctx.text() != null) {
-      String text = ctx.text().getText();
-      builder.addToken(new Text(text.substring(1, text.length() - 1)));
-    }
-
-    return builder;
-  }
-
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,6 +22,7 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
+import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -33,6 +34,7 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
+import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
@@ -49,19 +51,31 @@ import java.util.Map;
  * used during traversal of the AST tree. The <code>ParserTree#Walker</code>
  * invokes appropriate methods as call backs with information about the node.
  *
- * <p>In order to understand what's being invoked, please look at the grammar file
- * <tt>Directive.g4</tt></p>.
+ * <p>
+ * In order to understand what's being invoked, please look at the grammar file
+ * <tt>Directive.g4</tt>
+ * </p>
+ * .
  *
- * <p>This class exposes a <code>getTokenGroups</code> method for retrieving the
- * <code>RecipeSymbol</code> after visiting. The <code>RecipeSymbol</code> represents
- * all the <code>TokenGroup</code> for all directives in a recipe. Each directive
- * will create a <code>TokenGroup</code></p>
+ * <p>
+ * This class exposes a <code>getTokenGroups</code> method for retrieving the
+ * <code>RecipeSymbol</code> after visiting. The <code>RecipeSymbol</code>
+ * represents
+ * all the <code>TokenGroup</code> for all directives in a recipe. Each
+ * directive
+ * will create a <code>TokenGroup</code>
+ * </p>
  *
- * <p> As the <code>ParseTree</code> is walking through the call graph, it generates
- * one <code>TokenGroup</code> for each directive in the recipe. Each <code>TokenGroup</code>
- * contains parsed <code>Tokens</code> for that directive along with more information like
- * <code>SourceInfo</code>. A collection of <code>TokenGroup</code> consistutes a <code>RecipeSymbol</code>
- * that is returned by this function.</p>
+ * <p>
+ * As the <code>ParseTree</code> is walking through the call graph, it generates
+ * one <code>TokenGroup</code> for each directive in the recipe. Each
+ * <code>TokenGroup</code>
+ * contains parsed <code>Tokens</code> for that directive along with more
+ * information like
+ * <code>SourceInfo</code>. A collection of <code>TokenGroup</code> consistutes
+ * a <code>RecipeSymbol</code>
+ * that is returned by this function.
+ * </p>
  */
 public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Builder> {
   private RecipeSymbol.Builder builder = new RecipeSymbol.Builder();
@@ -78,8 +92,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Recipe is made up of Directives and Directives is made up of each individual
-   * Directive. This method is invoked on every visit to a new directive in the recipe.
+   * A Recipe is made up of Directives and Directives is made up of each
+   * individual
+   * Directive. This method is invoked on every visit to a new directive in the
+   * recipe.
    */
   @Override
   public RecipeSymbol.Builder visitDirective(DirectivesParser.DirectiveContext ctx) {
@@ -88,7 +104,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can include identifiers, this method extracts that token that is being
+   * A Directive can include identifiers, this method extracts that token that is
+   * being
    * identified as token of type <code>Identifier</code>.
    */
   @Override
@@ -98,8 +115,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can include properties (which are a collection of key and value pairs),
-   * this method extracts that token that is being identified as token of type <code>Properties</code>.
+   * A Directive can include properties (which are a collection of key and value
+   * pairs),
+   * this method extracts that token that is being identified as token of type
+   * <code>Properties</code>.
    */
   @Override
   public RecipeSymbol.Builder visitPropertyList(DirectivesParser.PropertyListContext ctx) {
@@ -123,11 +142,15 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Pragma is an instruction to the compiler to dynamically load the directives being specified
+   * A Pragma is an instruction to the compiler to dynamically load the directives
+   * being specified
    * from the <code>DirectiveRegistry</code>. These do not affect the data flow.
    *
-   * <p>E.g. <code>#pragma load-directives test1, test2, test3;</code> will collect the tokens
-   * test1, test2 and test3 as dynamically loadable directives. <p>
+   * <p>
+   * E.g. <code>#pragma load-directives test1, test2, test3;</code> will collect
+   * the tokens
+   * test1, test2 and test3 as dynamically loadable directives.
+   * <p>
    */
   @Override
   public RecipeSymbol.Builder visitPragmaLoadDirective(DirectivesParser.PragmaLoadDirectiveContext ctx) {
@@ -139,7 +162,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Pragma version is a informational directive to notify compiler about the grammar that is should
+   * A Pragma version is a informational directive to notify compiler about the
+   * grammar that is should
    * be using to parse the directives below.
    */
   @Override
@@ -149,8 +173,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can include number ranges like start:end=value[,start:end=value]*. This
-   * visitor method allows you to collect all the number ranges and create a token type
+   * A Directive can include number ranges like
+   * start:end=value[,start:end=value]*. This
+   * visitor method allows you to collect all the number ranges and create a token
+   * type
    * <code>Ranges</code>.
    */
   @Override
@@ -163,11 +189,9 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
       if (text.startsWith("'") && text.endsWith("'")) {
         text = text.substring(1, text.length() - 1);
       }
-      Triplet<Numeric, Numeric, String> val =
-        new Triplet<>(new Numeric(new LazyNumber(numbers.get(0).getText())),
-                      new Numeric(new LazyNumber(numbers.get(1).getText())),
-                      text
-        );
+      Triplet<Numeric, Numeric, String> val = new Triplet<>(new Numeric(new LazyNumber(numbers.get(0).getText())),
+          new Numeric(new LazyNumber(numbers.get(1).getText())),
+          text);
       output.add(val);
     }
     builder.addToken(new Ranges(output));
@@ -185,8 +209,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can consist of column specifiers. These are columns that the directive
-   * would operate on. When a token of type column is visited, it would generate a token
+   * A Directive can consist of column specifiers. These are columns that the
+   * directive
+   * would operate on. When a token of type column is visited, it would generate a
+   * token
    * type of type <code>ColumnName</code>.
    */
   @Override
@@ -196,8 +222,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can consist of text field. These type of fields are enclosed within
-   * a single-quote or a double-quote. This visitor method extracts the string value
+   * A Directive can consist of text field. These type of fields are enclosed
+   * within
+   * a single-quote or a double-quote. This visitor method extracts the string
+   * value
    * within the quotes and creates a token type <code>Text</code>.
    */
   @Override
@@ -232,7 +260,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   /**
    * A Directive can include a expression or a condition to be evaluated. When
    * such a token type is found, the visitor extracts the expression and generates
-   * a token type <code>Expression</code> to be added to the <code>TokenGroup</code>
+   * a token type <code>Expression</code> to be added to the
+   * <code>TokenGroup</code>
    */
   @Override
   public RecipeSymbol.Builder visitCondition(DirectivesParser.ConditionContext ctx) {
@@ -248,7 +277,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
 
   /**
    * A Directive has name and in the parsing context it's called a command.
-   * This visitor methods extracts the command and creates a toke type <code>DirectiveName</code>
+   * This visitor methods extracts the command and creates a toke type
+   * <code>DirectiveName</code>
    */
   @Override
   public RecipeSymbol.Builder visitCommand(DirectivesParser.CommandContext ctx) {
@@ -257,7 +287,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of columns specified. It creates a token
+   * This visitor methods extracts the list of columns specified. It creates a
+   * token
    * type <code>ColumnNameList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -272,7 +303,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of numeric specified. It creates a token
+   * This visitor methods extracts the list of numeric specified. It creates a
+   * token
    * type <code>NumericList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -287,7 +319,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of booleans specified. It creates a token
+   * This visitor methods extracts the list of booleans specified. It creates a
+   * token
    * type <code>BoolList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -302,7 +335,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of strings specified. It creates a token
+   * This visitor methods extracts the list of strings specified. It creates a
+   * token
    * type <code>StringList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -326,4 +360,21 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     int column = ctx.getStart().getCharPositionInLine();
     return new SourceInfo(lineno, column, text);
   }
+
+  @Override
+  public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
+    if (ctx.BYTE_SIZE() != null) {
+      builder.addToken(new ByteSize(ctx.BYTE_SIZE().getText()));
+    } else if (ctx.TIME_DURATION() != null) {
+      builder.addToken(new TimeDuration(ctx.TIME_DURATION().getText()));
+    } else if (ctx.number() != null) {
+      builder.addToken(new Numeric(new LazyNumber(ctx.number().getText())));
+    } else if (ctx.text() != null) {
+      String text = ctx.text().getText();
+      builder.addToken(new Text(text.substring(1, text.length() - 1)));
+    }
+
+    return builder;
+  }
+
 }

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/SyntaxErrorListener.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/SyntaxErrorListener.java
@@ -38,7 +38,7 @@ public final class SyntaxErrorListener extends BaseErrorListener {
 
   @Override
   public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine,
-                          String msg, RecognitionException e) {
+      String msg, RecognitionException e) {
 
     Parser parser = (Parser) recognizer;
     String name = parser.getSourceName();
@@ -60,7 +60,7 @@ public final class SyntaxErrorListener extends BaseErrorListener {
           msg = "unexpected token found '" + ((NoViableAltException) e).getStartToken().getText() + "'";
         }
       }
-      String message = "At line " + line + ":" + charPositionInLine +  ": " + msg;
+      String message = "At line " + line + ":" + charPositionInLine + ": " + msg;
       errors.add(new SyntaxError(line, charPositionInLine, message, source));
       return;
     }
@@ -68,15 +68,15 @@ public final class SyntaxErrorListener extends BaseErrorListener {
     String offSymName = DirectivesLexer.VOCABULARY.getDisplayName(offSymbol.getType());
     String message = "At line " + line + ":" + charPositionInLine + " at " + offSymName.toLowerCase() + ": " + msg;
 
-//    StringBuilder sb = new StringBuilder(message);
-//    sb.append(", alternatives = {");
-//    for (int idx = lastError + 1; idx <= thisError; idx++) {
-//      Token token = tokens.get(idx);
-//      if (token.getChannel() != Token.HIDDEN_CHANNEL) {
-//        sb.append(token.getText()).append(",");
-//      }
-//    }
-//    sb.append("}");
+    // StringBuilder sb = new StringBuilder(message);
+    // sb.append(", alternatives = {");
+    // for (int idx = lastError + 1; idx <= thisError; idx++) {
+    // Token token = tokens.get(idx);
+    // if (token.getChannel() != Token.HIDDEN_CHANNEL) {
+    // sb.append(token.getText()).append(",");
+    // }
+    // }
+    // sb.append("}");
     lastError = thisError;
     errors.add(new SyntaxError(line, charPositionInLine, message, source));
   }


### PR DESCRIPTION
Summary
This pull request introduces the following enhancements to the Wrangler transformation engine:

1 .New Token Types
BYTE_SIZE: Parses values like 10KB, 2MB, 1.5GB, etc.
TIME_DURATION: Parses values like 5s, 2m, 100ms, etc.

2. Grammar & Visitor Updates
Modified parsing rules and RecipeVisitor to support and extract the new token types from recipes.

3. New Directive: aggregate-stats
A directive that aggregates byte size and time duration values over rows, with support for both total and average aggregation modes.

4. Example Usage
 - aggregate-stats :data_size :duration total_size_mb total_time_sec average
 
This will calculate the average size (in MB) and time (in seconds) from the data_size and duration columns and store the results in total_size_mb and total_time_sec.

5. Testing
Unit tested via TestingRig in AggregateStatsTest.java
Both total and average modes verified
Apache RAT check passed after adding appropriate license headers

6. Notes
AggregateStats uses TransientStore for row-wise aggregation
Parser integration done using custom visitor logic (RecipeVisitor.java)
Work includes at directive testing; integration into live pipelines can be a follow-up enhancement

