### PR TITLE
feat(parser): add ByteSize and TimeDuration token types

### DIFF
--- a/prompt.txt
+++ b/prompt.txt
@@ -1,0 +1,9 @@
+How do I add a new token type to CDAP Wrangler's parser?"
+
+"How to regenerate ANTLR parser/lexer files after updating grammar in a Maven project?"
+
+"How do I verify that new tokens are parsed correctly in CDAP Wrangler?"
+
+"How to test ANTLR grammar changes in a Java Maven project?"
+
+"How to run Wrangler build with only wrangler-core after fixing code?"

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ package io.cdap.wrangler.api.parser;
+
+ import com.google.gson.JsonElement;
+ import com.google.gson.JsonObject;
+ import io.cdap.wrangler.api.annotations.PublicEvolving;
+ 
+ import java.io.Serializable;
+ import java.util.regex.Matcher;
+ import java.util.regex.Pattern;
+ 
+ /**
+  * Represents a byte size value with support for different units (B, KB, MB, GB, TB, PB).
+  */
+ @PublicEvolving
+ public class ByteSize implements Token, Serializable {
+   private static final Pattern PATTERN = Pattern.compile("(\\d+(?:\\.\\d+)?)\\s*([BKMGTP]B)");
+   private static final long[] MULTIPLIERS = {
+     1L,                    // B
+     1024L,                 // KB
+     1024L * 1024L,         // MB
+     1024L * 1024L * 1024L, // GB
+     1024L * 1024L * 1024L * 1024L, // TB
+     1024L * 1024L * 1024L * 1024L * 1024L  // PB
+   };
+ 
+   private final long bytes;
+   private final String original;
+ 
+   /**
+    * Creates a ByteSize instance from a string representation.
+    * @param value The string representation of the byte size (e.g., "10KB", "1.5MB")
+    * @throws IllegalArgumentException if the string cannot be parsed
+    */
+   public ByteSize(String value) {
+     this.original = value;
+     Matcher matcher = PATTERN.matcher(value);
+     if (!matcher.matches()) {
+       throw new IllegalArgumentException("Invalid byte size format: " + value);
+     }
+ 
+     double number = Double.parseDouble(matcher.group(1));
+     String unit = matcher.group(2);
+     int unitIndex = getUnitIndex(unit);
+     this.bytes = (long) (number * MULTIPLIERS[unitIndex]);
+   }
+ 
+   private int getUnitIndex(String unit) {
+     switch (unit) {
+       case "B": return 0;
+       case "KB": return 1;
+       case "MB": return 2;
+       case "GB": return 3;
+       case "TB": return 4;
+       case "PB": return 5;
+       default:
+         throw new IllegalArgumentException("Invalid unit: " + unit);
+     }
+   }
+ 
+   /**
+    * Returns the size in bytes.
+    * @return The size in bytes
+    */
+   public long getBytes() {
+     return bytes;
+   }
+ 
+   @Override
+   public Object value() {
+     return bytes;
+   }
+ 
+   @Override
+   public TokenType type() {
+     return TokenType.BYTE_SIZE;
+   }
+ 
+   @Override
+   public JsonElement toJson() {
+     JsonObject object = new JsonObject();
+     object.addProperty("bytes", bytes);
+     object.addProperty("original", original);
+     return object;
+   }
+ 
+   @Override
+   public String toString() {
+     return original;
+   }
+ }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ package io.cdap.wrangler.api.parser;
+
+ import com.google.gson.JsonElement;
+ import com.google.gson.JsonObject;
+ import io.cdap.wrangler.api.annotations.PublicEvolving;
+ 
+ import java.io.Serializable;
+ import java.util.regex.Matcher;
+ import java.util.regex.Pattern;
+ 
+ /**
+  * Represents a time duration value with support for different units (ns, ms, s, m, h, d).
+  */
+ @PublicEvolving
+ public class TimeDuration implements Token, Serializable {
+   private static final Pattern PATTERN = Pattern.compile("(\\d+(?:\\.\\d+)?)\\s*([nmshd])s?");
+   private static final long[] MULTIPLIERS = {
+     1L,                    // ns
+     1000L,                 // ms
+     1000L * 1000L,         // s
+     1000L * 1000L * 60L,   // m
+     1000L * 1000L * 60L * 60L, // h
+     1000L * 1000L * 60L * 60L * 24L  // d
+   };
+ 
+   private final long nanoseconds;
+   private final String original;
+ 
+   /**
+    * Creates a TimeDuration instance from a string representation.
+    * @param value The string representation of the time duration (e.g., "100ms", "2.5s")
+    * @throws IllegalArgumentException if the string cannot be parsed
+    */
+   public TimeDuration(String value) {
+     this.original = value;
+     Matcher matcher = PATTERN.matcher(value);
+     if (!matcher.matches()) {
+       throw new IllegalArgumentException("Invalid time duration format: " + value);
+     }
+ 
+     double number = Double.parseDouble(matcher.group(1));
+     String unit = matcher.group(2);
+     int unitIndex = getUnitIndex(unit);
+     this.nanoseconds = (long) (number * MULTIPLIERS[unitIndex]);
+   }
+ 
+   private int getUnitIndex(String unit) {
+     switch (unit) {
+       case "n": return 0;
+       case "m": return 1;
+       case "s": return 2;
+       case "h": return 3;
+       case "d": return 4;
+       default:
+         throw new IllegalArgumentException("Invalid unit: " + unit);
+     }
+   }
+ 
+   /**
+    * Returns the duration in nanoseconds.
+    * @return The duration in nanoseconds
+    */
+   public long getNanoseconds() {
+     return nanoseconds;
+   }
+ 
+   @Override
+   public Object value() {
+     return nanoseconds;
+   }
+ 
+   @Override
+   public TokenType type() {
+     return TokenType.TIME_DURATION;
+   }
+ 
+   @Override
+   public JsonElement toJson() {
+     JsonObject object = new JsonObject();
+     object.addProperty("nanoseconds", nanoseconds);
+     object.addProperty("original", original);
+     return object;
+   }
+ 
+   @Override
+   public String toString() {
+     return original;
+   }
+ }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -14,143 +14,158 @@
  * the License.
  */
 
-package io.cdap.wrangler.api.parser;
+ package io.cdap.wrangler.api.parser;
 
-import io.cdap.wrangler.api.annotations.PublicEvolving;
-
-import java.io.Serializable;
-
-/**
- * The TokenType class provides the enumerated types for different types of
- * tokens that are supported by the grammar.
- *
- * Each of the enumerated types specified in this class also has associated
- * object representing it. e.g. {@code DIRECTIVE_NAME} is represented by the
- * object {@code DirectiveName}.
- *
- * @see Bool
- * @see BoolList
- * @see ColumnName
- * @see ColumnNameList
- * @see DirectiveName
- * @see Numeric
- * @see NumericList
- * @see Properties
- * @see Ranges
- * @see Expression
- * @see Text
- * @see TextList
- */
-@PublicEvolving
-public enum TokenType implements Serializable {
-  /**
-   * Represents the enumerated type for the object {@code DirectiveName} type.
-   * This type is associated with the token that is recognized as a directive
-   * name within the recipe.
-   */
-  DIRECTIVE_NAME,
-
-  /**
-   * Represents the enumerated type for the object of {@code ColumnName} type.
-   * This type is associated with token that represents the column as defined
-   * by the grammar as :<column-name>.
-   */
-  COLUMN_NAME,
-
-  /**
-   * Represents the enumerated type for the object of {@code Text} type.
-   * This type is associated with the token that is either enclosed within a single quote(')
-   * or a double quote (") as string.
-   */
-  TEXT,
-
-  /**
-   * Represents the enumerated type for the object of {@code Numeric} type.
-   * This type is associated with the token that is either a integer or real number.
-   */
-  NUMERIC,
-
-  /**
-   * Represents the enumerated type for the object of {@code Bool} type.
-   * This type is associated with the token that either represents string 'true' or 'false'.
-   */
-  BOOLEAN,
-
-  /**
-   * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the rule that is a collection of {@code Boolean} values
-   * separated by comman(,). E.g.
-   * <code>
-   *   ColumnName[,ColumnName]*
-   * </code>
-   */
-  COLUMN_NAME_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code TextList} type.
-   * This type is associated with the comma separated text represented were each text
-   * is enclosed within a single quote (') or double quote (") and each text is separated
-   * by comma (,). E.g.
-   * <code>
-   *   Text[,Text]*
-   * </code>
-   */
-  TEXT_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code NumericList} type.
-   * This type is associated with the collection of {@code Numeric} values separated by
-   * comma(,). E.g.
-   * <code>
-   *   Numeric[,Numeric]*
-   * </code>
-   *
-   */
-  NUMERIC_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the collection of {@code Bool} values separated by
-   * comma(,). E.g.
-   * <code>
-   *   Boolean[,Boolean]*
-   * </code>
-   */
-  BOOLEAN_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code Expression} type.
-   * This type is associated with code block that either represents a condition or
-   * an expression. E.g.
-   * <code>
-   *   exp:{ <expression || condition> }
-   * </code>
-   */
-  EXPRESSION,
-
-  /**
-   * Represents the enumerated type for the object of type {@code Properties} type.
-   * This type is associated with a collection of key and value pairs all separated
-   * by a comma(,). E.g.
-   * <code>
-   *   prop:{ <key>=<value>[,<key>=<value>]*}
-   * </code>
-   */
-  PROPERTIES,
-
-  /**
-   * Represents the enumerated type for the object of type {@code Ranges} types.
-   * This type is associated with a collection of range represented in the form shown
-   * below
-   * <code>
-   *   <start>:<end>=value[,<start>:<end>=value]*
-   * </code>
-   */
-  RANGES,
-
-  /**
-   * Represents the enumerated type for the object of type {@code String} with restrictions
-   * on characters that can be present in a string.
-   */
-  IDENTIFIER
-}
+ import io.cdap.wrangler.api.annotations.PublicEvolving;
+ 
+ import java.io.Serializable;
+ 
+ /**
+  * The TokenType class provides the enumerated types for different types of
+  * tokens that are supported by the grammar.
+  *
+  * Each of the enumerated types specified in this class also has associated
+  * object representing it. e.g. {@code DIRECTIVE_NAME} is represented by the
+  * object {@code DirectiveName}.
+  *
+  * @see Bool
+  * @see BoolList
+  * @see ColumnName
+  * @see ColumnNameList
+  * @see DirectiveName
+  * @see Numeric
+  * @see NumericList
+  * @see Properties
+  * @see Ranges
+  * @see Expression
+  * @see Text
+  * @see TextList
+  * @see ByteSize
+  * @see TimeDuration
+  */
+ @PublicEvolving
+ public enum TokenType implements Serializable {
+   /**
+    * Represents the enumerated type for the object {@code DirectiveName} type.
+    * This type is associated with the token that is recognized as a directive
+    * name within the recipe.
+    */
+   DIRECTIVE_NAME,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code ColumnName} type.
+    * This type is associated with token that represents the column as defined
+    * by the grammar as :<column-name>.
+    */
+   COLUMN_NAME,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code Text} type.
+    * This type is associated with the token that is either enclosed within a single quote(')
+    * or a double quote (") as string.
+    */
+   TEXT,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code Numeric} type.
+    * This type is associated with the token that is either a integer or real number.
+    */
+   NUMERIC,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code Bool} type.
+    * This type is associated with the token that either represents string 'true' or 'false'.
+    */
+   BOOLEAN,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code BoolList} type.
+    * This type is associated with the rule that is a collection of {@code Boolean} values
+    * separated by comman(,). E.g.
+    * <code>
+    *   ColumnName[,ColumnName]*
+    * </code>
+    */
+   COLUMN_NAME_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code TextList} type.
+    * This type is associated with the comma separated text represented were each text
+    * is enclosed within a single quote (') or double quote (") and each text is separated
+    * by comma (,). E.g.
+    * <code>
+    *   Text[,Text]*
+    * </code>
+    */
+   TEXT_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code NumericList} type.
+    * This type is associated with the collection of {@code Numeric} values separated by
+    * comma(,). E.g.
+    * <code>
+    *   Numeric[,Numeric]*
+    * </code>
+    *
+    */
+   NUMERIC_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code BoolList} type.
+    * This type is associated with the collection of {@code Bool} values separated by
+    * comma(,). E.g.
+    * <code>
+    *   Boolean[,Boolean]*
+    * </code>
+    */
+   BOOLEAN_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code Expression} type.
+    * This type is associated with code block that either represents a condition or
+    * an expression. E.g.
+    * <code>
+    *   exp:{ <expression || condition> }
+    * </code>
+    */
+   EXPRESSION,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code Properties} type.
+    * This type is associated with a collection of key and value pairs all separated
+    * by a comma(,). E.g.
+    * <code>
+    *   prop:{ <key>=<value>[,<key>=<value>]*}
+    * </code>
+    */
+   PROPERTIES,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code Ranges} types.
+    * This type is associated with a collection of range represented in the form shown
+    * below
+    * <code>
+    *   <start>:<end>=value[,<start>:<end>=value]*
+    * </code>
+    */
+   RANGES,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code String} with restrictions
+    * on characters that can be present in a string.
+    */
+   IDENTIFIER,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code ByteSize}.
+    * This type is associated with byte size values like "10KB", "1.5MB", etc.
+    */
+   BYTE_SIZE,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code TimeDuration}.
+    * This type is associated with time duration values like "100ms", "2.5s", etc.
+    */
+   TIME_DURATION
+ }
+ 

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -8,8 +8,8 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
  */
@@ -31,8 +31,8 @@ options {
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
  */
@@ -64,6 +64,8 @@ directive
     | stringList
     | numberRanges
     | properties
+    | byteSizeArg
+    | timeDurationArg
   )*?
   ;
 
@@ -140,7 +142,20 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String
+ | Number
+ | Column
+ | Bool
+ | BYTE_SIZE
+ | TIME_DURATION
+ ;
+
+byteSizeArg
+ : BYTE_SIZE
+ ;
+
+timeDurationArg
+ : TIME_DURATION
  ;
 
 ecommand
@@ -257,6 +272,32 @@ Number
  : Int ('.' Digit*)?
  ;
 
+BYTE_SIZE
+ : DECIMAL BYTE_UNIT
+ ;
+
+fragment BYTE_UNIT
+ : 'B'
+ | 'KB'
+ | 'MB'
+ | 'GB'
+ | 'TB'
+ | 'PB'
+ ;
+
+TIME_DURATION
+ : DECIMAL TIME_UNIT
+ ;
+
+fragment TIME_UNIT
+ : 'ns'
+ | 'ms'
+ | 's'
+ | 'm'
+ | 'h'
+ | 'd'
+ ;
+
 Identifier
  : [a-zA-Z_\-] [a-zA-Z_0-9\-]*
  ;
@@ -311,3 +352,9 @@ fragment Int
 fragment Digit
  : [0-9]
  ;
+
+// Byte size and time duration fragments and rules
+fragment BYTE_UNIT : ('B'|'KB'|'MB'|'GB'|'TB'|'PB');
+fragment TIME_UNIT : ('ns'|'ms'|'s'|'m'|'h'|'d');
+fragment DIGIT : [0-9];
+fragment DECIMAL : DIGIT+ ('.' DIGIT+)?;

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/SizeTimeAggregator.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/SizeTimeAggregator.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ package io.cdap.directives.aggregates;
+
+ import com.google.common.collect.ImmutableList;
+ import io.cdap.cdap.api.annotation.Description;
+ import io.cdap.cdap.api.annotation.Name;
+ import io.cdap.cdap.api.annotation.Plugin;
+ import io.cdap.wrangler.api.Arguments;
+ import io.cdap.wrangler.api.Directive;
+ import io.cdap.wrangler.api.DirectiveExecutionException;
+ import io.cdap.wrangler.api.DirectiveParseException;
+ import io.cdap.wrangler.api.ExecutorContext;
+ import io.cdap.wrangler.api.Optional;
+ import io.cdap.wrangler.api.Row;
+ import io.cdap.wrangler.api.annotations.Categories;
+ import io.cdap.wrangler.api.lineage.Lineage;
+ import io.cdap.wrangler.api.lineage.Mutation;
+ import io.cdap.wrangler.api.parser.ColumnName;
+ import io.cdap.wrangler.api.parser.Text;
+ import io.cdap.wrangler.api.parser.TokenType;
+ import io.cdap.wrangler.api.parser.UsageDefinition;
+ import io.cdap.wrangler.expression.EL;
+ import io.cdap.wrangler.expression.ELContext;
+ import io.cdap.wrangler.expression.ELException;
+ import io.cdap.wrangler.expression.ELResult;
+ 
+ import java.util.List;
+ import java.util.concurrent.atomic.AtomicLong;
+ 
+ /**
+  * A directive for aggregating size and time values across rows.
+  */
+ @Plugin(type = Directive.TYPE)
+ @Name("size-time-aggregator")
+ @Categories(categories = { "aggregates" })
+ @Description("Aggregates size and time values across rows, with optional unit conversion")
+ public class SizeTimeAggregator implements Directive, Lineage {
+   public static final String NAME = "size-time-aggregator";
+   private String sizeColumn;
+   private String timeColumn;
+   private String targetSizeColumn;
+   private String targetTimeColumn;
+   private String sizeUnit = "B";  // Default to bytes
+   private String timeUnit = "ns"; // Default to nanoseconds
+   private String aggregationType = "total"; // Default to total
+ 
+   @Override
+   public UsageDefinition define() {
+     UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+     builder.define("size-column", TokenType.COLUMN_NAME);
+     builder.define("time-column", TokenType.COLUMN_NAME);
+     builder.define("target-size-column", TokenType.COLUMN_NAME);
+     builder.define("target-time-column", TokenType.COLUMN_NAME);
+     builder.define("size-unit", TokenType.TEXT, Optional.TRUE);
+     builder.define("time-unit", TokenType.TEXT, Optional.TRUE);
+     builder.define("aggregation-type", TokenType.TEXT, Optional.TRUE);
+     return builder.build();
+   }
+ 
+   @Override
+   public void initialize(Arguments args) throws DirectiveParseException {
+     this.sizeColumn = ((ColumnName) args.value("size-column")).value();
+     this.timeColumn = ((ColumnName) args.value("time-column")).value();
+     this.targetSizeColumn = ((ColumnName) args.value("target-size-column")).value();
+     this.targetTimeColumn = ((ColumnName) args.value("target-time-column")).value();
+ 
+     if (args.contains("size-unit")) {
+       this.sizeUnit = ((Text) args.value("size-unit")).value();
+     }
+     if (args.contains("time-unit")) {
+       this.timeUnit = ((Text) args.value("time-unit")).value();
+     }
+     if (args.contains("aggregation-type")) {
+       this.aggregationType = ((Text) args.value("aggregation-type")).value();
+     }
+   }
+ 
+   @Override
+   public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
+     AtomicLong totalBytes = new AtomicLong(0);
+     AtomicLong totalNanos = new AtomicLong(0);
+     AtomicLong count = new AtomicLong(0);
+ 
+     // Accumulate totals
+     rows.forEach(row -> {
+       Object sizeValue = row.getValue(row.find(sizeColumn));
+       Object timeValue = row.getValue(row.find(timeColumn));
+ 
+       // Convert size to bytes
+       if (sizeValue instanceof String) {
+         String sizeStr = (String) sizeValue;
+         if (sizeStr.endsWith("B")) {
+           totalBytes.addAndGet(parseByteSize(sizeStr));
+         } else {
+           totalBytes.addAndGet(Long.parseLong(sizeStr));
+         }
+       } else if (sizeValue instanceof Number) {
+         totalBytes.addAndGet(((Number) sizeValue).longValue());
+       }
+ 
+       // Convert time to nanoseconds
+       if (timeValue instanceof String) {
+         String timeStr = (String) timeValue;
+         totalNanos.addAndGet(parseTimeDuration(timeStr));
+       } else if (timeValue instanceof Number) {
+         totalNanos.addAndGet(((Number) timeValue).longValue());
+       }
+ 
+       count.incrementAndGet();
+     });
+ 
+     // Convert to target units
+     double finalSize = convertBytes(totalBytes.get(), sizeUnit);
+     double finalTime = convertNanos(totalNanos.get(), timeUnit);
+ 
+     // Apply aggregation type
+     if ("average".equalsIgnoreCase(aggregationType)) {
+       finalSize = finalSize / count.get();
+       finalTime = finalTime / count.get();
+     }
+ 
+     // Return single row with results
+     Row result = new Row();
+     result.add(targetSizeColumn, finalSize);
+     result.add(targetTimeColumn, finalTime);
+     return ImmutableList.of(result);
+   }
+ 
+   private long parseByteSize(String size) {
+     size = size.trim().toUpperCase();
+     long multiplier = 1;
+     if (size.endsWith("KB")) {
+       multiplier = 1024;
+       size = size.substring(0, size.length() - 2);
+     } else if (size.endsWith("MB")) {
+       multiplier = 1024 * 1024;
+       size = size.substring(0, size.length() - 2);
+     } else if (size.endsWith("GB")) {
+       multiplier = 1024 * 1024 * 1024;
+       size = size.substring(0, size.length() - 2);
+     } else if (size.endsWith("TB")) {
+       multiplier = 1024L * 1024 * 1024 * 1024;
+       size = size.substring(0, size.length() - 2);
+     } else if (size.endsWith("PB")) {
+       multiplier = 1024L * 1024 * 1024 * 1024 * 1024;
+       size = size.substring(0, size.length() - 2);
+     } else if (size.endsWith("B")) {
+       size = size.substring(0, size.length() - 1);
+     }
+     return Long.parseLong(size) * multiplier;
+   }
+ 
+   private long parseTimeDuration(String duration) {
+     duration = duration.trim().toLowerCase();
+     long multiplier = 1;
+     if (duration.endsWith("ns")) {
+       multiplier = 1;
+       duration = duration.substring(0, duration.length() - 2);
+     } else if (duration.endsWith("ms")) {
+       multiplier = 1_000_000;
+       duration = duration.substring(0, duration.length() - 2);
+     } else if (duration.endsWith("s")) {
+       multiplier = 1_000_000_000;
+       duration = duration.substring(0, duration.length() - 1);
+     } else if (duration.endsWith("m")) {
+       multiplier = 60L * 1_000_000_000;
+       duration = duration.substring(0, duration.length() - 1);
+     } else if (duration.endsWith("h")) {
+       multiplier = 60L * 60 * 1_000_000_000;
+       duration = duration.substring(0, duration.length() - 1);
+     } else if (duration.endsWith("d")) {
+       multiplier = 24L * 60 * 60 * 1_000_000_000;
+       duration = duration.substring(0, duration.length() - 1);
+     }
+     return Long.parseLong(duration) * multiplier;
+   }
+ 
+   private double convertBytes(long bytes, String unit) throws DirectiveExecutionException {
+     switch (unit.toUpperCase()) {
+       case "B": return bytes;
+       case "KB": return bytes / 1024.0;
+       case "MB": return bytes / (1024.0 * 1024);
+       case "GB": return bytes / (1024.0 * 1024 * 1024);
+       case "TB": return bytes / (1024.0 * 1024 * 1024 * 1024);
+       case "PB": return bytes / (1024.0 * 1024 * 1024 * 1024 * 1024);
+       default: throw new DirectiveExecutionException("Invalid size unit: " + unit);
+     }
+   }
+ 
+   private double convertNanos(long nanos, String unit) throws DirectiveExecutionException {
+     switch (unit.toLowerCase()) {
+       case "ns": return nanos;
+       case "ms": return nanos / 1_000_000.0;
+       case "s": return nanos / 1_000_000_000.0;
+       case "m": return nanos / (60.0 * 1_000_000_000);
+       case "h": return nanos / (60.0 * 60 * 1_000_000_000);
+       case "d": return nanos / (24.0 * 60 * 60 * 1_000_000_000);
+       default: throw new DirectiveExecutionException("Invalid time unit: " + unit);
+     }
+   }
+ 
+   @Override
+   public void destroy() {
+     // no-op
+   }
+ 
+   @Override
+   public Mutation lineage() {
+     return Mutation.builder()
+       .readable("Aggregated size and time values from columns '%s' and '%s'", sizeColumn, timeColumn)
+       .relation(sizeColumn, targetSizeColumn)
+       .relation(timeColumn, targetTimeColumn)
+       .build();
+   }
+ } 

--- a/wrangler-core/src/main/java/io/cdap/wrangler/directives/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/directives/AggregateStats.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ package io.cdap.wrangler.directives;
+
+ import io.cdap.wrangler.api.Arguments;
+ import io.cdap.wrangler.api.Directive;
+ import io.cdap.wrangler.api.DirectiveExecutionException;
+ import io.cdap.wrangler.api.DirectiveParseException;
+ import io.cdap.wrangler.api.ExecutorContext;
+ import io.cdap.wrangler.api.Row;
+ import io.cdap.wrangler.api.annotations.PublicEvolving;
+ import io.cdap.wrangler.api.parser.ByteSize;
+ import io.cdap.wrangler.api.parser.ColumnName;
+ import io.cdap.wrangler.api.parser.Text;
+ import io.cdap.wrangler.api.parser.TimeDuration;
+ import io.cdap.wrangler.api.parser.TokenType;
+ import io.cdap.wrangler.api.parser.UsageDefinition;
+ 
+ import java.util.Collections;
+ import java.util.List;
+ 
+ /**
+  * A directive that aggregates byte sizes and time durations from source columns
+  * into target columns.
+  */
+ @PublicEvolving
+ public class AggregateStats implements Directive {
+   private String sizeColumn;
+   private String timeColumn;
+   private String targetSizeColumn;
+   private String targetTimeColumn;
+   private String sizeUnit = "MB";
+   private String timeUnit = "s";
+   private String aggregationType = "total";
+ 
+   @Override
+   public UsageDefinition define() {
+     UsageDefinition.Builder builder = UsageDefinition.builder("aggregate-stats");
+     builder.define("size-column", TokenType.COLUMN_NAME);
+     builder.define("time-column", TokenType.COLUMN_NAME);
+     builder.define("target-size-column", TokenType.COLUMN_NAME);
+     builder.define("target-time-column", TokenType.COLUMN_NAME);
+     builder.define("size-unit", TokenType.TEXT, true);
+     builder.define("time-unit", TokenType.TEXT, true);
+     builder.define("aggregation-type", TokenType.TEXT, true);
+     return builder.build();
+   }
+ 
+   @Override
+   public void initialize(Arguments args) throws DirectiveParseException {
+     this.sizeColumn = ((ColumnName) args.value("size-column")).value();
+     this.timeColumn = ((ColumnName) args.value("time-column")).value();
+     this.targetSizeColumn = ((ColumnName) args.value("target-size-column")).value();
+     this.targetTimeColumn = ((ColumnName) args.value("target-time-column")).value();
+     
+     if (args.contains("size-unit")) {
+       this.sizeUnit = ((Text) args.value("size-unit")).value();
+     }
+     if (args.contains("time-unit")) {
+       this.timeUnit = ((Text) args.value("time-unit")).value();
+     }
+     if (args.contains("aggregation-type")) {
+       this.aggregationType = ((Text) args.value("aggregation-type")).value();
+     }
+   }
+ 
+   @Override
+   public void destroy() {
+     // No cleanup needed
+   }
+ 
+   @Override
+   public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
+     long totalBytes = 0;
+     long totalNanos = 0;
+     int count = 0;
+ 
+     for (Row row : rows) {
+       int sizeIdx = row.find(sizeColumn);
+       int timeIdx = row.find(timeColumn);
+ 
+       if (sizeIdx == -1) {
+         throw new DirectiveExecutionException(
+           String.format("Column '%s' not found in row", sizeColumn));
+       }
+       if (timeIdx == -1) {
+         throw new DirectiveExecutionException(
+           String.format("Column '%s' not found in row", timeColumn));
+       }
+ 
+       Object sizeValue = row.getValue(sizeIdx);
+       Object timeValue = row.getValue(timeIdx);
+ 
+       if (sizeValue instanceof ByteSize) {
+         totalBytes += ((ByteSize) sizeValue).getBytes();
+       } else if (sizeValue instanceof String) {
+         totalBytes += new ByteSize((String) sizeValue).getBytes();
+       } else {
+         throw new DirectiveExecutionException(
+           String.format("Column '%s' must contain byte size values", sizeColumn));
+       }
+ 
+       if (timeValue instanceof TimeDuration) {
+         totalNanos += ((TimeDuration) timeValue).getNanoseconds();
+       } else if (timeValue instanceof String) {
+         totalNanos += new TimeDuration((String) timeValue).getNanoseconds();
+       } else {
+         throw new DirectiveExecutionException(
+           String.format("Column '%s' must contain time duration values", timeColumn));
+       }
+ 
+       count++;
+     }
+ 
+     // Convert to target units
+     double finalSize = convertBytes(totalBytes, sizeUnit);
+     double finalTime = convertNanos(totalNanos, timeUnit);
+ 
+     // Apply aggregation type
+     if ("average".equalsIgnoreCase(aggregationType)) {
+       finalSize = finalSize / count;
+       finalTime = finalTime / count;
+     }
+ 
+     // Create result row
+     Row result = new Row();
+     result.add(targetSizeColumn, finalSize);
+     result.add(targetTimeColumn, finalTime);
+ 
+     return Collections.singletonList(result);
+   }
+ 
+   private double convertBytes(long bytes, String unit) throws DirectiveExecutionException {
+     switch (unit.toUpperCase()) {
+       case "B":
+         return bytes;
+       case "KB":
+         return bytes / 1024.0;
+       case "MB":
+         return bytes / (1024.0 * 1024);
+       case "GB":
+         return bytes / (1024.0 * 1024 * 1024);
+       case "TB":
+         return bytes / (1024.0 * 1024 * 1024 * 1024);
+       case "PB":
+         return bytes / (1024.0 * 1024 * 1024 * 1024 * 1024);
+       default:
+         throw new DirectiveExecutionException("Invalid size unit: " + unit);
+     }
+   }
+ 
+   private double convertNanos(long nanos, String unit) throws DirectiveExecutionException {
+     switch (unit.toLowerCase()) {
+       case "ns":
+         return nanos;
+       case "ms":
+         return nanos / 1_000_000.0;
+       case "s":
+         return nanos / 1_000_000_000.0;
+       case "m":
+         return nanos / (60.0 * 1_000_000_000);
+       case "h":
+         return nanos / (60.0 * 60 * 1_000_000_000);
+       case "d":
+         return nanos / (24.0 * 60 * 60 * 1_000_000_000);
+       default:
+         throw new DirectiveExecutionException("Invalid time unit: " + unit);
+     }
+   }
+ } 

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/DirectiveClass.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/DirectiveClass.java
@@ -14,54 +14,77 @@
  * the License.
  */
 
-package io.cdap.wrangler.parser;
+ package io.cdap.wrangler.parser;
 
-import io.cdap.cdap.api.artifact.ArtifactId;
-import io.cdap.wrangler.registry.DirectiveScope;
-
-import javax.annotation.Nullable;
-
-/**
- * This class carries the class information about a directive.
- */
-public class DirectiveClass {
-
-  private final String name;
-  private final DirectiveScope scope;
-  private final ArtifactId artifactId;
-  private final String className;
-
-  public DirectiveClass(String name, String className, DirectiveScope scope, @Nullable ArtifactId artifactId) {
-    this.name = name;
-    this.className = className;
-    this.scope = scope;
-    this.artifactId = artifactId;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public String getClassName() {
-    return className;
-  }
-
-  public DirectiveScope getScope() {
-    return scope;
-  }
-
-  @Nullable
-  public ArtifactId getArtifactId() {
-    return artifactId;
-  }
-
-  @Override
-  public String toString() {
-    return "DirectiveClass{" +
-      "name='" + name + '\'' +
-      ", scope=" + scope +
-      ", artifactId=" + artifactId +
-      ", className='" + className + '\'' +
-      '}';
-  }
-}
+ import io.cdap.cdap.api.artifact.ArtifactId;
+ import io.cdap.wrangler.registry.DirectiveScope;
+ 
+ import javax.annotation.Nullable;
+ 
+ /**
+  * This class carries the class information about a directive.
+  */
+ public class DirectiveClass {
+ 
+   private final String name;
+   private final DirectiveScope scope;
+   private final ArtifactId artifactId;
+   private final String className;
+ 
+   // New fields for byte size and time duration
+   private final String byteSizeArg; // e.g., "10KB"
+   private final String timeDurationArg; // e.g., "150ms"
+ 
+   public DirectiveClass(String name, String className, DirectiveScope scope,
+       @Nullable ArtifactId artifactId,
+       @Nullable String byteSizeArg,
+       @Nullable String timeDurationArg) {
+     this.name = name;
+     this.className = className;
+     this.scope = scope;
+     this.artifactId = artifactId;
+     this.byteSizeArg = byteSizeArg;
+     this.timeDurationArg = timeDurationArg;
+   }
+ 
+   public String getName() {
+     return name;
+   }
+ 
+   public String getClassName() {
+     return className;
+   }
+ 
+   public DirectiveScope getScope() {
+     return scope;
+   }
+ 
+   @Nullable
+   public ArtifactId getArtifactId() {
+     return artifactId;
+   }
+ 
+   // New getter for byte size argument
+   @Nullable
+   public String getByteSizeArg() {
+     return byteSizeArg;
+   }
+ 
+   // New getter for time duration argument
+   @Nullable
+   public String getTimeDurationArg() {
+     return timeDurationArg;
+   }
+ 
+   @Override
+   public String toString() {
+     return "DirectiveClass{" +
+         "name='" + name + '\'' +
+         ", scope=" + scope +
+         ", artifactId=" + artifactId +
+         ", className='" + className + '\'' +
+         ", byteSizeArg='" + byteSizeArg + '\'' +
+         ", timeDurationArg='" + timeDurationArg + '\'' +
+         '}';
+   }
+ }

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/SizeTimeAggregatorTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/SizeTimeAggregatorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ package io.cdap.directives.aggregates;
+
+ import io.cdap.wrangler.api.Row;
+ import io.cdap.wrangler.api.parser.ColumnName;
+ import io.cdap.wrangler.api.parser.Text;
+ import io.cdap.wrangler.api.parser.TokenType;
+ import io.cdap.wrangler.api.parser.UsageDefinition;
+ import io.cdap.wrangler.parser.MapArguments;
+ import io.cdap.wrangler.api.TokenGroup;
+ import io.cdap.wrangler.api.SourceInfo;
+ import org.junit.Assert;
+ import org.junit.Test;
+ 
+ import java.util.Arrays;
+ import java.util.List;
+ 
+ public class SizeTimeAggregatorTest {
+ 
+   @Test
+   public void testTotalAggregation() throws Exception {
+     List<Row> rows = Arrays.asList(
+       createRow("1MB", "100ms"),
+       createRow("2MB", "200ms"),
+       createRow("3MB", "300ms")
+     );
+ 
+     SizeTimeAggregator directive = new SizeTimeAggregator();
+     
+     // Create UsageDefinition
+     UsageDefinition.Builder builder = UsageDefinition.builder("size-time-aggregator");
+     builder.define("size-column", TokenType.COLUMN_NAME);
+     builder.define("time-column", TokenType.COLUMN_NAME);
+     builder.define("target-size-column", TokenType.COLUMN_NAME);
+     builder.define("target-time-column", TokenType.COLUMN_NAME);
+     
+     // Create TokenGroup
+     TokenGroup tokenGroup = new TokenGroup(new SourceInfo(1, 1, "test"));
+     tokenGroup.add(new ColumnName("size"));
+     tokenGroup.add(new ColumnName("time"));
+     tokenGroup.add(new ColumnName("total_size"));
+     tokenGroup.add(new ColumnName("total_time"));
+     
+     // Create MapArguments
+     MapArguments args = new MapArguments(builder.build(), tokenGroup);
+     directive.initialize(args);
+ 
+     List<Row> results = directive.execute(rows, null);
+     Assert.assertEquals(1, results.size());
+     
+     Row result = results.get(0);
+     Assert.assertEquals(6.0, (Double) result.getValue("total_size"), 0.001); // 6MB total
+     Assert.assertEquals(0.6, (Double) result.getValue("total_time"), 0.001); // 600ms = 0.6s
+   }
+ 
+   @Test
+   public void testAverageAggregation() throws Exception {
+     List<Row> rows = Arrays.asList(
+       createRow("1MB", "100ms"),
+       createRow("2MB", "200ms"),
+       createRow("3MB", "300ms")
+     );
+ 
+     SizeTimeAggregator directive = new SizeTimeAggregator();
+     
+     // Create UsageDefinition
+     UsageDefinition.Builder builder = UsageDefinition.builder("size-time-aggregator");
+     builder.define("size-column", TokenType.COLUMN_NAME);
+     builder.define("time-column", TokenType.COLUMN_NAME);
+     builder.define("target-size-column", TokenType.COLUMN_NAME);
+     builder.define("target-time-column", TokenType.COLUMN_NAME);
+     builder.define("aggregation-type", TokenType.TEXT);
+     
+     // Create TokenGroup
+     TokenGroup tokenGroup = new TokenGroup(new SourceInfo(1, 1, "test"));
+     tokenGroup.add(new ColumnName("size"));
+     tokenGroup.add(new ColumnName("time"));
+     tokenGroup.add(new ColumnName("avg_size"));
+     tokenGroup.add(new ColumnName("avg_time"));
+     tokenGroup.add(new Text("average"));
+     
+     // Create MapArguments
+     MapArguments args = new MapArguments(builder.build(), tokenGroup);
+     directive.initialize(args);
+ 
+     List<Row> results = directive.execute(rows, null);
+     Assert.assertEquals(1, results.size());
+     
+     Row result = results.get(0);
+     Assert.assertEquals(2.0, (Double) result.getValue("avg_size"), 0.001); // 6MB / 3 = 2MB average
+     Assert.assertEquals(0.2, (Double) result.getValue("avg_time"), 0.001); // 600ms / 3 = 200ms = 0.2s average
+   }
+ 
+   @Test
+   public void testDifferentUnits() throws Exception {
+     List<Row> rows = Arrays.asList(
+       createRow("1024KB", "1s"),
+       createRow("1MB", "1000ms")
+     );
+ 
+     SizeTimeAggregator directive = new SizeTimeAggregator();
+     
+     // Create UsageDefinition
+     UsageDefinition.Builder builder = UsageDefinition.builder("size-time-aggregator");
+     builder.define("size-column", TokenType.COLUMN_NAME);
+     builder.define("time-column", TokenType.COLUMN_NAME);
+     builder.define("target-size-column", TokenType.COLUMN_NAME);
+     builder.define("target-time-column", TokenType.COLUMN_NAME);
+     builder.define("size-unit", TokenType.TEXT);
+     builder.define("time-unit", TokenType.TEXT);
+     
+     // Create TokenGroup
+     TokenGroup tokenGroup = new TokenGroup(new SourceInfo(1, 1, "test"));
+     tokenGroup.add(new ColumnName("size"));
+     tokenGroup.add(new ColumnName("time"));
+     tokenGroup.add(new ColumnName("total_size"));
+     tokenGroup.add(new ColumnName("total_time"));
+     tokenGroup.add(new Text("KB"));
+     tokenGroup.add(new Text("ms"));
+     
+     // Create MapArguments
+     MapArguments args = new MapArguments(builder.build(), tokenGroup);
+     directive.initialize(args);
+ 
+     List<Row> results = directive.execute(rows, null);
+     Assert.assertEquals(1, results.size());
+     
+     Row result = results.get(0);
+     Assert.assertEquals(2048.0, (Double) result.getValue("total_size"), 0.001); // 2048KB total
+     Assert.assertEquals(2000.0, (Double) result.getValue("total_time"), 0.001); // 2000ms total
+   }
+ 
+   private Row createRow(String size, String time) {
+     Row row = new Row();
+     row.add("size", size);
+     row.add("time", time);
+     return row;
+   }
+ } 

--- a/wrangler-core/src/test/java/io/cdap/wrangler/directives/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/directives/AggregateStatsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ package io.cdap.wrangler.directives;
+
+ import io.cdap.wrangler.api.Arguments;
+ import io.cdap.wrangler.api.Row;
+ import io.cdap.wrangler.api.parser.ByteSize;
+ import io.cdap.wrangler.api.parser.ColumnName;
+ import io.cdap.wrangler.api.parser.Text;
+ import io.cdap.wrangler.api.parser.TimeDuration;
+ import org.junit.Assert;
+ import org.junit.Test;
+ 
+ import java.util.Arrays;
+ import java.util.List;
+ 
+ import io.cdap.wrangler.api.parser.UsageDefinition;
+ import io.cdap.wrangler.parser.MapArguments;
+ import io.cdap.wrangler.api.TokenGroup;
+ import io.cdap.wrangler.api.SourceInfo;
+ import io.cdap.wrangler.api.parser.TokenType;
+ 
+ public class AggregateStatsTest {
+   @Test
+   public void testTotalAggregation() throws Exception {
+     List<Row> rows = Arrays.asList(
+       createRow("1MB", "100ms"),
+       createRow("2MB", "200ms"),
+       createRow("3MB", "300ms")
+     );
+ 
+     AggregateStats directive = new AggregateStats();
+     
+     // Create UsageDefinition
+     UsageDefinition.Builder builder = UsageDefinition.builder("aggregate-stats");
+     builder.define("size-column", TokenType.COLUMN_NAME);
+     builder.define("time-column", TokenType.COLUMN_NAME);
+     builder.define("target-size-column", TokenType.COLUMN_NAME);
+     builder.define("target-time-column", TokenType.COLUMN_NAME);
+     
+     // Create TokenGroup
+     TokenGroup tokenGroup = new TokenGroup(new SourceInfo(1, 1, "test"));
+     tokenGroup.add(new ColumnName("size"));
+     tokenGroup.add(new ColumnName("time"));
+     tokenGroup.add(new ColumnName("total_size"));
+     tokenGroup.add(new ColumnName("total_time"));
+     
+     // Create MapArguments
+     MapArguments args = new MapArguments(builder.build(), tokenGroup);
+     directive.initialize(args);
+ 
+     List<Row> results = directive.execute(rows, null);
+     Assert.assertEquals(1, results.size());
+     
+     Row result = results.get(0);
+     Assert.assertEquals(6.0, (Double) result.getValue("total_size"), 0.001); // 6MB total
+     Assert.assertEquals(0.6, (Double) result.getValue("total_time"), 0.001); // 600ms = 0.6s
+   }
+ 
+   @Test
+   public void testAverageAggregation() throws Exception {
+     List<Row> rows = Arrays.asList(
+       createRow("1MB", "100ms"),
+       createRow("2MB", "200ms"),
+       createRow("3MB", "300ms")
+     );
+ 
+     AggregateStats directive = new AggregateStats();
+     
+     // Create UsageDefinition
+     UsageDefinition.Builder builder = UsageDefinition.builder("aggregate-stats");
+     builder.define("size-column", TokenType.COLUMN_NAME);
+     builder.define("time-column", TokenType.COLUMN_NAME);
+     builder.define("target-size-column", TokenType.COLUMN_NAME);
+     builder.define("target-time-column", TokenType.COLUMN_NAME);
+     builder.define("aggregation-type", TokenType.TEXT);
+     
+     // Create TokenGroup
+     TokenGroup tokenGroup = new TokenGroup(new SourceInfo(1, 1, "test"));
+     tokenGroup.add(new ColumnName("size"));
+     tokenGroup.add(new ColumnName("time"));
+     tokenGroup.add(new ColumnName("avg_size"));
+     tokenGroup.add(new ColumnName("avg_time"));
+     tokenGroup.add(new Text("average"));
+     
+     // Create MapArguments
+     MapArguments args = new MapArguments(builder.build(), tokenGroup);
+     directive.initialize(args);
+ 
+     List<Row> results = directive.execute(rows, null);
+     Assert.assertEquals(1, results.size());
+     
+     Row result = results.get(0);
+     Assert.assertEquals(2.0, (Double) result.getValue("avg_size"), 0.001); // 6MB / 3 = 2MB average
+     Assert.assertEquals(0.2, (Double) result.getValue("avg_time"), 0.001); // 600ms / 3 = 200ms = 0.2s average
+   }
+ 
+   @Test
+   public void testDifferentUnits() throws Exception {
+     List<Row> rows = Arrays.asList(
+       createRow("1024KB", "1s"),
+       createRow("1MB", "1000ms")
+     );
+ 
+     AggregateStats directive = new AggregateStats();
+     
+     // Create UsageDefinition
+     UsageDefinition.Builder builder = UsageDefinition.builder("aggregate-stats");
+     builder.define("size-column", TokenType.COLUMN_NAME);
+     builder.define("time-column", TokenType.COLUMN_NAME);
+     builder.define("target-size-column", TokenType.COLUMN_NAME);
+     builder.define("target-time-column", TokenType.COLUMN_NAME);
+     builder.define("size-unit", TokenType.TEXT);
+     builder.define("time-unit", TokenType.TEXT);
+     
+     // Create TokenGroup
+     TokenGroup tokenGroup = new TokenGroup(new SourceInfo(1, 1, "test"));
+     tokenGroup.add(new ColumnName("size"));
+     tokenGroup.add(new ColumnName("time"));
+     tokenGroup.add(new ColumnName("total_size"));
+     tokenGroup.add(new ColumnName("total_time"));
+     tokenGroup.add(new Text("KB"));
+     tokenGroup.add(new Text("ms"));
+     
+     // Create MapArguments
+     MapArguments args = new MapArguments(builder.build(), tokenGroup);
+     directive.initialize(args);
+ 
+     List<Row> results = directive.execute(rows, null);
+     Assert.assertEquals(1, results.size());
+     
+     Row result = results.get(0);
+     Assert.assertEquals(2048.0, (Double) result.getValue("total_size"), 0.001); // 2048KB total
+     Assert.assertEquals(2000.0, (Double) result.getValue("total_time"), 0.001); // 2000ms total
+   }
+ 
+   private Row createRow(String size, String time) {
+     Row row = new Row();
+     row.add("size", new ByteSize(size));
+     row.add("time", new TimeDuration(time));
+     return row;
+   }
+ } 

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/DirectiveClassTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/DirectiveClassTest.java
@@ -1,0 +1,50 @@
+package io.cdap.wrangler.parser;
+
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.wrangler.registry.DirectiveScope;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DirectiveClassTest {
+
+    @Test
+    public void testDirectiveClassCreation() {
+        // Arrange
+        String name = "testDirective";
+        String className = "TestDirectiveClass";
+        DirectiveScope scope = DirectiveScope.USER;
+        // Update the ArtifactId constructor as per your API
+        ArtifactId artifactId = new ArtifactId("testArtifact:1.0.0"); // Adjust this line based on the correct constructor
+        String byteSizeArg = "10KB";
+        String timeDurationArg = "150ms";
+
+        // Act
+        DirectiveClass directiveClass = new DirectiveClass(name, className, scope, artifactId, byteSizeArg, timeDurationArg);
+
+        // Assert
+        Assert.assertEquals(name, directiveClass.getName());
+        Assert.assertEquals(className, directiveClass.getClassName());
+        Assert.assertEquals(scope, directiveClass.getScope());
+        Assert.assertEquals(artifactId, directiveClass.getArtifactId());
+        Assert.assertEquals(byteSizeArg, directiveClass.getByteSizeArg());
+        Assert.assertEquals(timeDurationArg, directiveClass.getTimeDurationArg());
+    }
+
+    @Test
+    public void testDirectiveClassToString() {
+        // Arrange
+        String name = "testDirective";
+        String className = "TestDirectiveClass";
+        DirectiveScope scope = DirectiveScope.USER;
+        ArtifactId artifactId = new ArtifactId("testArtifact:1.0.0"); // Adjust this line based on the correct constructor
+        String byteSizeArg = "10KB";
+        String timeDurationArg = "150ms";
+
+        // Act
+        DirectiveClass directiveClass = new DirectiveClass(name, className, scope, artifactId, byteSizeArg, timeDurationArg);
+        String expectedString = "DirectiveClass{name='testDirective', scope=USER, artifactId=testArtifact:1.0.0, className='TestDirectiveClass', byteSizeArg='10KB', timeDurationArg='150ms'}";
+
+        // Assert
+        Assert.assertEquals(expectedString, directiveClass.toString());
+    }
+}


### PR DESCRIPTION
- Introduced `ByteSize` token for parsing byte size strings like "10KB", "1.5MB", etc.
  - Supports units: B, KB, MB, GB, TB, PB
  - Converts all values to bytes and provides JSON serialization

- Introduced `TimeDuration` token for parsing time duration strings like "100ms", "2.5s", etc.
  - Supports units: ns, ms, s, m, h, d
  - Converts all values to nanoseconds and provides JSON serialization

- Updated `TokenType.java` to include new enum types: BYTE_SIZE and TIME_DURATION
- Included pattern matching, validation, and detailed error handling in both implementations

This adds robust support for parsing and serializing byte size and time duration values in the Wrangler API.