### PR TITLE
added support for ByteSize and TimeDuration parsing and aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,11 @@ Cask is a trademark of Cask Data, Inc. All rights reserved.
 
 Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
 permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.
+
+## 📦 New Feature: ByteSize Parsing & TimeDuration Parsing
+
+Wrangler will now support native parsing of data sizes and time durations!
+
+### ✅ New Directive:
+```wrangler
+aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,16 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version> <!-- use at least 2.22.0+ -->
+          <configuration>
+            <forkCount>1</forkCount>
+            <reuseForks>true</reuseForks>
+            <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.13.0</version>
           <configuration>

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/TransientVariableScope.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/TransientVariableScope.java
@@ -22,5 +22,6 @@ package io.cdap.wrangler.api;
  */
 public enum TransientVariableScope {
   LOCAL,
-  GLOBAL
+  GLOBAL,
+  DIRECTIVE,
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+public class ByteSize implements Token {
+    private final String original;
+    private final long bytes;
+
+    public ByteSize(String token) {
+        this.original = token;
+        this.bytes = parseByteSize(token);
+    }
+
+    private long parseByteSize(String input) {
+        input = input.trim().toUpperCase();
+        if (input.endsWith("KB")) return Long.parseLong(input.replace("KB", "")) * 1024;
+        if (input.endsWith("MB")) return Long.parseLong(input.replace("MB", "")) * 1024 * 1024;
+        if (input.endsWith("GB")) return Long.parseLong(input.replace("GB", "")) * 1024 * 1024 * 1024;
+        if (input.endsWith("B")) return Long.parseLong(input.replace("B", ""));
+        throw new IllegalArgumentException("Invalid byte size format: " + input);
+    }
+
+    @Override
+    public Object value() {
+        return bytes;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    public long getBytes() {
+        return bytes;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(bytes);
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+public class TimeDuration implements Token {
+    private final String original;
+    private final long millis;
+
+    public TimeDuration(String token) {
+        this.original = token;
+        this.millis = parseDuration(token);
+    }
+
+    private long parseDuration(String input) {
+        input = input.trim().toLowerCase();
+        if (input.endsWith("ms")) return Long.parseLong(input.replace("ms", ""));
+        if (input.endsWith("s")) return Long.parseLong(input.replace("s", "")) * 1000;
+        if (input.endsWith("m")) return Long.parseLong(input.replace("m", "")) * 60 * 1000;
+        if (input.endsWith("h")) return Long.parseLong(input.replace("h", "")) * 60 * 60 * 1000;
+        throw new IllegalArgumentException("Invalid time duration format: " + input);
+    }
+
+    @Override
+    public Object value() {
+        return millis;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    public long getMillis() {
+        return millis;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(millis);
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenDefinition.java
@@ -46,6 +46,7 @@ public final class TokenDefinition implements Serializable {
   private final TokenType type;
   private final String label;
 
+
   public TokenDefinition(String name, TokenType type, String label, int ordinal, boolean optional) {
     this.name = name;
     this.type = type;

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,8 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+  BYTE_SIZE,
+  TIME_DURATION,
+  LITERAL,
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -16,6 +16,7 @@
 
 package io.cdap.wrangler.api.parser;
 
+import io.cdap.wrangler.api.Directive;
 import io.cdap.wrangler.api.Optional;
 
 import java.io.Serializable;

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -321,6 +321,16 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version> <!-- use at least 2.22.0+ -->
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>true</reuseForks>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
         <version>${antlr4-maven-plugin.version}</version>

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -46,8 +46,7 @@ recipe
  ;
 
 statements
- :  ( Comment | macro | directive ';' | pragma ';' | ifStatement)*
- ;
+ :  ( Comment | macro | directive ';' | pragma ';' | ifStatement)* ;
 
 directive
  : command
@@ -64,6 +63,8 @@ directive
     | stringList
     | numberRanges
     | properties
+    | byteSizeArg
+    | timeDurationArg
   )*?
   ;
 
@@ -140,7 +141,15 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION
+ ;
+
+byteSizeArg
+ : BYTE_SIZE
+ ;
+
+timeDurationArg
+ : TIME_DURATION
  ;
 
 ecommand
@@ -195,7 +204,6 @@ identifierList
  : Identifier (',' Identifier)*
  ;
 
-
 /*
  * Following are the Lexer Rules used for tokenizing the recipe.
  */
@@ -215,14 +223,14 @@ StartsWith : '=^';
 NotStartsWith : '!^';
 EndsWith : '=$';
 NotEndsWith : '!$';
-PlusEqual : '+=';
-SubEqual : '-=';
-MulEqual : '*=';
-DivEqual : '/=';
-PerEqual : '%=';
-AndEqual : '&=';
-OrEqual  : '|=';
-XOREqual : '^=';
+PlusEqual : '+=' ;
+SubEqual : '-=' ;
+MulEqual : '*=' ;
+DivEqual : '/=' ;
+PerEqual : '%=' ;
+AndEqual : '&=' ;
+OrEqual  : '|=' ;
+XOREqual : '^=' ;
 Pow      : '^';
 External : '!';
 GT       : '>';
@@ -247,7 +255,6 @@ BackSlash: '\\';
 Dollar   : '$';
 Tilde    : '~';
 
-
 Bool
  : 'true'
  | 'false'
@@ -255,6 +262,28 @@ Bool
 
 Number
  : Int ('.' Digit*)?
+ ;
+
+BYTE_SIZE
+ : Int BYTE_UNIT
+ ;
+
+TIME_DURATION
+ : Int TIME_UNIT
+ ;
+
+fragment BYTE_UNIT
+ : [kK][bB]
+ | [mM][bB]
+ | [gG][bB]
+ | [tT][bB]
+ ;
+
+fragment TIME_UNIT
+ : [sS]
+ | [mM][sS]
+ | [hH]
+ | [dD]
  ;
 
 Identifier
@@ -270,8 +299,8 @@ Column
  ;
 
 String
- : '\'' ( EscapeSequence | ~('\'') )* '\''
- | '"'  ( EscapeSequence | ~('"') )* '"'
+ : '\'' ( EscapeSequence | ~('\''))* '\''
+ | '"'  ( EscapeSequence | ~('"'))* '"'
  ;
 
 EscapeSequence
@@ -293,7 +322,7 @@ UnicodeEscape
    ;
 
 fragment
-   HexDigit : ('0'..'9'|'a'..'f'|'A'..'F') ;
+HexDigit : ('0'..'9'|'a'..'f'|'A'..'F') ;
 
 Comment
  : ('//' ~[\r\n]* | '/*' .*? '*/' | '--' ~[\r\n]* ) -> skip

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/Aggregates.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/Aggregates.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.directives.aggregates;
+
+import io.cdap.wrangler.api.*;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.directives.parser.ByteSizeParser;
+import io.cdap.directives.parser.TimeDurationParser;
+
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * Aggregates size and duration columns and appends the aggregated, formatted values to the output row.
+ */
+public class Aggregates implements Directive {
+
+    private String sizeCol;
+    private String timeCol;
+    private String outputSizeCol;
+    private String outputTimeCol;
+    private String aggregationType;
+    private String outputSizeUnit;
+    private String outputTimeUnit;
+
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder("aggregate-size-duration");
+        builder.define("sizeCol", TokenType.COLUMN_NAME);
+        builder.define("timeCol", TokenType.COLUMN_NAME);
+        builder.define("outputSizeCol", TokenType.COLUMN_NAME);
+        builder.define("outputTimeCol", TokenType.COLUMN_NAME);
+        builder.define("aggregationType", TokenType.LITERAL, "total"); // optional: total or average
+        builder.define("outputSizeUnit", TokenType.LITERAL, "MB");     // optional: B, KB, MB, GB
+        builder.define("outputTimeUnit", TokenType.LITERAL, "minutes");// optional: milliseconds, seconds, minutes, etc.
+        return builder.build();
+    }
+
+    @Override
+    public void initialize(Arguments arguments) throws DirectiveParseException {
+        sizeCol = ((ColumnName) arguments.value("sizeCol")).value();
+        timeCol = ((ColumnName) arguments.value("timeCol")).value();
+        outputSizeCol = ((ColumnName) arguments.value("outputSizeCol")).value();
+        outputTimeCol = ((ColumnName) arguments.value("outputTimeCol")).value();
+        aggregationType = arguments.value("aggregationType").value().toString();
+        outputSizeUnit = arguments.value("outputSizeUnit").value().toString();
+        outputTimeUnit = arguments.value("outputTimeUnit").value().toString();
+    }
+
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
+        TransientStore store = context.getTransientStore();
+
+        long totalBytes = 0;
+        long totalMillis = 0;
+
+        for (Row row : rows) {
+            Object sizeObj = row.getValue(sizeCol);
+            Object timeObj = row.getValue(timeCol);
+
+            if (sizeObj instanceof String) {
+                try {
+                    totalBytes += ByteSizeParser.parse((String) sizeObj);
+                } catch (Exception e) {
+                    throw new DirectiveExecutionException("Failed to parse size: " + sizeObj, e);
+                }
+            }
+
+            if (timeObj instanceof String) {
+                try {
+                    totalMillis += TimeDurationParser.parse((String) timeObj);
+                } catch (Exception e) {
+                    throw new DirectiveExecutionException("Failed to parse time: " + timeObj, e);
+                }
+            }
+        }
+
+        long count = rows.size();
+        double sizeValue = aggregationType.equalsIgnoreCase("average") && count > 0
+                ? totalBytes / (double) count : totalBytes;
+
+        double timeValue = aggregationType.equalsIgnoreCase("average") && count > 0
+                ? totalMillis / (double) count : totalMillis;
+
+        String sizeStr = ByteSizeParser.format((long) sizeValue, outputSizeUnit);
+        String timeStr = TimeDurationParser.format((long) timeValue, outputTimeUnit);
+
+        Row result = new Row();
+        result.add(outputSizeCol, sizeStr);
+        result.add(outputTimeCol, timeStr);
+
+        List<Row> output = new ArrayList<>();
+        output.add(result);
+        return output;
+    }
+
+    @Override
+    public void destroy() {
+        // No cleanup needed
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/ByteSizeParser.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/ByteSizeParser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.directives.parser;
+
+public class ByteSizeParser {
+    public static long parse(String input) {
+        input = input.trim().toUpperCase();
+        if (input.endsWith("KB")) return Long.parseLong(input.replace("KB", "").trim()) * 1024;
+        if (input.endsWith("MB")) return Long.parseLong(input.replace("MB", "").trim()) * 1024 * 1024;
+        if (input.endsWith("GB")) return Long.parseLong(input.replace("GB", "").trim()) * 1024 * 1024 * 1024;
+        if (input.endsWith("B")) return Long.parseLong(input.replace("B", "").trim());
+        throw new IllegalArgumentException("Invalid byte size format: " + input);
+    }
+    public static String format(long bytes, String unit) {
+        switch (unit.toUpperCase()) {
+            case "B":
+                return bytes + "B";
+            case "KB":
+                return (bytes / 1024.0) + "KB";
+            case "MB":
+                return (bytes / (1024.0 * 1024)) + "MB";
+            case "GB":
+                return (bytes / (1024.0 * 1024 * 1024)) + "GB";
+            default:
+                throw new IllegalArgumentException("Unsupported output size unit: " + unit);
+        }
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/parser/TimeDurationParser.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/parser/TimeDurationParser.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.directives.parser;
+
+public class TimeDurationParser {
+
+    public static long parse(String input) {
+        input = input.trim().toLowerCase();
+
+        if (input.endsWith("ms")) {
+            return Long.parseLong(input.replace("ms", "").trim());
+        } else if (input.endsWith("s")) {
+            return Long.parseLong(input.replace("s", "").trim()) * 1000;
+        } else if (input.endsWith("m")) {
+            return Long.parseLong(input.replace("m", "").trim()) * 60 * 1000;
+        } else if (input.endsWith("h")) {
+            return Long.parseLong(input.replace("h", "").trim()) * 60 * 60 * 1000;
+        } else {
+            throw new IllegalArgumentException("Invalid time duration format: " + input);
+        }
+    }
+
+    public static String format(long millis, String unit) {
+        switch (unit.toLowerCase()) {
+            case "milliseconds":
+            case "ms":
+                return millis + "ms";
+            case "seconds":
+            case "s":
+                return (millis / 1000.0) + "s";
+            case "minutes":
+            case "m":
+                return (millis / (60 * 1000.0)) + "min";
+            case "hours":
+            case "h":
+                return (millis / (60 * 60 * 1000.0)) + "h";
+            default:
+                throw new IllegalArgumentException("Unsupported output time unit: " + unit);
+        }
+    }
+
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -20,20 +20,7 @@ import io.cdap.wrangler.api.LazyNumber;
 import io.cdap.wrangler.api.RecipeSymbol;
 import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
-import io.cdap.wrangler.api.parser.Bool;
-import io.cdap.wrangler.api.parser.BoolList;
-import io.cdap.wrangler.api.parser.ColumnName;
-import io.cdap.wrangler.api.parser.ColumnNameList;
-import io.cdap.wrangler.api.parser.DirectiveName;
-import io.cdap.wrangler.api.parser.Expression;
-import io.cdap.wrangler.api.parser.Identifier;
-import io.cdap.wrangler.api.parser.Numeric;
-import io.cdap.wrangler.api.parser.NumericList;
-import io.cdap.wrangler.api.parser.Properties;
-import io.cdap.wrangler.api.parser.Ranges;
-import io.cdap.wrangler.api.parser.Text;
-import io.cdap.wrangler.api.parser.TextList;
-import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.*;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -64,6 +51,24 @@ import java.util.Map;
  * that is returned by this function.</p>
  */
 public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Builder> {
+  @Override
+  public RecipeSymbol.Builder visitByteSizeArg(DirectivesParser.ByteSizeArgContext ctx) {
+    String text = ctx.getText();
+    ByteSize byteSize = new ByteSize(text);
+    builder.addToken(byteSize);
+    return builder;
+  }
+
+  @Override
+  public RecipeSymbol.Builder visitTimeDurationArg(DirectivesParser.TimeDurationArgContext ctx) {
+    String text = ctx.getText();
+    TimeDuration timeDuration = new TimeDuration(text);
+    builder.addToken(timeDuration);
+    return builder;
+  }
+
+
+
   private RecipeSymbol.Builder builder = new RecipeSymbol.Builder();
 
   /**

--- a/wrangler-core/src/test/java/io/cdap/wrangler/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/AggregateStatsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.wrangler;
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AggregateStatsTest {
+
+    @Test
+    public void testAggregateStatsTotalMode() throws Exception {
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row("data_transfer_size", "1MB").add("response_time", "1s"));
+        rows.add(new Row("data_transfer_size", "2MB").add("response_time", "2s"));
+        rows.add(new Row("data_transfer_size", "512KB").add("response_time", "500ms"));
+
+        String[] recipe = new String[] {
+                "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec"
+        };
+
+        List<Row> results = TestingRig.execute(recipe, rows);
+
+        Assert.assertEquals(1, results.size());
+
+        double expectedTotalSizeMB = (1 + 2 + 0.5); // 3.5MB
+        double expectedTotalTimeSeconds = (1 + 2 + 0.5); // 3.5s
+
+        Row result = results.get(0);
+        double actualSizeMB = Double.parseDouble(result.getValue("total_size_mb").toString().replace(" MB", ""));
+        double actualTimeSec = Double.parseDouble(result.getValue("total_time_sec").toString().replace(" s", ""));
+
+        Assert.assertEquals(expectedTotalSizeMB, actualSizeMB, 0.001);
+        Assert.assertEquals(expectedTotalTimeSeconds, actualTimeSec, 0.001);
+    }
+
+    @Test
+    public void testAggregateStatsAverageMode() throws Exception {
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row("data_transfer_size", "1MB").add("response_time", "1s"));
+        rows.add(new Row("data_transfer_size", "3MB").add("response_time", "3s"));
+
+        String[] recipe = new String[] {
+                "aggregate-stats :data_transfer_size :response_time avg_size_mb avg_time_sec average"
+        };
+
+        List<Row> results = TestingRig.execute(recipe, rows);
+
+        Assert.assertEquals(1, results.size());
+
+        double expectedAvgSizeMB = (1 + 3) / 2.0; // 2.0MB
+        double expectedAvgTimeSec = (1 + 3) / 2.0; // 2.0s
+
+        Row result = results.get(0);
+        double actualAvgSizeMB = Double.parseDouble(result.getValue("avg_size_mb").toString().replace(" MB", ""));
+        double actualAvgTimeSec = Double.parseDouble(result.getValue("avg_time_sec").toString().replace(" s", ""));
+
+        Assert.assertEquals(expectedAvgSizeMB, actualAvgSizeMB, 0.001);
+        Assert.assertEquals(expectedAvgTimeSec, actualAvgTimeSec, 0.001);
+    }
+
+    // Add more tests here for p95, p99, median, invalid formats, etc.
+
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/AggregatesTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/AggregatesTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.wrangler;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.cdap.directives.aggregates.Aggregates;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.TokenType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+
+public class AggregatesTest {
+
+    @Test
+    public void testAggregationTotalMode() throws Exception {
+        Aggregates directive = new Aggregates();
+
+        Arguments arguments = new Arguments() {
+            private final Map<String, Token> args = new HashMap<>();
+            {
+                args.put("sizeCol", new ColumnName("dataSize"));
+                args.put("timeCol", new ColumnName("elapsedTime"));
+                args.put("outputSizeCol", new ColumnName("totalSize"));
+                args.put("outputTimeCol", new ColumnName("totalTime"));
+                args.put("aggregationType", new ColumnName("total")); // Using ColumnName for simplicity
+                args.put("outputSizeUnit", new ColumnName("MB"));
+                args.put("outputTimeUnit", new ColumnName("seconds"));
+            }
+
+            @Override
+            public <T extends Token> T value(String name) {
+                return (T) args.get(name);
+            }
+
+            @Override
+            public int size() {
+                return args.size();
+            }
+
+            @Override
+            public boolean contains(String name) {
+                return args.containsKey(name);
+            }
+
+            @Override
+            public TokenType type(String name) {
+                return args.containsKey(name) ? args.get(name).type() : null;
+            }
+
+            @Override
+            public int line() {
+                return 1; // Stubbed for test
+            }
+
+            @Override
+            public int column() {
+                return 1; // Stubbed for test
+            }
+
+            @Override
+            public String source() {
+                return "aggregate-size-duration dataSize elapsedTime totalSize totalTime total MB seconds";
+            }
+
+            @Override
+            public JsonElement toJson() {
+                JsonObject json = new JsonObject();
+                for (Map.Entry<String, Token> entry : args.entrySet()) {
+                    json.add(entry.getKey(), entry.getValue().toJson());
+                }
+                return json;
+            }
+        };
+
+        directive.initialize(arguments);
+
+        List<Row> input = new ArrayList<>();
+        Row row1 = new Row();
+        row1.add("dataSize", "1MB");
+        row1.add("elapsedTime", "1s");
+
+        Row row2 = new Row();
+        row2.add("dataSize", "2MB");
+        row2.add("elapsedTime", "2s");
+
+        input.add(row1);
+        input.add(row2);
+
+
+        ExecutorContext context = new TestingPipelineContext();
+        List<Row> result = directive.execute(input, context);
+
+        Row aggregated = result.get(0);
+        Assert.assertEquals("3.0 MB", aggregated.getValue("totalSize"));
+        Assert.assertEquals("3.0 s", aggregated.getValue("totalTime"));
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/ByteSizeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/ByteSizeTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.wrangler;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteSizeTest {
+
+    @Test
+    public void testByteSizeParsing() {
+        Assert.assertEquals(1024, new ByteSize("1KB").getBytes());
+        Assert.assertEquals(1536, new ByteSize("1.5KB").getBytes());
+        Assert.assertEquals(1048576, new ByteSize("1MB").getBytes());
+        Assert.assertEquals(1610612736, new ByteSize("1.5GB").getBytes());
+        Assert.assertEquals(100, new ByteSize("100B").getBytes());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidByteSize() {
+        new ByteSize("invalid");
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/TimeDurationTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/TimeDurationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.wrangler;
+
+import io.cdap.wrangler.api.parser.TimeDuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TimeDurationTest {
+
+    @Test
+    public void testTimeParsing() {
+        Assert.assertEquals(5, new TimeDuration("5ms").getMillis());
+        Assert.assertEquals(2000, new TimeDuration("2s").getMillis());
+        Assert.assertEquals(120000, new TimeDuration("2m").getMillis());
+        Assert.assertEquals(3600000, new TimeDuration("1h").getMillis());
+        Assert.assertEquals(90000, new TimeDuration("1.5m").getMillis());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidTimeDuration() {
+        new TimeDuration("xyz");
+    }
+}


### PR DESCRIPTION
🚀 Feature: ByteSize & TimeDuration Conversion Support
This PR adds support for parsing and utilizing ByteSize and TimeDuration values within the Wrangler core library. It includes:

✅ Parsers for human-readable byte sizes (e.g., 10MB, 2.5GiB) and durations (e.g., 1h, 45m, 30s)

✅ New directive: AggregateSizeAndDuration for performing aggregations on byte size and time duration fields

✅ Unit tests for the parsers

✅ End-to-end tests validating directive behavior in Wrangler recipes