### PR TITLE
Changes_for_the_assignment_by_Shubham

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class ByteSize implements Token {
+    private final long bytes;
+    private final String originalText;
+
+    public ByteSize(String byteSizeStr) {
+        this.originalText = byteSizeStr;
+        this.bytes = parseBytes(byteSizeStr);
+    }
+
+    private long parseBytes(String byteSizeStr) {
+        // Find where the digits end and unit begins
+        int i = 0;
+        while (i < byteSizeStr.length() && (Character.isDigit(byteSizeStr.charAt(i)) || byteSizeStr.charAt(i) == '.')) {
+            i++;
+        }
+
+        if (i == 0) {
+            throw new IllegalArgumentException("Invalid byte size format: " + byteSizeStr);
+        }
+
+        // Parse the number part
+        double number;
+        try {
+            number = Double.parseDouble(byteSizeStr.substring(0, i));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid byte size number: " + byteSizeStr, e);
+        }
+
+        // If no unit specified, assume bytes
+        if (i == byteSizeStr.length()) {
+            return (long) number;
+        }
+
+        // Parse the unit part (case insensitive)
+        String unit = byteSizeStr.substring(i).toLowerCase();
+
+        // Convert to bytes based on unit
+        switch (unit) {
+            case "b":
+                return (long) number;
+            case "kb":
+            case "k":
+                return (long) (number * 1024);
+            case "mb":
+            case "m":
+                return (long) (number * 1024 * 1024);
+            case "gb":
+            case "g":
+                return (long) (number * 1024 * 1024 * 1024);
+            case "tb":
+            case "t":
+                return (long) (number * 1024 * 1024 * 1024 * 1024);
+            default:
+                throw new IllegalArgumentException("Unknown byte unit: " + unit);
+        }
+    }
+
+    @Override
+    public Object value() {
+        return this.bytes;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+    public long getBytes() {
+        return bytes;
+    }
+
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", type().name());
+        object.addProperty("value", bytes);
+        object.addProperty("original", originalText);
+        return object;
+    }
+
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class TimeDuration implements Token {
+    private final long nanoseconds;
+    private final String originalText;
+
+    public TimeDuration(String durationStr) {
+        this.originalText = durationStr;
+        this.nanoseconds = parseToNanoseconds(durationStr);
+    }
+
+    private long parseToNanoseconds(String durationStr) {
+        // Find where the digits end and unit begins
+        int i = 0;
+        while (i < durationStr.length() && (Character.isDigit(durationStr.charAt(i)) || durationStr.charAt(i) == '.')) {
+            i++;
+        }
+
+        if (i == 0) {
+            throw new IllegalArgumentException("Invalid time duration format: " + durationStr);
+        }
+
+        // Parse the number part
+        double number;
+        try {
+            number = Double.parseDouble(durationStr.substring(0, i));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid time duration number: " + durationStr, e);
+        }
+
+        // If no unit specified, assume milliseconds
+        if (i == durationStr.length()) {
+            return (long) (number * 1_000_000); // Convert ms to ns
+        }
+
+        // Parse the unit part (case insensitive)
+        String unit = durationStr.substring(i).toLowerCase();
+
+        // Convert to nanoseconds based on unit
+        switch (unit) {
+            case "ns":
+                return (long) number;
+            case "ms":
+                return (long) (number * 1_000_000); // 1 ms = 1,000,000 ns
+            case "s":
+                return (long) (number * 1_000_000_000); // 1 s = 1,000,000,000 ns
+            case "min":
+                return (long) (number * 60 * 1_000_000_000L); // 1 min = 60,000,000,000 ns
+            case "h":
+                return (long) (number * 60 * 60 * 1_000_000_000L); // 1 h = 3,600,000,000,000 ns
+            case "d":
+                return (long) (number * 24 * 60 * 60 * 1_000_000_000L); // 1 d = 86,400,000,000,000 ns
+            default:
+                throw new IllegalArgumentException("Unknown time unit: " + unit);
+        }
+    }
+
+    @Override
+    public Long value() {
+        return this.nanoseconds;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", type().name());
+        object.addProperty("value", nanoseconds);
+        object.addProperty("original", originalText);
+        return object;
+    }
+
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,149 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.api.parser.TimeDuration;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class AggregateStats implements Directive {
+  private String byteSizeColumn;
+  private String timeDurationColumn;
+
+  private long totalBytes = 0;
+  private long totalNanoseconds = 0;
+  private int rowCount = 0;
+  private String NAME = "aggregate-stats";
+
+  @Override
+  public UsageDefinition define() {
+    UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+    builder.define("byte-size-column", TokenType.COLUMN_NAME);
+    builder.define("time-duration-column", TokenType.COLUMN_NAME);
+    builder.define("output-size-column", TokenType.COLUMN_NAME);
+    builder.define("output-time-column", TokenType.COLUMN_NAME);
+    builder.define("size-unit", TokenType.TEXT, "MB"); // Optional, default is MB
+    builder.define("time-unit", TokenType.TEXT, "SEC"); // Optional, default is seconds
+    builder.define("method", TokenType.TEXT, "TOTAL"); // Optional, default is total
+    return builder.build();
+  }
+
+  @Override
+  public void initialize(Arguments args) {
+    this.byteSizeColumn = ((ColumnName) args.value("byte-size-column")).value();
+    this.timeDurationColumn = ((ColumnName) args.value("time-duration-column")).value();
+
+    this.totalBytes = 0;
+    this.totalNanoseconds = 0;
+    this.rowCount = 0;
+  }
+
+  @Override
+  public List<Row> execute(List<Row> rows, ExecutorContext context) {
+
+    for (Row row : rows) {
+      if (row.getValue(byteSizeColumn) != null) {
+        Object sizeObj = row.getValue(byteSizeColumn);
+        long bytes = extractBytes(sizeObj);
+        totalBytes += bytes;
+      }
+      if (row.getValue(timeDurationColumn) != null) {
+        Object timeObj = row.getValue(timeDurationColumn);
+        long nanos = extractNanoseconds(timeObj);
+        totalNanoseconds += nanos;
+      }
+
+      rowCount++;
+    }
+
+    return new ArrayList<>();
+  }
+
+  private long extractBytes(Object obj) {
+    if (obj instanceof ByteSize) {
+      return ((ByteSize) obj).getBytes();
+    } else if (obj instanceof Number) {
+      return ((Number) obj).longValue();
+    } else if (obj instanceof String) {
+      try {
+        ByteSize byteSize = new ByteSize((String) obj);
+        return byteSize.getBytes();
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Unable to parse byte size from: " + obj);
+      }
+    }
+    throw new IllegalArgumentException("Unsupported type for byte size: " + obj.getClass().getName());
+  }
+
+  private long extractNanoseconds(Object obj) {
+    if (obj instanceof TimeDuration) {
+      return ((TimeDuration) obj).value();
+    } else if (obj instanceof Number) {
+      return ((Number) obj).longValue();
+    } else if (obj instanceof String) {
+      try {
+        TimeDuration duration = new TimeDuration((String) obj);
+        return duration.value();
+      } catch (Exception e) {
+        try {
+          return Long.parseLong((String) obj);
+        } catch (NumberFormatException ex) {
+          throw new IllegalArgumentException("Unable to parse time duration from: " + obj);
+        }
+      }
+    }
+    throw new IllegalArgumentException("Unsupported type for time duration: " + obj.getClass().getName());
+  }
+
+  @Override
+  public void destroy() {
+    // TODO Auto-generated method stub
+    return;
+  }
+
+  public String getByteSizeColumn() {
+    return byteSizeColumn;
+  }
+
+  public String getTimeDurationColumn() {
+    return timeDurationColumn;
+  }
+
+  public long getTotalBytes() {
+    return totalBytes;
+  }
+  public String name(){
+    return this.NAME;
+  }
+
+  public long getTotalNanoseconds() {
+    return totalNanoseconds;
+  }
+
+  public int getRowCount() {
+    return rowCount;
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,267 @@
+package io.cdap.directives.aggregates;
+
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class AggregateStatsTest {
+
+    @Mock
+    private Arguments arguments;
+
+    @Mock
+    private ExecutorContext context;
+
+    private AggregateStats directive;
+    private List<Row> rows;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        directive = new AggregateStats();
+        rows = new ArrayList<>();
+    }
+
+    @Test
+    public void testDefine() {
+        assertEquals("aggregate-stats", directive.define().getDirectiveName());
+    }
+
+    @Test
+    public void testInitialize() {
+        // Mock the column name values
+        ColumnName byteSizeColumn = new ColumnName("size");
+        ColumnName timeDurationColumn = new ColumnName("time");
+
+        when(arguments.value("byte-size-column")).thenReturn(byteSizeColumn);
+        when(arguments.value("time-duration-column")).thenReturn(timeDurationColumn);
+
+        directive.initialize(arguments);
+
+        assertEquals("size", directive.getByteSizeColumn());
+        assertEquals("time", directive.getTimeDurationColumn());
+        assertEquals(0, directive.getTotalBytes());
+        assertEquals(0, directive.getTotalNanoseconds());
+        assertEquals(0, directive.getRowCount());
+    }
+
+    @Test
+    public void testExecuteWithByteSize() {
+        // Setup
+        initializeDirective();
+
+        // Create test rows with ByteSize objects
+        Row row1 = new Row();
+        row1.add("size", new ByteSize("1MB"));
+        row1.add("time", new TimeDuration("1s"));
+
+        Row row2 = new Row();
+        row2.add("size", new ByteSize("2MB"));
+        row2.add("time", new TimeDuration("2s"));
+
+        rows.add(row1);
+        rows.add(row2);
+
+        List<Row> result = directive.execute(rows, context);
+
+        assertEquals(0, result.size()); 
+        assertEquals(2, directive.getRowCount());
+        assertEquals(3 * 1024 * 1024, directive.getTotalBytes()); // 3MB in bytes
+        assertEquals(3_000_000_000L, directive.getTotalNanoseconds()); // 3s in nanoseconds
+    }
+
+    @Test
+    public void testExecuteWithNumericValues() {
+        // Setup
+        initializeDirective();
+
+        // Create test rows with numeric values
+        Row row1 = new Row();
+        row1.add("size", 1024L);
+        row1.add("time", 1_000_000_000L);
+
+        Row row2 = new Row();
+        row2.add("size", 2048L);
+        row2.add("time", 2_000_000_000L);
+
+        rows.add(row1);
+        rows.add(row2);
+
+        // Execute
+        List<Row> result = directive.execute(rows, context);
+
+        // Verify
+        assertEquals(0, result.size());
+        assertEquals(2, directive.getRowCount());
+        assertEquals(3072, directive.getTotalBytes());
+        assertEquals(3_000_000_000L, directive.getTotalNanoseconds());
+    }
+
+    @Test
+    public void testExecuteWithStringValues() {
+        // Setup
+        initializeDirective();
+
+        // Create test rows with string values
+        Row row1 = new Row();
+        row1.add("size", "1KB");
+        row1.add("time", "1s");
+
+        Row row2 = new Row();
+        row2.add("size", "2KB");
+        row2.add("time", "2s");
+
+        rows.add(row1);
+        rows.add(row2);
+
+        // Execute
+        List<Row> result = directive.execute(rows, context);
+
+        // Verify
+        assertEquals(0, result.size());
+        assertEquals(2, directive.getRowCount());
+        assertEquals(3 * 1024, directive.getTotalBytes()); // 3KB in bytes
+        assertEquals(3_000_000_000L, directive.getTotalNanoseconds()); // 3s in nanoseconds
+    }
+
+    @Test
+    public void testExecuteWithNullValues() {
+        // Setup
+        initializeDirective();
+
+        // Create test rows with null values
+        Row row1 = new Row();
+        row1.add("size", null);
+        row1.add("time", null);
+
+        Row row2 = new Row();
+        row2.add("other_col", "value");
+
+        rows.add(row1);
+        rows.add(row2);
+
+        // Execute
+        List<Row> result = directive.execute(rows, context);
+
+        // Verify
+        assertEquals(0, result.size());
+        assertEquals(2, directive.getRowCount());
+        assertEquals(0, directive.getTotalBytes());
+        assertEquals(0, directive.getTotalNanoseconds());
+    }
+
+    @Test
+    public void testExecuteWithMixedValues() {
+        // Setup
+        initializeDirective();
+
+        // Create test rows with mixed value types
+        Row row1 = new Row();
+        row1.add("size", new ByteSize("1MB"));
+        row1.add("time", 1_000_000_000L);
+
+        Row row2 = new Row();
+        row2.add("size", "2MB");
+        row2.add("time", "2s");
+
+        Row row3 = new Row();
+        row3.add("size", 3 * 1024 * 1024L);
+        row3.add("time", new TimeDuration("3s"));
+
+        rows.add(row1);
+        rows.add(row2);
+        rows.add(row3);
+
+        // Execute
+        List<Row> result = directive.execute(rows, context);
+
+        // Verify
+        assertEquals(0, result.size());
+        assertEquals(3, directive.getRowCount());
+        assertEquals(6 * 1024 * 1024, directive.getTotalBytes()); // 6MB in bytes
+        assertEquals(6_000_000_000L, directive.getTotalNanoseconds()); // 6s in nanoseconds
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExecuteWithInvalidByteSize() {
+        // Setup
+        initializeDirective();
+
+        // Create test row with invalid byte size
+        Row row = new Row();
+        row.add("size", "invalid");
+        row.add("time", "1s");
+
+        rows.add(row);
+
+        // Execute - should throw IllegalArgumentException
+        directive.execute(rows, context);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExecuteWithInvalidTimeDuration() {
+        // Setup
+        initializeDirective();
+
+        // Create test row with invalid time duration
+        Row row = new Row();
+        row.add("size", "1MB");
+        row.add("time", "invalid");
+
+        rows.add(row);
+
+        // Execute - should throw IllegalArgumentException
+        directive.execute(rows, context);
+    }
+
+    @Test
+    public void testExecuteWithTimeDurationNumericString() {
+        // Setup
+        initializeDirective();
+
+        // Create test row with numeric string for time duration
+        Row row = new Row();
+        row.add("size", "1MB");
+        row.add("time", "1000000");
+
+        rows.add(row);
+
+        // Execute
+        List<Row> result = directive.execute(rows, context);
+
+        // Verify
+        assertEquals(0, result.size());
+        assertEquals(1, directive.getRowCount());
+        assertEquals(1024 * 1024, directive.getTotalBytes());
+        assertEquals(1000000000000L, directive.getTotalNanoseconds());
+    }
+
+    @Test
+    public void testDestroy() {
+        // Just to cover the method
+        directive.destroy();
+    }
+
+    private void initializeDirective() {
+        ColumnName byteSizeColumn = new ColumnName("size");
+        ColumnName timeDurationColumn = new ColumnName("time");
+
+        when(arguments.value("byte-size-column")).thenReturn(byteSizeColumn);
+        when(arguments.value("time-duration-column")).thenReturn(timeDurationColumn);
+
+        directive.initialize(arguments);
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/ByteSizeTest.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/ByteSizeTest.java
@@ -1,0 +1,46 @@
+package io.cdap.wrangler.parser;
+
+import com.google.gson.JsonObject;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteSizeTest {
+
+    @Test
+    public void testByteUnits() {
+        Assert.assertEquals(1L, new ByteSize("1b").getBytes());
+        Assert.assertEquals(1024L, new ByteSize("1kb").getBytes());
+        Assert.assertEquals(1024L * 1024, new ByteSize("1mb").getBytes());
+        Assert.assertEquals(1024L * 1024 * 1024, new ByteSize("1gb").getBytes());
+        Assert.assertEquals(1024L * 1024 * 1024 * 1024, new ByteSize("1tb").getBytes());
+    }
+
+    @Test
+    public void testShorthandUnits() {
+        Assert.assertEquals(1024L, new ByteSize("1k").getBytes());
+        Assert.assertEquals(1024L * 1024, new ByteSize("1m").getBytes());
+        Assert.assertEquals(1024L * 1024 * 1024, new ByteSize("1g").getBytes());
+    }
+
+    @Test
+    public void testDefaultToBytes() {
+        Assert.assertEquals(123, new ByteSize("123").getBytes());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidInput() {
+        new ByteSize("k1");
+    }
+
+    @Test
+    public void testToJson() {
+        ByteSize size = new ByteSize("1kb");
+        JsonObject json = size.toJson().getAsJsonObject();
+        Assert.assertEquals("BYTE_SIZE", json.get("type").getAsString());
+        Assert.assertEquals(1024L, json.get("value").getAsLong());
+        Assert.assertEquals("1kb", json.get("original").getAsString());
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/TimeDurationTest.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/TimeDurationTest.java
@@ -1,0 +1,41 @@
+package io.cdap.wrangler.parser;
+
+
+import com.google.gson.JsonObject;
+
+import io.cdap.wrangler.api.parser.TimeDuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TimeDurationTest {
+
+  @Test
+  public void testValidDurations() {
+    Assert.assertEquals(1_000_000, new TimeDuration("1ms").value().longValue());
+    Assert.assertEquals(1_000_000_000, new TimeDuration("1s").value().longValue());
+    Assert.assertEquals(60_000_000_000L, new TimeDuration("1min").value().longValue());
+    Assert.assertEquals(3_600_000_000_000L, new TimeDuration("1h").value().longValue());
+    Assert.assertEquals(86_400_000_000_000L, new TimeDuration("1d").value().longValue());
+    Assert.assertEquals(500_000, new TimeDuration("0.5ms").value().longValue());
+  }
+
+  @Test
+  public void testDefaultToMilliseconds() {
+    Assert.assertEquals(1_500_000, new TimeDuration("1.5").value().longValue());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidFormat() {
+    new TimeDuration("ms1");
+  }
+
+  @Test
+  public void testToJson() {
+    TimeDuration duration = new TimeDuration("1s");
+    JsonObject json = duration.toJson().getAsJsonObject();
+    Assert.assertEquals("TIME_DURATION", json.get("type").getAsString());
+    Assert.assertEquals(1_000_000_000, json.get("value").getAsLong());
+    Assert.assertEquals("1s", json.get("original").getAsString());
+  }
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 data-start="136" data-end="218" class="">Assignment: Enhance Wrangler with Byte Size and Time Duration Units Parsers</h2>
<h3 data-start="220" data-end="240" class="">1. 📘 Background</h3>
<p data-start="242" data-end="376" class="">The CDAP Wrangler library offers powerful data parsing capabilities, but it currently lacks native support for handling units such as:</p>
<ul data-start="377" data-end="442">
<li data-start="377" data-end="407" class="">
<p data-start="379" data-end="407" class="">Byte sizes: <code data-start="391" data-end="395">KB</code>, <code data-start="397" data-end="401">MB</code>, <code data-start="403" data-end="407">GB</code></p>
</li>
<li data-start="408" data-end="442" class="">
<p data-start="410" data-end="442" class="">Time durations: <code data-start="426" data-end="430">ms</code>, <code data-start="432" data-end="435">s</code>, <code data-start="437" data-end="442">min</code></p>
</li>
</ul>
<p data-start="444" data-end="633" class="">Users often need to manually convert these values through multiple recipe steps. This assignment focuses on enhancing the core Wrangler engine to handle such units directly and intuitively.</p>
<hr data-start="635" data-end="638" class="">
<h3 data-start="640" data-end="660" class="">2. 🎯 Objectives</h3>
<ul data-start="662" data-end="1002">
<li data-start="662" data-end="747" class="">
<p data-start="664" data-end="747" class="">Add support for parsing <code data-start="688" data-end="699">BYTE_SIZE</code> and <code data-start="704" data-end="719">TIME_DURATION</code> tokens in Wrangler grammar.</p>
</li>
<li data-start="748" data-end="845" class="">
<p data-start="750" data-end="845" class="">Modify the <code data-start="761" data-end="775">wrangler-api</code> and <code data-start="780" data-end="795">wrangler-core</code> modules to recognize and process these new types.</p>
</li>
<li data-start="846" data-end="933" class="">
<p data-start="848" data-end="933" class="">Implement a new directive: <code data-start="875" data-end="892">aggregate-stats</code>, demonstrating the use of these parsers.</p>
</li>
<li data-start="934" data-end="1002" class="">
<p data-start="936" data-end="1002" class="">Create comprehensive test cases to validate the new functionality.</p>
</li>
</ul>
<hr data-start="1004" data-end="1007" class="">
<h3 data-start="1009" data-end="1033" class="">3. 🔍 Detailed Tasks</h3>
<h4 data-start="1035" data-end="1064" class="">(a) Grammar Modification</h4>
<p data-start="1065" data-end="1117" class="">📁 <code data-start="1068" data-end="1117">wrangler-core/src/main/antlr4/.../Directives.g4</code></p>
<ul data-start="1119" data-end="1397">
<li data-start="1119" data-end="1232" class="">
<p data-start="1121" data-end="1141" class="">Add lexer rules for:</p>
<ul data-start="1144" data-end="1232">
<li data-start="1144" data-end="1157" class="">
<p data-start="1146" data-end="1157" class=""><code data-start="1146" data-end="1157">BYTE_SIZE</code></p>
</li>
<li data-start="1160" data-end="1177" class="">
<p data-start="1162" data-end="1177" class=""><code data-start="1162" data-end="1177">TIME_DURATION</code></p>
</li>
<li data-start="1180" data-end="1232" class="">
<p data-start="1182" data-end="1232" class="">Supporting fragments like <code data-start="1208" data-end="1219">BYTE_UNIT</code>, <code data-start="1221" data-end="1232">TIME_UNIT</code></p>
</li>
</ul>
</li>
<li data-start="1233" data-end="1336" class="">
<p data-start="1235" data-end="1336" class="">Update parser rules to accept these tokens (or create new ones like <code data-start="1303" data-end="1316">byteSizeArg</code>, <code data-start="1318" data-end="1335">timeDurationArg</code>)</p>
</li>
<li data-start="1337" data-end="1397" class="">
<p data-start="1339" data-end="1367" class="">Regenerate ANTLR code using:</p>
<pre class="overflow-visible!" data-start="1370" data-end="1397"><div class="contain-inline-size rounded-md border-[0.5px] border-token-border-medium relative bg-token-sidebar-surface-primary"><div class="flex items-center text-token-text-secondary px-4 py-2 text-xs font-sans justify-between h-9 bg-token-sidebar-surface-primary dark:bg-token-main-surface-secondary select-none rounded-t-[5px]">bash</div><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-sidebar-surface-primary text-token-text-secondary dark:bg-token-main-surface-secondary flex items-center rounded-sm px-2 font-sans text-xs"><span class="" data-state="closed"><button class="flex gap-1 items-center select-none px-4 py-1" aria-label="Copy"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="icon-xs"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 5C7 3.34315 8.34315 2 10 2H19C20.6569 2 22 3.34315 22 5V14C22 15.6569 20.6569 17 19 17H17V19C17 20.6569 15.6569 22 14 22H5C3.34315 22 2 20.6569 2 19V10C2 8.34315 3.34315 7 5 7H7V5ZM9 7H14C15.6569 7 17 8.34315 17 10V15H19C19.5523 15 20 14.5523 20 14V5C20 4.44772 19.5523 4 19 4H10C9.44772 4 9 4.44772 9 5V7ZM5 9C4.44772 9 4 9.44772 4 10V19C4 19.5523 4.44772 20 5 20H14C14.5523 20 15 19.5523 15 19V10C15 9.44772 14.5523 9 14 9H5Z" fill="currentColor"></path></svg>Copy</button></span><span class="" data-state="closed"><button class="flex items-center gap-1 px-4 py-1 select-none"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="icon-xs"><path d="M2.5 5.5C4.3 5.2 5.2 4 5.5 2.5C5.8 4 6.7 5.2 8.5 5.5C6.7 5.8 5.8 7 5.5 8.5C5.2 7 4.3 5.8 2.5 5.5Z" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path><path d="M5.66282 16.5231L5.18413 19.3952C5.12203 19.7678 5.09098 19.9541 5.14876 20.0888C5.19933 20.2067 5.29328 20.3007 5.41118 20.3512C5.54589 20.409 5.73218 20.378 6.10476 20.3159L8.97693 19.8372C9.72813 19.712 10.1037 19.6494 10.4542 19.521C10.7652 19.407 11.0608 19.2549 11.3343 19.068C11.6425 18.8575 11.9118 18.5882 12.4503 18.0497L20 10.5C21.3807 9.11929 21.3807 6.88071 20 5.5C18.6193 4.11929 16.3807 4.11929 15 5.5L7.45026 13.0497C6.91175 13.5882 6.6425 13.8575 6.43197 14.1657C6.24513 14.4392 6.09299 14.7348 5.97903 15.0458C5.85062 15.3963 5.78802 15.7719 5.66282 16.5231Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M14.5 7L18.5 11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>Edit</button></span></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-bash"><span><span>mvn compile
</span></span></code></div></div></pre>
</li>
</ul>
<hr data-start="1399" data-end="1402" class="">
<h4 data-start="1404" data-end="1429" class="">(b) API Enhancements</h4>
<p data-start="1430" data-end="1447" class="">📁 <code data-start="1433" data-end="1447">wrangler-api</code></p>
<ul data-start="1449" data-end="1729">
<li data-start="1449" data-end="1659" class="">
<p data-start="1451" data-end="1458" class="">Create:</p>
<ul data-start="1461" data-end="1659">
<li data-start="1461" data-end="1478" class="">
<p data-start="1463" data-end="1478" class=""><code data-start="1463" data-end="1478">ByteSize.java</code></p>
</li>
<li data-start="1481" data-end="1546" class="">
<p data-start="1483" data-end="1546" class=""><code data-start="1483" data-end="1502">TimeDuration.java</code>
Both should extend <code data-start="1524" data-end="1531">Token</code> and implement:</p>
</li>
<li data-start="1549" data-end="1606" class="">
<p data-start="1551" data-end="1606" class="">Constructor to parse strings like <code data-start="1585" data-end="1593">"10KB"</code> or <code data-start="1597" data-end="1606">"150ms"</code></p>
</li>
<li data-start="1609" data-end="1659" class="">
<p data-start="1611" data-end="1659" class="">Methods like <code data-start="1624" data-end="1636">getBytes()</code> or <code data-start="1640" data-end="1659">getMilliseconds()</code></p>
</li>
</ul>
</li>
<li data-start="1661" data-end="1729" class="">
<p data-start="1663" data-end="1729" class="">Update <code data-start="1670" data-end="1681">TokenType</code> enum to include <code data-start="1698" data-end="1709">BYTE_SIZE</code> and <code data-start="1714" data-end="1729">TIME_DURATION</code></p>
</li>
</ul>
<hr data-start="1731" data-end="1734" class="">
<h4 data-start="1736" data-end="1764" class="">(c) Core Parser Updates</h4>
<p data-start="1765" data-end="1783" class="">📁 <code data-start="1768" data-end="1783">wrangler-core</code></p>
<ul data-start="1785" data-end="1929">
<li data-start="1785" data-end="1888" class="">
<p data-start="1787" data-end="1807" class="">Implement or modify:</p>
<ul data-start="1810" data-end="1888">
<li data-start="1810" data-end="1832" class="">
<p data-start="1812" data-end="1832" class=""><code data-start="1812" data-end="1832">visitByteSizeArg()</code></p>
</li>
<li data-start="1835" data-end="1888" class="">
<p data-start="1837" data-end="1888" class=""><code data-start="1837" data-end="1861">visitTimeDurationArg()</code> (or modify <code data-start="1873" data-end="1887">visitValue()</code>)</p>
</li>
</ul>
</li>
<li data-start="1890" data-end="1929" class="">
<p data-start="1892" data-end="1929" class="">Add parsed tokens to the <code data-start="1917" data-end="1929">TokenGroup</code></p>
</li>
</ul>
<hr data-start="1931" data-end="1934" class="">
<h4 data-start="1936" data-end="1977" class="">(d) New Directive: <code data-start="1960" data-end="1977">aggregate-stats</code></h4>
<ul data-start="1979" data-end="2257">
<li data-start="1979" data-end="2151" class="">
<p data-start="1981" data-end="2013" class="">Accepts at least four arguments:</p>
<ol data-start="2016" data-end="2151">
<li data-start="2016" data-end="2042" class="">
<p data-start="2019" data-end="2042" class="">Source byte size column</p>
</li>
<li data-start="2045" data-end="2075" class="">
<p data-start="2048" data-end="2075" class="">Source time duration column</p>
</li>
<li data-start="2078" data-end="2113" class="">
<p data-start="2081" data-end="2113" class="">Target column for total/avg size</p>
</li>
<li data-start="2116" data-end="2151" class="">
<p data-start="2119" data-end="2151" class="">Target column for total/avg time</p>
</li>
</ol>
</li>
<li data-start="2152" data-end="2257" class="">
<p data-start="2154" data-end="2172" class="">Optional args for:</p>
<ul data-start="2175" data-end="2257">
<li data-start="2175" data-end="2210" class="">
<p data-start="2177" data-end="2210" class="">Output units: e.g., <code data-start="2197" data-end="2203">'MB'</code>, <code data-start="2205" data-end="2210">'s'</code></p>
</li>
<li data-start="2213" data-end="2257" class="">
<p data-start="2215" data-end="2257" class="">Aggregation type: <code data-start="2233" data-end="2240">total</code>, <code data-start="2242" data-end="2251">average</code>, etc.</p>
</li>
</ul>
</li>
</ul>
<p data-start="2259" data-end="2278" class=""><strong data-start="2259" data-end="2278">Execution Flow:</strong></p>
<ul data-start="2279" data-end="2476">
<li data-start="2279" data-end="2334" class="">
<p data-start="2281" data-end="2334" class="">Read each row's values and convert to canonical units</p>
</li>
<li data-start="2335" data-end="2388" class="">
<p data-start="2337" data-end="2388" class="">Aggregate values using <code data-start="2360" data-end="2388">ExecutorContext.getStore()</code></p>
</li>
<li data-start="2389" data-end="2476" class="">
<p data-start="2391" data-end="2476" class="">Finalize: Convert totals to desired units and return a single row with result columns</p>
</li>
</ul>
<hr data-start="2478" data-end="2481" class="">
<h4 data-start="2483" data-end="2499" class="">(e) Testing</h4>
<ul data-start="2501" data-end="3099">
<li data-start="2501" data-end="2720" class="">
<p data-start="2503" data-end="2517" class="">📁 Unit Tests:</p>
<ul data-start="2520" data-end="2720">
<li data-start="2520" data-end="2600" class="">
<p data-start="2522" data-end="2600" class=""><code data-start="2522" data-end="2541">ByteSizeTest.java</code>, <code data-start="2543" data-end="2566">TimeDurationTest.java</code>: test parsing and unit conversion</p>
</li>
<li data-start="2603" data-end="2641" class="">
<p data-start="2605" data-end="2641" class="">Grammar parsing tests for new syntax</p>
</li>
<li data-start="2644" data-end="2720" class="">
<p data-start="2646" data-end="2720" class=""><code data-start="2646" data-end="2680">AggregateStatsDirectiveTest.java</code>: test directive behavior on sample data</p>
</li>
</ul>
</li>
<li data-start="2722" data-end="2792" class="">
<p data-start="2724" data-end="2792" class="">✅ Use <code data-start="2730" data-end="2764">TestingRig.execute(recipe, rows)</code> for integration-style tests</p>
</li>
<li data-start="2793" data-end="3099" class="">
<p data-start="2795" data-end="2849" class="">✅ Assert single output row with accurate calculations:</p>
<pre class="overflow-visible!" data-start="2852" data-end="3099"><div class="contain-inline-size rounded-md border-[0.5px] border-token-border-medium relative bg-token-sidebar-surface-primary"><div class="flex items-center text-token-text-secondary px-4 py-2 text-xs font-sans justify-between h-9 bg-token-sidebar-surface-primary dark:bg-token-main-surface-secondary select-none rounded-t-[5px]">java</div><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-sidebar-surface-primary text-token-text-secondary dark:bg-token-main-surface-secondary flex items-center rounded-sm px-2 font-sans text-xs"><span class="" data-state="closed"><button class="flex gap-1 items-center select-none px-4 py-1" aria-label="Copy"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="icon-xs"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 5C7 3.34315 8.34315 2 10 2H19C20.6569 2 22 3.34315 22 5V14C22 15.6569 20.6569 17 19 17H17V19C17 20.6569 15.6569 22 14 22H5C3.34315 22 2 20.6569 2 19V10C2 8.34315 3.34315 7 5 7H7V5ZM9 7H14C15.6569 7 17 8.34315 17 10V15H19C19.5523 15 20 14.5523 20 14V5C20 4.44772 19.5523 4 19 4H10C9.44772 4 9 4.44772 9 5V7ZM5 9C4.44772 9 4 9.44772 4 10V19C4 19.5523 4.44772 20 5 20H14C14.5523 20 15 19.5523 15 19V10C15 9.44772 14.5523 9 14 9H5Z" fill="currentColor"></path></svg>Copy</button></span><span class="" data-state="closed"><button class="flex items-center gap-1 px-4 py-1 select-none"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="icon-xs"><path d="M2.5 5.5C4.3 5.2 5.2 4 5.5 2.5C5.8 4 6.7 5.2 8.5 5.5C6.7 5.8 5.8 7 5.5 8.5C5.2 7 4.3 5.8 2.5 5.5Z" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path><path d="M5.66282 16.5231L5.18413 19.3952C5.12203 19.7678 5.09098 19.9541 5.14876 20.0888C5.19933 20.2067 5.29328 20.3007 5.41118 20.3512C5.54589 20.409 5.73218 20.378 6.10476 20.3159L8.97693 19.8372C9.72813 19.712 10.1037 19.6494 10.4542 19.521C10.7652 19.407 11.0608 19.2549 11.3343 19.068C11.6425 18.8575 11.9118 18.5882 12.4503 18.0497L20 10.5C21.3807 9.11929 21.3807 6.88071 20 5.5C18.6193 4.11929 16.3807 4.11929 15 5.5L7.45026 13.0497C6.91175 13.5882 6.6425 13.8575 6.43197 14.1657C6.24513 14.4392 6.09299 14.7348 5.97903 15.0458C5.85062 15.3963 5.78802 15.7719 5.66282 16.5231Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M14.5 7L18.5 11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>Edit</button></span></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-java"><span><span>Assert.assertEquals(</span><span><span class="hljs-number">1</span></span><span>, results.size());
Assert.assertEquals(expectedTotalSizeInMB, results.get(</span><span><span class="hljs-number">0</span></span><span>).getValue(</span><span><span class="hljs-string">"total_size_mb"</span></span><span>), </span><span><span class="hljs-number">0.001</span></span><span>);
Assert.assertEquals(expectedTotalTimeInSec, results.get(</span><span><span class="hljs-number">0</span></span><span>).getValue(</span><span><span class="hljs-string">"total_time_sec"</span></span><span>), </span><span><span class="hljs-number">0.001</span></span><span>);
</span></span></code></div></div></pre>
</li>
</ul>
<hr data-start="3101" data-end="3104" class="">
<h3 data-start="3106" data-end="3146" class="">4. 🧪 Test Case: Aggregation Example</h3>
<h4 data-start="3148" data-end="3167" class="">Input Example:</h4>
<div class="pointer-events-none relative left-[50%]! flex w-[100cqw] translate-x-[-50%] justify-center *:pointer-events-auto"><div class="tableContainer horzScrollShadows">
data_transfer_size | response_time
-- | --
1.5MB | 150ms
500KB | 50ms
2MB | 200ms

</div></div>
<hr data-start="3632" data-end="3635" class="">
<h3 data-start="3637" data-end="3657" class="">5. 🤖 AI Tooling</h3>
<ul data-start="3659" data-end="3801">
<li data-start="3659" data-end="3723" class="">
<p data-start="3661" data-end="3723" class="">Record all prompts used with AI tools in a <code data-start="3704" data-end="3717">prompts.txt</code> file.</p>
</li>
<li data-start="3724" data-end="3801" class="">
<p data-start="3726" data-end="3734" class="">Example:</p>
<pre class="overflow-visible!" data-start="3737" data-end="3801"><div class="contain-inline-size rounded-md border-[0.5px] border-token-border-medium relative bg-token-sidebar-surface-primary"><div class="flex items-center text-token-text-secondary px-4 py-2 text-xs font-sans justify-between h-9 bg-token-sidebar-surface-primary dark:bg-token-main-surface-secondary select-none rounded-t-[5px]">vbnet</div><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-sidebar-surface-primary text-token-text-secondary dark:bg-token-main-surface-secondary flex items-center rounded-sm px-2 font-sans text-xs"><span class="" data-state="closed"><button class="flex gap-1 items-center select-none px-4 py-1" aria-label="Copy"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="icon-xs"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 5C7 3.34315 8.34315 2 10 2H19C20.6569 2 22 3.34315 22 5V14C22 15.6569 20.6569 17 19 17H17V19C17 20.6569 15.6569 22 14 22H5C3.34315 22 2 20.6569 2 19V10C2 8.34315 3.34315 7 5 7H7V5ZM9 7H14C15.6569 7 17 8.34315 17 10V15H19C19.5523 15 20 14.5523 20 14V5C20 4.44772 19.5523 4 19 4H10C9.44772 4 9 4.44772 9 5V7ZM5 9C4.44772 9 4 9.44772 4 10V19C4 19.5523 4.44772 20 5 20H14C14.5523 20 15 19.5523 15 19V10C15 9.44772 14.5523 9 14 9H5Z" fill="currentColor"></path></svg>Copy</button></span><span class="" data-state="closed"><button class="flex items-center gap-1 px-4 py-1 select-none"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="icon-xs"><path d="M2.5 5.5C4.3 5.2 5.2 4 5.5 2.5C5.8 4 6.7 5.2 8.5 5.5C6.7 5.8 5.8 7 5.5 8.5C5.2 7 4.3 5.8 2.5 5.5Z" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path><path d="M5.66282 16.5231L5.18413 19.3952C5.12203 19.7678 5.09098 19.9541 5.14876 20.0888C5.19933 20.2067 5.29328 20.3007 5.41118 20.3512C5.54589 20.409 5.73218 20.378 6.10476 20.3159L8.97693 19.8372C9.72813 19.712 10.1037 19.6494 10.4542 19.521C10.7652 19.407 11.0608 19.2549 11.3343 19.068C11.6425 18.8575 11.9118 18.5882 12.4503 18.0497L20 10.5C21.3807 9.11929 21.3807 6.88071 20 5.5C18.6193 4.11929 16.3807 4.11929 15 5.5L7.45026 13.0497C6.91175 13.5882 6.6425 13.8575 6.43197 14.1657C6.24513 14.4392 6.09299 14.7348 5.97903 15.0458C5.85062 15.3963 5.78802 15.7719 5.66282 16.5231Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M14.5 7L18.5 11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>Edit</button></span></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre!"><span><span><span class="hljs-symbol">Prompt:</span></span><span> </span><span><span class="hljs-string">"How to parse '10MB' into bytes using Java?"</span></span><span>
</span></span></code></div></div></pre>
</li>
</ul>
<hr data-start="3803" data-end="3806" class="">
<h3 data-start="3808" data-end="3839" class="">6. ✅ Deliverables Checklist</h3>
<ul data-start="3841" data-end="4130">
<li data-start="3841" data-end="3886" class="">
<p data-start="3843" data-end="3886" class="">✅ Forked repo with all code changes pushed.</p>
</li>
<li data-start="3887" data-end="3915" class="">
<p data-start="3889" data-end="3915" class="">✅ Modified <code data-start="3900" data-end="3915">Directives.g4</code></p>
</li>
<li data-start="3916" data-end="3953" class="">
<p data-start="3918" data-end="3953" class="">✅ New and updated Java source files</p>
</li>
<li data-start="3954" data-end="3998" class="">
<p data-start="3956" data-end="3998" class="">✅ Comprehensive tests for all new features</p>
</li>
<li data-start="3999" data-end="4040" class="">
<p data-start="4001" data-end="4040" class="">✅ A working build (<code data-start="4020" data-end="4039">mvn clean install</code>)</p>
</li>
<li data-start="4041" data-end="4079" class="">
<p data-start="4043" data-end="4079" class="">✅ <code data-start="4045" data-end="4058">prompts.txt</code> file (if applicable)</p>
</li>
<li data-start="4080" data-end="4130" class="">
<p data-start="4082" data-end="4130" class="">✅ Update <code data-start="4091" data-end="4102">README.md</code> with new usage instructions</p>
</li>
</ul>
<!--EndFragment-->
</body>
</html>