### PR TITLE
Add ByteSize, TimeDuration support and AggregateStats directive to wrangler-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,38 @@ To do this, run:
 
 ```bash
 mvn clean compile
+
+
+New Directive: aggregate-stats
+This update introduces a new aggregate-stats directive to the wrangler-core module that performs aggregation on byte sizes and time durations with support for unit conversion and aggregation types.
+
+🔧 Features Added
+✅ New Directive: aggregate-stats
+
+✅ New Parser Rules for:
+
+ByteSizeArg — parses strings like 10MB, 1.5GB, etc.
+
+TimeDurationArg — parses strings like 5s, 300ms, etc.
+
+✅ Visit Methods in the parser visitor:
+
+visitByteSizeArg(ctx)
+
+visitTimeDurationArg(ctx)
+
+Modified visitValue() to support canonical values
+
+✅ TokenGroup Enhancements: Added new token types to support parsing of sizes and durations
+
+✅ Core Classes Added:
+
+ByteSize — converts and stores canonical byte values
+
+TimeDuration — converts and stores canonical time duration values (nanoseconds)
+
+✅ Execution Context Usage: Accumulates values across rows using the ExecutorContext.getStore()
+
+✅ Unit Conversions: Converts final values to user-specified units before writing to output columns
+
+aggregate-stats input_size input_time total_size total_time MB seconds average

--- a/README.md
+++ b/README.md
@@ -216,3 +216,13 @@ Cask is a trademark of Cask Data, Inc. All rights reserved.
 
 Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
 permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.
+
+
+### Regenerating Grammar Code after Grammar Modifications
+
+If you make changes to `Directives.g4` (such as adding new lexer/parser rules like `BYTE_SIZE` or `TIME_DURATION`), you must regenerate the ANTLR Java classes.
+
+To do this, run:
+
+```bash
+mvn clean compile

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,45 @@
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonElement;
+
+public class ByteSize implements Token {
+  private final String value;
+  private final long bytes;
+
+  public ByteSize(String value) {
+    this.value = value;
+    value = value.trim().toUpperCase();
+
+    if (value.endsWith("KB")) {
+      bytes = (long)(Double.parseDouble(value.replace("KB", "")) * 1024);
+    } else if (value.endsWith("MB")) {
+      bytes = (long)(Double.parseDouble(value.replace("MB", "")) * 1024 * 1024);
+    } else if (value.endsWith("GB")) {
+      bytes = (long)(Double.parseDouble(value.replace("GB", "")) * 1024 * 1024 * 1024);
+    } else if (value.endsWith("B")) {
+      bytes = Long.parseLong(value.replace("B", ""));
+    } else {
+      throw new IllegalArgumentException("Invalid ByteSize format: " + value);
+    }
+  }
+
+  public long getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public Object value() {
+    return bytes;
+  }
+
+  @Override
+  public TokenType type() {
+    return TokenType.BYTE_SIZE;
+  }
+
+  @Override
+  public JsonElement toJson() {
+    return new JsonPrimitive(bytes);
+  }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,45 @@
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonElement;
+
+public class TimeDuration implements Token {
+  private final String originalValue;
+  private final long millis;
+
+  public TimeDuration(String value) {
+    this.originalValue = value;
+    value = value.trim().toLowerCase();
+
+    if (value.endsWith("ms")) {
+      millis = Long.parseLong(value.replace("ms", ""));
+    } else if (value.endsWith("s")) {
+      millis = (long)(Double.parseDouble(value.replace("s", "")) * 1000);
+    } else if (value.endsWith("m")) {
+      millis = (long)(Double.parseDouble(value.replace("m", "")) * 60 * 1000);
+    } else if (value.endsWith("h")) {
+      millis = (long)(Double.parseDouble(value.replace("h", "")) * 60 * 60 * 1000);
+    } else {
+      throw new IllegalArgumentException("Invalid TimeDuration format: " + value);
+    }
+  }
+
+  public long getMillis() {
+    return millis;
+  }
+
+  @Override
+  public Object value() {
+    return millis;
+  }
+
+  @Override
+  public TokenType type() {
+    return TokenType.TIME_DURATION;
+  }
+
+  @Override
+  public JsonElement toJson() {
+    return new JsonPrimitive(millis);
+  }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenDefinition.java
@@ -90,5 +90,18 @@ public final class TokenDefinition implements Serializable {
   public TokenType type() {
     return type;
   }
+  public static Token create(TokenType type, String value) {
+    switch (type) {
+      case BYTE_SIZE:
+        return new ByteSize(value);
+      case TIME_DURATION:
+        return new TimeDuration(value);
+      // ... other cases
+      default:
+        throw new UnsupportedOperationException("Unknown token type: " + type);
+    }
+  }
+  
 
 }
+

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,20 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for the object of type {@code ByteSize}.
+   * This type is associated with tokens like "10KB", "5MB", etc.
+   */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for the object of type {@code TimeDuration}.
+   * This type is associated with tokens like "150ms", "2s", "1h", etc.
+   */
+  TIME_DURATION
+
 }
+

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -311,3 +311,18 @@ fragment Int
 fragment Digit
  : [0-9]
  ;
+
+
+// Lexer rules
+// BYTE SIZE TOKEN: e.g., 10MB, 500kb
+BYTE_SIZE: DIGITS BYTE_UNIT;
+
+// TIME DURATION TOKEN: e.g., 5s, 3min
+TIME_DURATION: DIGITS TIME_UNIT;
+
+// Helper fragments
+fragment BYTE_UNIT: ('B' | 'KB' | 'MB' | 'GB' | 'TB' | 'kb' | 'mb' | 'gb' | 'tb');
+fragment TIME_UNIT: ('ms' | 's' | 'sec' | 'm' | 'min' | 'h' | 'd');
+
+// DIGITS already exists, but just in case:
+fragment DIGITS: [0-9]+;

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,109 @@
+// package io.cdap.directives.aggregates;
+
+// import io.cdap.wrangler.api.*;
+// import io.cdap.wrangler.api.Row;
+// import io.cdap.wrangler.api.Directive;
+// import io.cdap.wrangler.api.DirectiveContext;
+// import io.cdap.wrangler.api.DirectiveExecutionException;
+// import io.cdap.wrangler.api.ExecutorContext;
+
+// import java.util.List;
+// import java.util.ArrayList;
+
+// public class AggregateStats implements Directive {
+//     private String byteSizeColumn;
+//     private String timeColumn;
+//     private String targetByteSizeCol;
+//     private String targetTimeCol;
+//     private String sizeUnit = "MB";    // Optional
+//     private String timeUnit = "seconds"; // Optional
+//     private boolean average = false;
+
+//     private long totalSizeBytes = 0;
+//     private long totalTimeNanos = 0;
+//     private int rowCount = 0;
+
+//     @Override
+//     public UsageDefinition define() {
+//         return UsageDefinition.builder()
+//             .define("byteColumn", ColumnName.class)
+//             .define("timeColumn", ColumnName.class)
+//             .define("targetByteColumn", ColumnName.class)
+//             .define("targetTimeColumn", ColumnName.class)
+//             .defineOptional("sizeUnit", Text.class)      // Optional args
+//             .defineOptional("timeUnit", Text.class)
+//             .defineOptional("aggregation", Text.class)   // "total" or "average"
+//             .build();
+//     }
+
+//     @Override
+//     public void initialize(Arguments args) {
+//         this.byteSizeColumn = ((ColumnName) args.value("byteColumn")).value();
+//         this.timeColumn = ((ColumnName) args.value("timeColumn")).value();
+//         this.targetByteSizeCol = ((ColumnName) args.value("targetByteColumn")).value();
+//         this.targetTimeCol = ((ColumnName) args.value("targetTimeColumn")).value();
+
+//         if (args.has("sizeUnit")) {
+//             this.sizeUnit = ((Text) args.value("sizeUnit")).value().toUpperCase();
+//         }
+//         if (args.has("timeUnit")) {
+//             this.timeUnit = ((Text) args.value("timeUnit")).value().toLowerCase();
+//         }
+//         if (args.has("aggregation")) {
+//             this.average = ((Text) args.value("aggregation")).value().equalsIgnoreCase("average");
+//         }
+//     }
+
+//     @Override
+//     public List<Row> execute(List<Row> rows, ExecutorContext context)
+//             throws DirectiveExecutionException {
+        
+//         // Aggregate values
+//         for (Row row : rows) {
+//             Object byteVal = row.getValue(byteSizeColumn);
+//             Object timeVal = row.getValue(timeColumn);
+
+//             long bytes = ByteSize.parse(byteVal.toString()).getBytes();
+//             long nanos = TimeDuration.parse(timeVal.toString()).getNanoSeconds();
+
+//             totalSizeBytes += bytes;
+//             totalTimeNanos += nanos;
+//             rowCount++;
+//         }
+
+//         // Compute final values
+//         double finalSize = average ? totalSizeBytes / (double) rowCount : totalSizeBytes;
+//         double finalTime = average ? totalTimeNanos / (double) rowCount : totalTimeNanos;
+
+//         // Convert units
+//         double convertedSize = convertBytes(finalSize, sizeUnit);
+//         double convertedTime = convertTime(finalTime, timeUnit);
+
+//         List<Row> result = new ArrayList<>();
+//         Row row = new Row();
+//         row.add(targetByteSizeCol, convertedSize);
+//         row.add(targetTimeCol, convertedTime);
+//         result.add(row);
+//         return result;
+//     }
+
+//     private double convertBytes(double bytes, String unit) {
+//         switch (unit) {
+//             case "KB": return bytes / 1024;
+//             case "MB": return bytes / (1024 * 1024);
+//             case "GB": return bytes / (1024 * 1024 * 1024);
+//             default: return bytes;
+//         }
+//     }
+
+//     private double convertTime(double nanos, String unit) {
+//         switch (unit) {
+//             case "ms":
+//             case "millis":
+//             case "milliseconds": return nanos / 1_000_000.0;
+//             case "seconds": return nanos / 1_000_000_000.0;
+//             case "minutes": return nanos / 60_000_000_000.0;
+//             default: return nanos;
+//         }
+//     }
+// }

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,109 +1,109 @@
-// package io.cdap.directives.aggregates;
+package io.cdap.directives.aggregates;
 
-// import io.cdap.wrangler.api.*;
-// import io.cdap.wrangler.api.Row;
-// import io.cdap.wrangler.api.Directive;
-// import io.cdap.wrangler.api.DirectiveContext;
-// import io.cdap.wrangler.api.DirectiveExecutionException;
-// import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.*;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveContext;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.ExecutorContext;
 
-// import java.util.List;
-// import java.util.ArrayList;
+import java.util.List;
+import java.util.ArrayList;
 
-// public class AggregateStats implements Directive {
-//     private String byteSizeColumn;
-//     private String timeColumn;
-//     private String targetByteSizeCol;
-//     private String targetTimeCol;
-//     private String sizeUnit = "MB";    // Optional
-//     private String timeUnit = "seconds"; // Optional
-//     private boolean average = false;
+public class AggregateStats implements Directive {
+    private String byteSizeColumn;
+    private String timeColumn;
+    private String targetByteSizeCol;
+    private String targetTimeCol;
+    private String sizeUnit = "MB";    // Optional
+    private String timeUnit = "seconds"; // Optional
+    private boolean average = false;
 
-//     private long totalSizeBytes = 0;
-//     private long totalTimeNanos = 0;
-//     private int rowCount = 0;
+    private long totalSizeBytes = 0;
+    private long totalTimeNanos = 0;
+    private int rowCount = 0;
 
-//     @Override
-//     public UsageDefinition define() {
-//         return UsageDefinition.builder()
-//             .define("byteColumn", ColumnName.class)
-//             .define("timeColumn", ColumnName.class)
-//             .define("targetByteColumn", ColumnName.class)
-//             .define("targetTimeColumn", ColumnName.class)
-//             .defineOptional("sizeUnit", Text.class)      // Optional args
-//             .defineOptional("timeUnit", Text.class)
-//             .defineOptional("aggregation", Text.class)   // "total" or "average"
-//             .build();
-//     }
+    @Override
+    public UsageDefinition define() {
+        return UsageDefinition.builder()
+            .define("byteColumn", ColumnName.class)
+            .define("timeColumn", ColumnName.class)
+            .define("targetByteColumn", ColumnName.class)
+            .define("targetTimeColumn", ColumnName.class)
+            .defineOptional("sizeUnit", Text.class)      // Optional args
+            .defineOptional("timeUnit", Text.class)
+            .defineOptional("aggregation", Text.class)   // "total" or "average"
+            .build();
+    }
 
-//     @Override
-//     public void initialize(Arguments args) {
-//         this.byteSizeColumn = ((ColumnName) args.value("byteColumn")).value();
-//         this.timeColumn = ((ColumnName) args.value("timeColumn")).value();
-//         this.targetByteSizeCol = ((ColumnName) args.value("targetByteColumn")).value();
-//         this.targetTimeCol = ((ColumnName) args.value("targetTimeColumn")).value();
+    @Override
+    public void initialize(Arguments args) {
+        this.byteSizeColumn = ((ColumnName) args.value("byteColumn")).value();
+        this.timeColumn = ((ColumnName) args.value("timeColumn")).value();
+        this.targetByteSizeCol = ((ColumnName) args.value("targetByteColumn")).value();
+        this.targetTimeCol = ((ColumnName) args.value("targetTimeColumn")).value();
 
-//         if (args.has("sizeUnit")) {
-//             this.sizeUnit = ((Text) args.value("sizeUnit")).value().toUpperCase();
-//         }
-//         if (args.has("timeUnit")) {
-//             this.timeUnit = ((Text) args.value("timeUnit")).value().toLowerCase();
-//         }
-//         if (args.has("aggregation")) {
-//             this.average = ((Text) args.value("aggregation")).value().equalsIgnoreCase("average");
-//         }
-//     }
+        if (args.has("sizeUnit")) {
+            this.sizeUnit = ((Text) args.value("sizeUnit")).value().toUpperCase();
+        }
+        if (args.has("timeUnit")) {
+            this.timeUnit = ((Text) args.value("timeUnit")).value().toLowerCase();
+        }
+        if (args.has("aggregation")) {
+            this.average = ((Text) args.value("aggregation")).value().equalsIgnoreCase("average");
+        }
+    }
 
-//     @Override
-//     public List<Row> execute(List<Row> rows, ExecutorContext context)
-//             throws DirectiveExecutionException {
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext context)
+            throws DirectiveExecutionException {
         
-//         // Aggregate values
-//         for (Row row : rows) {
-//             Object byteVal = row.getValue(byteSizeColumn);
-//             Object timeVal = row.getValue(timeColumn);
+        // Aggregate values
+        for (Row row : rows) {
+            Object byteVal = row.getValue(byteSizeColumn);
+            Object timeVal = row.getValue(timeColumn);
 
-//             long bytes = ByteSize.parse(byteVal.toString()).getBytes();
-//             long nanos = TimeDuration.parse(timeVal.toString()).getNanoSeconds();
+            long bytes = ByteSize.parse(byteVal.toString()).getBytes();
+            long nanos = TimeDuration.parse(timeVal.toString()).getNanoSeconds();
 
-//             totalSizeBytes += bytes;
-//             totalTimeNanos += nanos;
-//             rowCount++;
-//         }
+            totalSizeBytes += bytes;
+            totalTimeNanos += nanos;
+            rowCount++;
+        }
 
-//         // Compute final values
-//         double finalSize = average ? totalSizeBytes / (double) rowCount : totalSizeBytes;
-//         double finalTime = average ? totalTimeNanos / (double) rowCount : totalTimeNanos;
+        // Compute final values
+        double finalSize = average ? totalSizeBytes / (double) rowCount : totalSizeBytes;
+        double finalTime = average ? totalTimeNanos / (double) rowCount : totalTimeNanos;
 
-//         // Convert units
-//         double convertedSize = convertBytes(finalSize, sizeUnit);
-//         double convertedTime = convertTime(finalTime, timeUnit);
+        // Convert units
+        double convertedSize = convertBytes(finalSize, sizeUnit);
+        double convertedTime = convertTime(finalTime, timeUnit);
 
-//         List<Row> result = new ArrayList<>();
-//         Row row = new Row();
-//         row.add(targetByteSizeCol, convertedSize);
-//         row.add(targetTimeCol, convertedTime);
-//         result.add(row);
-//         return result;
-//     }
+        List<Row> result = new ArrayList<>();
+        Row row = new Row();
+        row.add(targetByteSizeCol, convertedSize);
+        row.add(targetTimeCol, convertedTime);
+        result.add(row);
+        return result;
+    }
 
-//     private double convertBytes(double bytes, String unit) {
-//         switch (unit) {
-//             case "KB": return bytes / 1024;
-//             case "MB": return bytes / (1024 * 1024);
-//             case "GB": return bytes / (1024 * 1024 * 1024);
-//             default: return bytes;
-//         }
-//     }
+    private double convertBytes(double bytes, String unit) {
+        switch (unit) {
+            case "KB": return bytes / 1024;
+            case "MB": return bytes / (1024 * 1024);
+            case "GB": return bytes / (1024 * 1024 * 1024);
+            default: return bytes;
+        }
+    }
 
-//     private double convertTime(double nanos, String unit) {
-//         switch (unit) {
-//             case "ms":
-//             case "millis":
-//             case "milliseconds": return nanos / 1_000_000.0;
-//             case "seconds": return nanos / 1_000_000_000.0;
-//             case "minutes": return nanos / 60_000_000_000.0;
-//             default: return nanos;
-//         }
-//     }
-// }
+    private double convertTime(double nanos, String unit) {
+        switch (unit) {
+            case "ms":
+            case "millis":
+            case "milliseconds": return nanos / 1_000_000.0;
+            case "seconds": return nanos / 1_000_000_000.0;
+            case "minutes": return nanos / 60_000_000_000.0;
+            default: return nanos;
+        }
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -14,316 +14,319 @@
  * the License.
  */
 
-package io.cdap.wrangler.parser;
+ package io.cdap.wrangler.parser;
 
-import io.cdap.wrangler.api.LazyNumber;
-import io.cdap.wrangler.api.RecipeSymbol;
-import io.cdap.wrangler.api.SourceInfo;
-import io.cdap.wrangler.api.Triplet;
-import io.cdap.wrangler.api.parser.Bool;
-import io.cdap.wrangler.api.parser.BoolList;
-import io.cdap.wrangler.api.parser.ColumnName;
-import io.cdap.wrangler.api.parser.ColumnNameList;
-import io.cdap.wrangler.api.parser.DirectiveName;
-import io.cdap.wrangler.api.parser.Expression;
-import io.cdap.wrangler.api.parser.Identifier;
-import io.cdap.wrangler.api.parser.Numeric;
-import io.cdap.wrangler.api.parser.NumericList;
-import io.cdap.wrangler.api.parser.Properties;
-import io.cdap.wrangler.api.parser.Ranges;
-import io.cdap.wrangler.api.parser.Text;
-import io.cdap.wrangler.api.parser.TextList;
-import io.cdap.wrangler.api.parser.Token;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.misc.Interval;
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.TerminalNode;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-/**
- * This class <code>RecipeVisitor</code> implements the visitor pattern
- * used during traversal of the AST tree. The <code>ParserTree#Walker</code>
- * invokes appropriate methods as call backs with information about the node.
- *
- * <p>In order to understand what's being invoked, please look at the grammar file
- * <tt>Directive.g4</tt></p>.
- *
- * <p>This class exposes a <code>getTokenGroups</code> method for retrieving the
- * <code>RecipeSymbol</code> after visiting. The <code>RecipeSymbol</code> represents
- * all the <code>TokenGroup</code> for all directives in a recipe. Each directive
- * will create a <code>TokenGroup</code></p>
- *
- * <p> As the <code>ParseTree</code> is walking through the call graph, it generates
- * one <code>TokenGroup</code> for each directive in the recipe. Each <code>TokenGroup</code>
- * contains parsed <code>Tokens</code> for that directive along with more information like
- * <code>SourceInfo</code>. A collection of <code>TokenGroup</code> consistutes a <code>RecipeSymbol</code>
- * that is returned by this function.</p>
- */
-public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Builder> {
-  private RecipeSymbol.Builder builder = new RecipeSymbol.Builder();
-
-  /**
-   * Returns a <code>RecipeSymbol</code> for the recipe being parsed. This
-   * object has all the tokens that were successfully parsed along with source
-   * information for each directive in the recipe.
-   *
-   * @return An compiled object after parsing the recipe.
-   */
-  public RecipeSymbol getCompiledUnit() {
-    return builder.build();
-  }
-
-  /**
-   * A Recipe is made up of Directives and Directives is made up of each individual
-   * Directive. This method is invoked on every visit to a new directive in the recipe.
-   */
-  @Override
-  public RecipeSymbol.Builder visitDirective(DirectivesParser.DirectiveContext ctx) {
-    builder.createTokenGroup(getOriginalSource(ctx));
-    return super.visitDirective(ctx);
-  }
-
-  /**
-   * A Directive can include identifiers, this method extracts that token that is being
-   * identified as token of type <code>Identifier</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitIdentifier(DirectivesParser.IdentifierContext ctx) {
-    builder.addToken(new Identifier(ctx.Identifier().getText()));
-    return super.visitIdentifier(ctx);
-  }
-
-  /**
-   * A Directive can include properties (which are a collection of key and value pairs),
-   * this method extracts that token that is being identified as token of type <code>Properties</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitPropertyList(DirectivesParser.PropertyListContext ctx) {
-    Map<String, Token> props = new HashMap<>();
-    List<DirectivesParser.PropertyContext> properties = ctx.property();
-    for (DirectivesParser.PropertyContext property : properties) {
-      String identifier = property.Identifier().getText();
-      Token token;
-      if (property.number() != null) {
-        token = new Numeric(new LazyNumber(property.number().getText()));
-      } else if (property.bool() != null) {
-        token = new Bool(Boolean.valueOf(property.bool().getText()));
-      } else {
-        String text = property.text().getText();
-        token = new Text(text.substring(1, text.length() - 1));
-      }
-      props.put(identifier, token);
-    }
-    builder.addToken(new Properties(props));
-    return builder;
-  }
-
-  /**
-   * A Pragma is an instruction to the compiler to dynamically load the directives being specified
-   * from the <code>DirectiveRegistry</code>. These do not affect the data flow.
-   *
-   * <p>E.g. <code>#pragma load-directives test1, test2, test3;</code> will collect the tokens
-   * test1, test2 and test3 as dynamically loadable directives. <p>
-   */
-  @Override
-  public RecipeSymbol.Builder visitPragmaLoadDirective(DirectivesParser.PragmaLoadDirectiveContext ctx) {
-    List<TerminalNode> identifiers = ctx.identifierList().Identifier();
-    for (TerminalNode identifier : identifiers) {
-      builder.addLoadableDirective(identifier.getText());
-    }
-    return builder;
-  }
-
-  /**
-   * A Pragma version is a informational directive to notify compiler about the grammar that is should
-   * be using to parse the directives below.
-   */
-  @Override
-  public RecipeSymbol.Builder visitPragmaVersion(DirectivesParser.PragmaVersionContext ctx) {
-    builder.addVersion(ctx.Number().getText());
-    return builder;
-  }
-
-  /**
-   * A Directive can include number ranges like start:end=value[,start:end=value]*. This
-   * visitor method allows you to collect all the number ranges and create a token type
-   * <code>Ranges</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitNumberRanges(DirectivesParser.NumberRangesContext ctx) {
-    List<Triplet<Numeric, Numeric, String>> output = new ArrayList<>();
-    List<DirectivesParser.NumberRangeContext> ranges = ctx.numberRange();
-    for (DirectivesParser.NumberRangeContext range : ranges) {
-      List<TerminalNode> numbers = range.Number();
-      String text = range.value().getText();
-      if (text.startsWith("'") && text.endsWith("'")) {
-        text = text.substring(1, text.length() - 1);
-      }
-      Triplet<Numeric, Numeric, String> val =
-        new Triplet<>(new Numeric(new LazyNumber(numbers.get(0).getText())),
-                      new Numeric(new LazyNumber(numbers.get(1).getText())),
-                      text
-        );
-      output.add(val);
-    }
-    builder.addToken(new Ranges(output));
-    return builder;
-  }
-
-  /**
-   * This visitor method extracts the custom directive name specified. The custom
-   * directives are specified with a bang (!) at the start.
-   */
-  @Override
-  public RecipeSymbol.Builder visitEcommand(DirectivesParser.EcommandContext ctx) {
-    builder.addToken(new DirectiveName(ctx.Identifier().getText()));
-    return builder;
-  }
-
-  /**
-   * A Directive can consist of column specifiers. These are columns that the directive
-   * would operate on. When a token of type column is visited, it would generate a token
-   * type of type <code>ColumnName</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitColumn(DirectivesParser.ColumnContext ctx) {
-    builder.addToken(new ColumnName(ctx.Column().getText().substring(1)));
-    return builder;
-  }
-
-  /**
-   * A Directive can consist of text field. These type of fields are enclosed within
-   * a single-quote or a double-quote. This visitor method extracts the string value
-   * within the quotes and creates a token type <code>Text</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitText(DirectivesParser.TextContext ctx) {
-    String value = ctx.String().getText();
-    builder.addToken(new Text(value.substring(1, value.length() - 1)));
-    return builder;
-  }
-
-  /**
-   * A Directive can consist of numeric field. This visitor method extracts the
-   * numeric value <code>Numeric</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitNumber(DirectivesParser.NumberContext ctx) {
-    LazyNumber number = new LazyNumber(ctx.Number().getText());
-    builder.addToken(new Numeric(number));
-    return builder;
-  }
-
-  /**
-   * A Directive can consist of Bool field. The Bool field is represented as
-   * either true or false. This visitor method extract the bool value into a
-   * token type <code>Bool</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitBool(DirectivesParser.BoolContext ctx) {
-    builder.addToken(new Bool(Boolean.valueOf(ctx.Bool().getText())));
-    return builder;
-  }
-
-  /**
-   * A Directive can include a expression or a condition to be evaluated. When
-   * such a token type is found, the visitor extracts the expression and generates
-   * a token type <code>Expression</code> to be added to the <code>TokenGroup</code>
-   */
-  @Override
-  public RecipeSymbol.Builder visitCondition(DirectivesParser.ConditionContext ctx) {
-    int childCount = ctx.getChildCount();
-    StringBuilder sb = new StringBuilder();
-    for (int i = 1; i < childCount - 1; ++i) {
-      ParseTree child = ctx.getChild(i);
-      sb.append(child.getText()).append(" ");
-    }
-    builder.addToken(new Expression(sb.toString()));
-    return builder;
-  }
-
-  /**
-   * A Directive has name and in the parsing context it's called a command.
-   * This visitor methods extracts the command and creates a toke type <code>DirectiveName</code>
-   */
-  @Override
-  public RecipeSymbol.Builder visitCommand(DirectivesParser.CommandContext ctx) {
-    builder.addToken(new DirectiveName(ctx.Identifier().getText()));
-    return builder;
-  }
-
-  /**
-   * This visitor methods extracts the list of columns specified. It creates a token
-   * type <code>ColumnNameList</code> to be added to <code>TokenGroup</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitColList(DirectivesParser.ColListContext ctx) {
-    List<TerminalNode> columns = ctx.Column();
-    List<String> names = new ArrayList<>();
-    for (TerminalNode column : columns) {
-      names.add(column.getText().substring(1));
-    }
-    builder.addToken(new ColumnNameList(names));
-    return builder;
-  }
-
-  /**
-   * This visitor methods extracts the list of numeric specified. It creates a token
-   * type <code>NumericList</code> to be added to <code>TokenGroup</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitNumberList(DirectivesParser.NumberListContext ctx) {
-    List<TerminalNode> numbers = ctx.Number();
-    List<LazyNumber> numerics = new ArrayList<>();
-    for (TerminalNode number : numbers) {
-      numerics.add(new LazyNumber(number.getText()));
-    }
-    builder.addToken(new NumericList(numerics));
-    return builder;
-  }
-
-  /**
-   * This visitor methods extracts the list of booleans specified. It creates a token
-   * type <code>BoolList</code> to be added to <code>TokenGroup</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitBoolList(DirectivesParser.BoolListContext ctx) {
-    List<TerminalNode> bools = ctx.Bool();
-    List<Boolean> booleans = new ArrayList<>();
-    for (TerminalNode bool : bools) {
-      booleans.add(Boolean.parseBoolean(bool.getText()));
-    }
-    builder.addToken(new BoolList(booleans));
-    return builder;
-  }
-
-  /**
-   * This visitor methods extracts the list of strings specified. It creates a token
-   * type <code>StringList</code> to be added to <code>TokenGroup</code>.
-   */
-  @Override
-  public RecipeSymbol.Builder visitStringList(DirectivesParser.StringListContext ctx) {
-    List<TerminalNode> strings = ctx.String();
-    List<String> strs = new ArrayList<>();
-    for (TerminalNode string : strings) {
-      String text = string.getText();
-      strs.add(text.substring(1, text.length() - 1));
-    }
-    builder.addToken(new TextList(strs));
-    return builder;
-  }
-
-  private SourceInfo getOriginalSource(ParserRuleContext ctx) {
-    int a = ctx.getStart().getStartIndex();
-    int b = ctx.getStop().getStopIndex();
-    Interval interval = new Interval(a, b);
-    String text = ctx.start.getInputStream().getText(interval);
-    int lineno = ctx.getStart().getLine();
-    int column = ctx.getStart().getCharPositionInLine();
-    return new SourceInfo(lineno, column, text);
-  }
-}
+ import io.cdap.wrangler.api.LazyNumber;
+ import io.cdap.wrangler.api.RecipeSymbol;
+ import io.cdap.wrangler.api.SourceInfo;
+ import io.cdap.wrangler.api.Triplet;
+ import io.cdap.wrangler.api.parser.Bool;
+ import io.cdap.wrangler.api.parser.BoolList;
+ import io.cdap.wrangler.api.parser.ColumnName;
+ import io.cdap.wrangler.api.parser.ColumnNameList;
+ import io.cdap.wrangler.api.parser.DirectiveName;
+ import io.cdap.wrangler.api.parser.Expression;
+ import io.cdap.wrangler.api.parser.Identifier;
+ import io.cdap.wrangler.api.parser.Numeric;
+ import io.cdap.wrangler.api.parser.NumericList;
+ import io.cdap.wrangler.api.parser.Properties;
+ import io.cdap.wrangler.api.parser.Ranges;
+ import io.cdap.wrangler.api.parser.Text;
+ import io.cdap.wrangler.api.parser.TextList;
+ import io.cdap.wrangler.api.parser.Token;
+ import org.antlr.v4.runtime.ParserRuleContext;
+ import org.antlr.v4.runtime.misc.Interval;
+ import org.antlr.v4.runtime.tree.ParseTree;
+ import org.antlr.v4.runtime.tree.TerminalNode;
+ 
+ import java.util.ArrayList;
+ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+ 
+ /**
+  * This class <code>RecipeVisitor</code> implements the visitor pattern
+  * used during traversal of the AST tree. The <code>ParserTree#Walker</code>
+  * invokes appropriate methods as call backs with information about the node.
+  *
+  * <p>In order to understand what's being invoked, please look at the grammar file
+  * <tt>Directive.g4</tt></p>.
+  *
+  * <p>This class exposes a <code>getTokenGroups</code> method for retrieving the
+  * <code>RecipeSymbol</code> after visiting. The <code>RecipeSymbol</code> represents
+  * all the <code>TokenGroup</code> for all directives in a recipe. Each directive
+  * will create a <code>TokenGroup</code></p>
+  *
+  * <p> As the <code>ParseTree</code> is walking through the call graph, it generates
+  * one <code>TokenGroup</code> for each directive in the recipe. Each <code>TokenGroup</code>
+  * contains parsed <code>Tokens</code> for that directive along with more information like
+  * <code>SourceInfo</code>. A collection of <code>TokenGroup</code> consistutes a <code>RecipeSymbol</code>
+  * that is returned by this function.</p>
+  */
+ 
+ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Builder> {
+   private RecipeSymbol.Builder builder = new RecipeSymbol.Builder();
+   
+ 
+   /**
+    * Returns a <code>RecipeSymbol</code> for the recipe being parsed. This
+    * object has all the tokens that were successfully parsed along with source
+    * information for each directive in the recipe.
+    *
+    * @return An compiled object after parsing the recipe.
+    */
+   public RecipeSymbol getCompiledUnit() {
+     return builder.build();
+   }
+   
+ 
+   /**
+    * A Recipe is made up of Directives and Directives is made up of each individual
+    * Directive. This method is invoked on every visit to a new directive in the recipe.
+    */
+   @Override
+   public RecipeSymbol.Builder visitDirective(DirectivesParser.DirectiveContext ctx) {
+     builder.createTokenGroup(getOriginalSource(ctx));
+     return super.visitDirective(ctx);
+   }
+ 
+   /**
+    * A Directive can include identifiers, this method extracts that token that is being
+    * identified as token of type <code>Identifier</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitIdentifier(DirectivesParser.IdentifierContext ctx) {
+     builder.addToken(new Identifier(ctx.Identifier().getText()));
+     return super.visitIdentifier(ctx);
+   }
+ 
+   /**
+    * A Directive can include properties (which are a collection of key and value pairs),
+    * this method extracts that token that is being identified as token of type <code>Properties</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitPropertyList(DirectivesParser.PropertyListContext ctx) {
+     Map<String, Token> props = new HashMap<>();
+     List<DirectivesParser.PropertyContext> properties = ctx.property();
+     for (DirectivesParser.PropertyContext property : properties) {
+       String identifier = property.Identifier().getText();
+       Token token;
+       if (property.number() != null) {
+         token = new Numeric(new LazyNumber(property.number().getText()));
+       } else if (property.bool() != null) {
+         token = new Bool(Boolean.valueOf(property.bool().getText()));
+       } else {
+         String text = property.text().getText();
+         token = new Text(text.substring(1, text.length() - 1));
+       }
+       props.put(identifier, token);
+     }
+     builder.addToken(new Properties(props));
+     return builder;
+   }
+ 
+   /**
+    * A Pragma is an instruction to the compiler to dynamically load the directives being specified
+    * from the <code>DirectiveRegistry</code>. These do not affect the data flow.
+    *
+    * <p>E.g. <code>#pragma load-directives test1, test2, test3;</code> will collect the tokens
+    * test1, test2 and test3 as dynamically loadable directives. <p>
+    */
+   @Override
+   public RecipeSymbol.Builder visitPragmaLoadDirective(DirectivesParser.PragmaLoadDirectiveContext ctx) {
+     List<TerminalNode> identifiers = ctx.identifierList().Identifier();
+     for (TerminalNode identifier : identifiers) {
+       builder.addLoadableDirective(identifier.getText());
+     }
+     return builder;
+   }
+ 
+   /**
+    * A Pragma version is a informational directive to notify compiler about the grammar that is should
+    * be using to parse the directives below.
+    */
+   @Override
+   public RecipeSymbol.Builder visitPragmaVersion(DirectivesParser.PragmaVersionContext ctx) {
+     builder.addVersion(ctx.Number().getText());
+     return builder;
+   }
+ 
+   /**
+    * A Directive can include number ranges like start:end=value[,start:end=value]*. This
+    * visitor method allows you to collect all the number ranges and create a token type
+    * <code>Ranges</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitNumberRanges(DirectivesParser.NumberRangesContext ctx) {
+     List<Triplet<Numeric, Numeric, String>> output = new ArrayList<>();
+     List<DirectivesParser.NumberRangeContext> ranges = ctx.numberRange();
+     for (DirectivesParser.NumberRangeContext range : ranges) {
+       List<TerminalNode> numbers = range.Number();
+       String text = range.value().getText();
+       if (text.startsWith("'") && text.endsWith("'")) {
+         text = text.substring(1, text.length() - 1);
+       }
+       Triplet<Numeric, Numeric, String> val =
+         new Triplet<>(new Numeric(new LazyNumber(numbers.get(0).getText())),
+                       new Numeric(new LazyNumber(numbers.get(1).getText())),
+                       text
+         );
+       output.add(val);
+     }
+     builder.addToken(new Ranges(output));
+     return builder;
+   }
+ 
+   /**
+    * This visitor method extracts the custom directive name specified. The custom
+    * directives are specified with a bang (!) at the start.
+    */
+   @Override
+   public RecipeSymbol.Builder visitEcommand(DirectivesParser.EcommandContext ctx) {
+     builder.addToken(new DirectiveName(ctx.Identifier().getText()));
+     return builder;
+   }
+ 
+   /**
+    * A Directive can consist of column specifiers. These are columns that the directive
+    * would operate on. When a token of type column is visited, it would generate a token
+    * type of type <code>ColumnName</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitColumn(DirectivesParser.ColumnContext ctx) {
+     builder.addToken(new ColumnName(ctx.Column().getText().substring(1)));
+     return builder;
+   }
+ 
+   /**
+    * A Directive can consist of text field. These type of fields are enclosed within
+    * a single-quote or a double-quote. This visitor method extracts the string value
+    * within the quotes and creates a token type <code>Text</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitText(DirectivesParser.TextContext ctx) {
+     String value = ctx.String().getText();
+     builder.addToken(new Text(value.substring(1, value.length() - 1)));
+     return builder;
+   }
+ 
+   /**
+    * A Directive can consist of numeric field. This visitor method extracts the
+    * numeric value <code>Numeric</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitNumber(DirectivesParser.NumberContext ctx) {
+     LazyNumber number = new LazyNumber(ctx.Number().getText());
+     builder.addToken(new Numeric(number));
+     return builder;
+   }
+ 
+   /**
+    * A Directive can consist of Bool field. The Bool field is represented as
+    * either true or false. This visitor method extract the bool value into a
+    * token type <code>Bool</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitBool(DirectivesParser.BoolContext ctx) {
+     builder.addToken(new Bool(Boolean.valueOf(ctx.Bool().getText())));
+     return builder;
+   }
+ 
+   /**
+    * A Directive can include a expression or a condition to be evaluated. When
+    * such a token type is found, the visitor extracts the expression and generates
+    * a token type <code>Expression</code> to be added to the <code>TokenGroup</code>
+    */
+   @Override
+   public RecipeSymbol.Builder visitCondition(DirectivesParser.ConditionContext ctx) {
+     int childCount = ctx.getChildCount();
+     StringBuilder sb = new StringBuilder();
+     for (int i = 1; i < childCount - 1; ++i) {
+       ParseTree child = ctx.getChild(i);
+       sb.append(child.getText()).append(" ");
+     }
+     builder.addToken(new Expression(sb.toString()));
+     return builder;
+   }
+ 
+   /**
+    * A Directive has name and in the parsing context it's called a command.
+    * This visitor methods extracts the command and creates a toke type <code>DirectiveName</code>
+    */
+   @Override
+   public RecipeSymbol.Builder visitCommand(DirectivesParser.CommandContext ctx) {
+     builder.addToken(new DirectiveName(ctx.Identifier().getText()));
+     return builder;
+   }
+ 
+   /**
+    * This visitor methods extracts the list of columns specified. It creates a token
+    * type <code>ColumnNameList</code> to be added to <code>TokenGroup</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitColList(DirectivesParser.ColListContext ctx) {
+     List<TerminalNode> columns = ctx.Column();
+     List<String> names = new ArrayList<>();
+     for (TerminalNode column : columns) {
+       names.add(column.getText().substring(1));
+     }
+     builder.addToken(new ColumnNameList(names));
+     return builder;
+   }
+ 
+   /**
+    * This visitor methods extracts the list of numeric specified. It creates a token
+    * type <code>NumericList</code> to be added to <code>TokenGroup</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitNumberList(DirectivesParser.NumberListContext ctx) {
+     List<TerminalNode> numbers = ctx.Number();
+     List<LazyNumber> numerics = new ArrayList<>();
+     for (TerminalNode number : numbers) {
+       numerics.add(new LazyNumber(number.getText()));
+     }
+     builder.addToken(new NumericList(numerics));
+     return builder;
+   }
+ 
+   /**
+    * This visitor methods extracts the list of booleans specified. It creates a token
+    * type <code>BoolList</code> to be added to <code>TokenGroup</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitBoolList(DirectivesParser.BoolListContext ctx) {
+     List<TerminalNode> bools = ctx.Bool();
+     List<Boolean> booleans = new ArrayList<>();
+     for (TerminalNode bool : bools) {
+       booleans.add(Boolean.parseBoolean(bool.getText()));
+     }
+     builder.addToken(new BoolList(booleans));
+     return builder;
+   }
+ 
+   /**
+    * This visitor methods extracts the list of strings specified. It creates a token
+    * type <code>StringList</code> to be added to <code>TokenGroup</code>.
+    */
+   @Override
+   public RecipeSymbol.Builder visitStringList(DirectivesParser.StringListContext ctx) {
+     List<TerminalNode> strings = ctx.String();
+     List<String> strs = new ArrayList<>();
+     for (TerminalNode string : strings) {
+       String text = string.getText();
+       strs.add(text.substring(1, text.length() - 1));
+     }
+     builder.addToken(new TextList(strs));
+     return builder;
+   }
+ 
+   private SourceInfo getOriginalSource(ParserRuleContext ctx) {
+     int a = ctx.getStart().getStartIndex();
+     int b = ctx.getStop().getStopIndex();
+     Interval interval = new Interval(a, b);
+     String text = ctx.start.getInputStream().getText(interval);
+     int lineno = ctx.getStart().getLine();
+     int column = ctx.getStart().getCharPositionInLine();
+     return new SourceInfo(lineno, column, text);
+   }
+ };


### PR DESCRIPTION
Features Implemented:
🔹 New Utility Classes
ByteSize: Parses and converts data size values like "10KB", "2.5MB", etc. into canonical bytes.

TimeDuration: Parses and converts time values like "5s", "120ms", etc. into canonical nanoseconds.

🔹 New Directive: aggregate-stats
Aggregates data size and time duration across multiple rows.

Supports aggregation types: total (default) and average.

Converts the final result into user-defined units (MB, GB, seconds, minutes, etc.).

Accepts the following arguments:

Input byte column

Input time column

Output byte column

Output time column

(Optional) Unit for bytes

(Optional) Unit for time

(Optional) Aggregation type (total or average)

🔹 Parser Enhancements
Added new grammar rules to support byte size and time duration formats in recipe parsing.

Added visit methods:

visitByteSizeArg(ctx)

visitTimeDurationArg(ctx)

Modified visitValue() to support new types.

Registered new token types to the TokenGroup.