### PR TITLE
Added ByteSize and TimeDuration

### DIFF
--- a/prompts.txt
+++ b/prompts.txt
@@ -1,0 +1,8 @@
+prompts used in Zeotap assignment
+
+1. Requested guidance to implement a new aggregate directive in the Wrangler framework (wrangler-core module) for byte size and time duration aggregation.
+2. Asked for explanation of ExecutorContext and TransientStore and whether the provided Java class (AggregateStats.java) was final.
+3. Reported a series of Java compilation errors related to method signatures and requested help fixing them:
+   - Incorrect usage of `get` method in TransientStore with scope and key.
+   - Attempted use of nonexistent `remove` method in TransientStore.
+4. Asked to generate a text file summarizing all user prompts from the conversation without showing code or outputs.

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+import java.util.Locale;
+
+public class ByteSize implements Token {
+    private final long bytes;
+
+    public ByteSize(String value) {
+        this.bytes = parseByteSize(value); //call the method
+    }
+    //calculate the canonical value
+    private long parseByteSize(String value) {
+        String val = value.toUpperCase(Locale.ROOT).trim();
+        try {
+            if (val.endsWith("KB")) {
+                return Long.parseLong(val.replace("KB", "").trim()) * 1024L;
+            } else if (val.endsWith("MB")) {
+                return Long.parseLong(val.replace("MB", "").trim()) * 1024L * 1024L;
+            } else if (val.endsWith("GB")) {
+                return Long.parseLong(val.replace("GB", "").trim()) * 1024L * 1024L * 1024L;
+            } else if (val.endsWith("TB")) {
+                return Long.parseLong(val.replace("TB", "").trim()) * 1024L * 1024L * 1024L * 1024L;
+            } else if (val.endsWith("PB")) {
+                return Long.parseLong(val.replace("PB", "").trim()) * 1024L * 1024L * 1024L * 1024L * 1024L;
+            } else if (val.endsWith("B")) {
+                return Long.parseLong(val.replace("B", "").trim());
+            } else {
+                throw new IllegalArgumentException("Invalid byte size format: " + value);
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid number in byte size: " + value, e);
+        }
+    }
+
+    public long getBytes() {
+        return bytes;
+    }
+    // implement the Token interface
+    @Override
+    public Object value() {
+        return bytes;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(bytes);
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+
+import java.util.Locale;
+
+public class TimeDuration implements Token {
+    private final long millis;
+
+    public TimeDuration(String value) {
+        this.millis = parseTimeDuration(value);
+    }
+    //calculate canonical value, ignoring the fractions for now
+    private long parseTimeDuration(String value) {
+        String val = value.toLowerCase(Locale.ROOT).trim();
+        if (val.endsWith("ms")) {
+            return Long.parseLong(val.replace("ms", "").trim());
+        } else if (val.endsWith("s")) {
+            return Long.parseLong(val.replace("s", "").trim()) * 1000L;
+        } else if (val.endsWith("m")) {
+            return Long.parseLong(val.replace("m", "").trim()) * 60L * 1000L;
+        } else if (val.endsWith("h")) {
+            return Long.parseLong(val.replace("h", "").trim()) * 3600L * 1000L;
+        } else if (val.endsWith("d")) {
+            return Long.parseLong(val.replace("d", "").trim()) * 24L * 3600L * 1000L;
+        } else {
+            throw new IllegalArgumentException("Invalid time duration format: " + value);
+        }
+    }
+
+    public long getMillis() {
+        return millis;
+    }
+    //implement interface
+    @Override
+    public Object value() {
+        return null;
+    }
+
+    @Override
+    public TokenType type() {
+        return null;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return null;
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenDefinition.java
@@ -45,6 +45,9 @@ public final class TokenDefinition implements Serializable {
   private final String name;
   private final TokenType type;
   private final String label;
+  //added
+  private final int BYTE_SIZE;
+  private final int TIME_DURATION;
 
   public TokenDefinition(String name, TokenType type, String label, int ordinal, boolean optional) {
     this.name = name;
@@ -52,6 +55,8 @@ public final class TokenDefinition implements Serializable {
     this.label = label;
     this.ordinal = ordinal;
     this.optional = optional;
+    this.BYTE_SIZE=0;
+    this.TIME_DURATION=0;
   }
 
   /**

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,7 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+  BYTE_SIZE,
+  TIME_DURATION
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -47,11 +47,15 @@ public final class UsageDefinition implements Serializable {
   private final transient int optionalCnt;
   private final String directive;
   private final List<TokenDefinition> tokens;
+  private final int BYTE_SIZE;
+  private final int TIME_DURATION;
 
   private UsageDefinition(String directive, int optionalCnt, List<TokenDefinition> tokens) {
     this.directive = directive;
     this.tokens = tokens;
     this.optionalCnt = optionalCnt;
+    this.TIME_DURATION = 0;
+    this.BYTE_SIZE = 0;
   }
 
   /**

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -64,6 +64,8 @@ directive
     | stringList
     | numberRanges
     | properties
+    | byteSizeArg
+    | timeDurationArg
   )*?
   ;
 
@@ -195,6 +197,9 @@ identifierList
  : Identifier (',' Identifier)*
  ;
 
+byteSizeArg : BYTE_SIZE ;
+
+timeDurationArg : TIME_DURATION ;
 
 /*
  * Following are the Lexer Rules used for tokenizing the recipe.
@@ -311,3 +316,26 @@ fragment Int
 fragment Digit
  : [0-9]
  ;
+
+BYTE_SIZE
+    : (Digit+ ('.' Digit+)?) BYTE_UNIT
+    ;
+
+TIME_DURATION
+    : (Digit+ ('.' Digit+)?) TIME_UNIT
+    ;
+
+fragment BYTE_UNIT 
+    : 'B' 
+    | 'KB' | 'MB' | 'GB' | 'TB'
+    | 'b'  | 'kb' | 'mb' | 'gb' | 'tb'
+    ;
+
+fragment TIME_UNIT 
+    : 'ns'  
+    | 'ms'  
+    | 's'   
+    | 'm'   
+    | 'h'   
+    | 'd'   
+    ;

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -328,7 +328,6 @@ TIME_DURATION
 fragment BYTE_UNIT 
     : 'B' 
     | 'KB' | 'MB' | 'GB' | 'TB'
-    | 'b'  | 'kb' | 'mb' | 'gb' | 'tb'
     ;
 
 fragment TIME_UNIT 

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -318,11 +318,11 @@ fragment Digit
  ;
 
 BYTE_SIZE
-    : (Digit+ ('.' Digit+)?) BYTE_UNIT
+    : (Digit+) BYTE_UNIT
     ;
 
 TIME_DURATION
-    : (Digit+ ('.' Digit+)?) TIME_UNIT
+    : (Digit+) TIME_UNIT
     ;
 
 fragment BYTE_UNIT 

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,178 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.TransientStore;
+import io.cdap.wrangler.api.TransientVariableScope;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Directive that aggregates byte size and time duration values.
+ */
+@Plugin(type = Directive.TYPE)
+@Name(AggregateStats.NAME)
+@Categories(categories = {"aggregates"})
+@Description("Aggregates byte size and time duration values into total statistics")
+public class AggregateStats implements Directive {
+  public static final String NAME = "aggregate-stats";
+  private String byteSizeColumn;
+  private String timeDurationColumn;
+  private String totalSizeColumn;
+  private String totalTimeColumn;
+  
+  /**
+   * Class to store aggregated values.
+   */
+  private static class AggregationValues implements Serializable {
+    private static final long serialVersionUID = 1L;
+    long totalBytes = 0;
+    double totalSeconds = 0.0;
+  }
+
+  @Override
+  public UsageDefinition define() {
+    UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+    builder.define("byteSizeColumn", TokenType.COLUMN_NAME);
+    builder.define("timeDurationColumn", TokenType.COLUMN_NAME);
+    builder.define("totalSizeColumn", TokenType.COLUMN_NAME);
+    builder.define("totalTimeColumn", TokenType.COLUMN_NAME);
+    return builder.build();
+  }
+
+  @Override
+  public void initialize(Arguments args) throws DirectiveParseException {
+    this.byteSizeColumn = ((ColumnName) args.value("byteSizeColumn")).value();
+    this.timeDurationColumn = ((ColumnName) args.value("timeDurationColumn")).value();
+    this.totalSizeColumn = ((ColumnName) args.value("totalSizeColumn")).value();
+    this.totalTimeColumn = ((ColumnName) args.value("totalTimeColumn")).value();
+  }
+
+  @Override
+  public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
+    // Get the transient store from the context.
+    TransientStore store = context.getTransientStore();
+    
+    // Create a unique key for storing our aggregate values.
+    String storeKey = NAME + "-" + byteSizeColumn + "-" + timeDurationColumn;
+    
+    // Retrieve the current aggregation values from the store.
+    AggregationValues aggValues = (AggregationValues) store.get(storeKey);
+    
+    // If no values exist yet for this key, initialize them.
+    if (aggValues == null) {
+      aggValues = new AggregationValues();
+    }
+    
+    // Process each row in the batch.
+    for (Row row : rows) {
+      // Process the byte size column.
+      int byteSizeIdx = row.find(byteSizeColumn);
+      if (byteSizeIdx != -1) {
+        Object byteSizeObj = row.getValue(byteSizeColumn);
+        if (byteSizeObj != null) {
+          try {
+            long bytes;
+            if (byteSizeObj instanceof ByteSize) {
+              bytes = ((ByteSize) byteSizeObj).getBytes();
+            } else {
+              // Try to parse as string.
+              bytes = new ByteSize(byteSizeObj.toString()).getBytes();
+            }
+            aggValues.totalBytes += bytes;
+          } catch (Exception e) {
+            // Optionally log or handle invalid values.
+          }
+        }
+      }
+      
+      // Process the time duration column.
+      int timeDurationIdx = row.find(timeDurationColumn);
+      if (timeDurationIdx != -1) {
+        Object timeDurationObj = row.getValue(timeDurationColumn);
+        if (timeDurationObj != null) {
+          try {
+            double seconds;
+            if (timeDurationObj instanceof TimeDuration) {
+              // Assume getMillis() returns time in milliseconds.
+              seconds = ((TimeDuration) timeDurationObj).getMillis() / 1000.0;
+            } else {
+              seconds = new TimeDuration(timeDurationObj.toString()).getMillis() / 1000.0;
+            }
+            aggValues.totalSeconds += seconds;
+          } catch (Exception e) {
+            // Optionally log or handle invalid values.
+          }
+        }
+      }
+    }
+    
+    // Update the values in the store (set() requires scope).
+    store.set(TransientVariableScope.LOCAL, storeKey, aggValues);
+    
+    // Check if this is the final batch.
+    boolean isFinalBatch = store.get("batch.final") != null;
+    
+    if (isFinalBatch) {
+      // Finalization: retrieve the aggregated totals.
+      AggregationValues finalValues = (AggregationValues) store.get(storeKey);
+      
+      // Convert bytes to megabytes (MB).
+      double totalSizeMB = finalValues.totalBytes / (1024.0 * 1024.0);
+      
+      // Create a new result row with the target columns.
+      Row resultRow = new Row();
+      resultRow.add(totalSizeColumn, totalSizeMB);
+      resultRow.add(totalTimeColumn, finalValues.totalSeconds); // total time in seconds.
+      
+      // Clean up: remove the aggregate values from the store.
+      store.set(TransientVariableScope.LOCAL, storeKey, null);  
+
+      // Return the result row.
+      List<Row> results = new ArrayList<>();
+      results.add(resultRow);
+      return results;
+    }
+    
+    // For non-final batches, return the input rows unchanged.
+    return rows;
+  }
+
+  @Override
+  public void destroy() {
+    // No resources to clean up.
+  }
+}
+

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -34,6 +34,9 @@ import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
 import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -316,7 +319,20 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     builder.addToken(new TextList(strs));
     return builder;
   }
-
+  @Override
+public RecipeSymbol.Builder visitByteSizeArg(DirectivesParser.ByteSizeArgContext ctx) {
+  String raw = ctx.getText();
+  // ByteSize token class is expected to handle parsing from raw string to bytes
+  builder.addToken(new io.cdap.wrangler.api.parser.ByteSize(raw));
+  return builder;
+}
+@Override
+public RecipeSymbol.Builder visitTimeDurationArg(DirectivesParser.TimeDurationArgContext ctx) {
+  String raw = ctx.getText();
+  // TimeDuration token class should convert raw input (e.g., "5s", "100ms") to millis internally
+  builder.addToken(new io.cdap.wrangler.api.parser.TimeDuration(raw));
+  return builder;
+}
   private SourceInfo getOriginalSource(ParserRuleContext ctx) {
     int a = ctx.getStart().getStartIndex();
     int b = ctx.getStop().getStopIndex();

--- a/wrangler-core/src/test/java/io/cdap/wrangler/executor/AggregateStatsDirectiveTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/executor/AggregateStatsDirectiveTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.wrangler.executor;
+
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.test.TestingRig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AggregateStatsDirectiveTest {
+
+    @Test
+    public void testAggregateStatsDirectiveTotal() throws Exception {
+        List<Row> rows = Arrays.asList(
+            new Row("data_transfer_size", "1KB").add("response_time", "100ms"),
+            new Row("data_transfer_size", "2KB").add("response_time", "150ms"),
+            new Row("data_transfer_size", "512B").add("response_time", "50ms")
+        );
+
+        String[] recipe = new String[] {
+            "aggregate-stats :data_transfer_size :response_time :total_size_mb :total_time_sec"
+        };
+
+        List<Row> results = TestingRig.execute(recipe, rows);
+
+        double expectedTotalSizeInMB = (1024 + 2048 + 512) / (1024.0 * 1024.0); // 3.5KB to MB
+        double expectedTotalTimeInSec = (100 + 150 + 50) / 1000.0; // 300ms to seconds
+
+        Assert.assertEquals(1, results.size());
+        Assert.assertEquals(expectedTotalSizeInMB,
+            (double) results.get(0).getValue("total_size_mb"), 0.0001);
+        Assert.assertEquals(expectedTotalTimeInSec,
+            (double) results.get(0).getValue("total_time_sec"), 0.0001);
+    }
+}
+

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/ByteSizeTimeDurationTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/ByteSizeTimeDurationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+// ByteSizeTimeDurationTest.java
+
+package io.cdap.wrangler.parser;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteSizeTimeDurationTest {
+
+    @Test
+    public void testByteSizeParsing() {
+        Assert.assertEquals(1024L, new ByteSize("1KB").getBytes());
+        Assert.assertEquals(1_048_576L, new ByteSize("1MB").getBytes());
+        Assert.assertEquals(1_073_741_824L, new ByteSize("1GB").getBytes());
+        Assert.assertEquals(1_099_511_627_776L, new ByteSize("1TB").getBytes());
+    }
+
+    @Test
+    public void testTimeDurationParsing() {
+        Assert.assertEquals(5_000_000L, new TimeDuration("5ms").getMillis());
+        Assert.assertEquals(60_000_000_000L, new TimeDuration("1m").getMillis());
+        Assert.assertEquals(3_600_000_000_000L, new TimeDuration("1h").getMillis());
+    }
+}
+

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/GrammarBasedParserTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/GrammarBasedParserTest.java
@@ -74,5 +74,22 @@ public class GrammarBasedParserTest {
     List<Directive> directives = parser.parse();
     Assert.assertEquals(0, directives.size());
   }
+  @Test
+  public void testValidByteSizeAndTimeDurationParsing() throws Exception {
+      String[] recipe = new String[] {
+          "aggregate-stats :data_transfer_size :response_time :total_size_mb :total_time_sec"
+      };
+      // Should compile successfully
+      TestingRig.compile(recipe);
+  }
+  
+  @Test(expected = Exception.class)
+  public void testInvalidByteSizeSyntax() throws Exception {
+      String[] recipe = new String[] {
+          "aggregate-stats :data_transfer_size :invalid_duration :total_size_mb :total_time_sec"
+      };
+      // Should throw due to invalid input
+      TestingRig.compile(recipe);
+  }
 
 }


### PR DESCRIPTION
This PR enhances the Wrangler library by adding native support for parsing and aggregating byte size and time duration values within directives. It includes the following 
Grammar updates to support new token types: BYTE_SIZE and TIME_DURATION 
New token classes: ByteSize and TimeDuration in the wrangler-api module
New directive: aggregate-stats, which performs aggregation on byte sizes and time durations

![2025-04-12T22:43:00,584204314+05:30](https://github.com/user-attachments/assets/5aea0d10-aaa4-41d0-86f5-eac8493980c0)

