### PR TITLE
feat: Enhance Wrangler with Byte Size and Time Duration Units 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ These directives are currently available:
 | [Parse XML To JSON](wrangler-docs/directives/parse-xml-to-json.md)              | Parses an XML document into a JSON structure                     |
 | [Parse as Currency](wrangler-docs/directives/parse-as-currency.md)              | Parses a string representation of currency into a number.        |
 | [Parse as Datetime](wrangler-docs/directives/parse-as-datetime.md)              | Parses strings with datetime values to CDAP datetime type        |
+| [Parse as ByteSize](wrangler-docs/directives/parse-as-bytesize.md)              | Parses a string representation of byte size into a numeric value |
+| [Parse as TimeDuration](wrangler-docs/directives/parse-as-timeduration.md)      | Parses a string representation of time duration into a numeric value |
 | **Output Formatters**                                                  |                                                                  |
 | [Write as CSV](wrangler-docs/directives/write-as-csv.md)                        | Converts a record into CSV format                                |
 | [Write as JSON](wrangler-docs/directives/write-as-json-map.md)                  | Converts the record into a JSON map                              |

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -6,22 +6,23 @@ import io.cdap.wrangler.api.annotations.PublicEvolving;
 
 /**
  * Represents a Token for ByteSize, capable of parsing a size string
- * (e.g., "10KB") and converting it to a canonical unit (bytes).
+ * (e.g., "10KB", "1.5MB") and converting it to a canonical unit (bytes).
  */
 @PublicEvolving
 public class ByteSize implements Token {
 
+    // Use double for multipliers to handle fractional input accurately before casting
+    private static final double KILOBYTE = 1024.0;
+    private static final double MEGABYTE = KILOBYTE * 1024.0;
+    private static final double GIGABYTE = MEGABYTE * 1024.0;
+    private static final double TERABYTE = GIGABYTE * 1024.0; // Added Terabyte
 
-    private static final long KILOBYTE = 1024L;
-    private static final long MEGABYTE = KILOBYTE * 1024L;
-    private static final long GIGABYTE = MEGABYTE * 1024L;
-
-    private final long value;
+    private final long value; // Store final value in bytes as long
 
     /**
      * Constructs a ByteSizeToken by parsing the given size string.
      *
-     * @param value The size string to parse (e.g., "10KB", "150MB").
+     * @param value The size string to parse (e.g., "10KB", "1.5MB").
      * @throws IllegalArgumentException If the size string is invalid.
      */
     public ByteSize(String value) {
@@ -30,10 +31,11 @@ public class ByteSize implements Token {
 
     /**
      * Parses the given size string and converts it into bytes.
+     * Handles integer and floating-point numbers.
      *
      * @param sizeString The size string to parse.
-     * @return The size in bytes.
-     * @throws IllegalArgumentException If the size string is invalid.
+     * @return The size in bytes (truncated to long).
+     * @throws IllegalArgumentException If the size string format or unit is invalid.
      */
     private long parseSize(String sizeString) {
         if (sizeString == null || sizeString.trim().isEmpty()) {
@@ -41,16 +43,43 @@ public class ByteSize implements Token {
         }
 
         sizeString = sizeString.trim().toUpperCase();
-        if (sizeString.endsWith("KB")) {
-            return Long.parseLong(sizeString.replace("KB", "")) * KILOBYTE;
-        } else if (sizeString.endsWith("MB")) {
-            return Long.parseLong(sizeString.replace("MB", "")) * MEGABYTE;
-        } else if (sizeString.endsWith("GB")) {
-            return Long.parseLong(sizeString.replace("GB", "")) * GIGABYTE;
-        } else if (sizeString.endsWith("B")) {
-            return Long.parseLong(sizeString.replace("B", ""));
-        } else {
-            throw new IllegalArgumentException("Unsupported size unit in string: " + sizeString);
+        String numericPart;
+        double multiplier;
+
+        try {
+            if (sizeString.endsWith("KB")) {
+                numericPart = sizeString.substring(0, sizeString.length() - 2);
+                multiplier = KILOBYTE;
+            } else if (sizeString.endsWith("MB")) {
+                numericPart = sizeString.substring(0, sizeString.length() - 2);
+                multiplier = MEGABYTE;
+            } else if (sizeString.endsWith("GB")) {
+                numericPart = sizeString.substring(0, sizeString.length() - 2);
+                multiplier = GIGABYTE;
+            } else if (sizeString.endsWith("TB")) { // Added Terabyte
+                numericPart = sizeString.substring(0, sizeString.length() - 2);
+                multiplier = TERABYTE;
+            } else if (sizeString.endsWith("B")) {
+                numericPart = sizeString.substring(0, sizeString.length() - 1);
+                multiplier = 1.0;
+            } else {
+                // Match the test's expected generic message format
+                throw new IllegalArgumentException("Invalid byte size format or unsupported unit in string: " + sizeString);
+            }
+
+            if (numericPart.isEmpty()) {
+                throw new IllegalArgumentException("Missing numeric value in size string: " + sizeString);
+            }
+
+            double parsedValue = Double.parseDouble(numericPart);
+            if (parsedValue < 0) {
+                throw new IllegalArgumentException("Size value cannot be negative: " + sizeString);
+            }
+            // Cast to long truncates fractional bytes, which is reasonable for byte sizes.
+            return (long) (parsedValue * multiplier);
+
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid numeric value in size string: " + sizeString, e);
         }
     }
 
@@ -64,31 +93,41 @@ public class ByteSize implements Token {
     }
 
     /**
-     * Returns the size in kilobytes.
+     * Returns the size in kilobytes (double for potential fractions).
      *
      * @return The size in kilobytes.
      */
-    public long getKiloBytes() {
-        return value/KILOBYTE;
+    public double getKiloBytes() {
+        return value / KILOBYTE;
     }
 
     /**
-     * Returns the size in megabytes.
+     * Returns the size in megabytes (double for potential fractions).
      *
      * @return The size in megabytes.
      */
-    public long getMegaBytes() {
-        return value/MEGABYTE;
+    public double getMegaBytes() {
+        return value / MEGABYTE;
     }
 
     /**
-     * Returns the size in megabytes.
+     * Returns the size in gigabytes (double for potential fractions).
      *
-     * @return The size in megabytes.
+     * @return The size in gigabytes.
      */
-    public long getGigaBytes() {
-        return value/GIGABYTE;
+    public double getGigaBytes() {
+        return value / GIGABYTE;
     }
+
+    /**
+     * Returns the size in terabytes (double for potential fractions).
+     *
+     * @return The size in terabytes.
+     */
+    public double getTeraBytes() {
+        return value / TERABYTE;
+    }
+
 
     @Override
     public Object value() {
@@ -104,7 +143,14 @@ public class ByteSize implements Token {
     public JsonElement toJson() {
         JsonObject object = new JsonObject();
         object.addProperty("type", TokenType.BYTE_SIZE.name());
-        object.addProperty("value", value);
+        object.addProperty("value", value); // Store the canonical long value
         return object;
+    }
+
+    @Override
+    public String toString() {
+        // Provide a reasonable string representation, maybe the original input if stored,
+        // or reconstruct from the byte value. For simplicity, just return bytes.
+        return value + "B";
     }
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,7 +1,6 @@
 package io.cdap.wrangler.api.parser;
 
 import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import io.cdap.wrangler.api.annotations.PublicEvolving;
 

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,111 @@
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+/**
+ * Represents a Token for ByteSize, capable of parsing a size string
+ * (e.g., "10KB") and converting it to a canonical unit (bytes).
+ */
+@PublicEvolving
+public class ByteSize implements Token {
+
+
+    private static final long KILOBYTE = 1024L;
+    private static final long MEGABYTE = KILOBYTE * 1024L;
+    private static final long GIGABYTE = MEGABYTE * 1024L;
+
+    private final long value;
+
+    /**
+     * Constructs a ByteSizeToken by parsing the given size string.
+     *
+     * @param value The size string to parse (e.g., "10KB", "150MB").
+     * @throws IllegalArgumentException If the size string is invalid.
+     */
+    public ByteSize(String value) {
+        this.value = parseSize(value);
+    }
+
+    /**
+     * Parses the given size string and converts it into bytes.
+     *
+     * @param sizeString The size string to parse.
+     * @return The size in bytes.
+     * @throws IllegalArgumentException If the size string is invalid.
+     */
+    private long parseSize(String sizeString) {
+        if (sizeString == null || sizeString.trim().isEmpty()) {
+            throw new IllegalArgumentException("Size string must not be null or empty.");
+        }
+
+        sizeString = sizeString.trim().toUpperCase();
+        if (sizeString.endsWith("KB")) {
+            return Long.parseLong(sizeString.replace("KB", "")) * KILOBYTE;
+        } else if (sizeString.endsWith("MB")) {
+            return Long.parseLong(sizeString.replace("MB", "")) * MEGABYTE;
+        } else if (sizeString.endsWith("GB")) {
+            return Long.parseLong(sizeString.replace("GB", "")) * GIGABYTE;
+        } else if (sizeString.endsWith("B")) {
+            return Long.parseLong(sizeString.replace("B", ""));
+        } else {
+            throw new IllegalArgumentException("Unsupported size unit in string: " + sizeString);
+        }
+    }
+
+    /**
+     * Returns the size in bytes.
+     *
+     * @return The size in bytes.
+     */
+    public long getBytes() {
+        return value;
+    }
+
+    /**
+     * Returns the size in kilobytes.
+     *
+     * @return The size in kilobytes.
+     */
+    public long getKiloBytes() {
+        return value/KILOBYTE;
+    }
+
+    /**
+     * Returns the size in megabytes.
+     *
+     * @return The size in megabytes.
+     */
+    public long getMegaBytes() {
+        return value/MEGABYTE;
+    }
+
+    /**
+     * Returns the size in megabytes.
+     *
+     * @return The size in megabytes.
+     */
+    public long getGigaBytes() {
+        return value/GIGABYTE;
+    }
+
+    @Override
+    public Object value() {
+        return value;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.BYTE_SIZE.name());
+        object.addProperty("value", value);
+        return object;
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
 package io.cdap.wrangler.api.parser;
 
 import com.google.gson.JsonElement;

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright © 2017-2019 Cask Data, Inc.
+ *  Copyright © 2023 Google LLC // Update copyright year/holder if needed
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
  *  use this file except in compliance with the License. You may obtain a copy of
@@ -24,20 +25,21 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Represents a Token for TimeDuration, capable of parsing a duration string
- * (e.g., "5ms", "2.1s") and converting it to a canonical unit (nanoseconds).
+ * (e.g., "5ms", "2.1s") and converting it to a canonical unit (milliseconds).
  */
 @PublicEvolving
 public class TimeDuration implements Token {
 
-    // Multipliers to convert units to nanoseconds (use double for accuracy with fractions)
-    private static final double NANOS_PER_MICROSECOND = 1_000.0;
-    private static final double NANOS_PER_MILLISECOND = 1_000_000.0;
-    private static final double NANOS_PER_SECOND = 1_000_000_000.0;
-    private static final double NANOS_PER_MINUTE = 60.0 * NANOS_PER_SECOND;
-    private static final double NANOS_PER_HOUR = 60.0 * NANOS_PER_MINUTE;
-    private static final double NANOS_PER_DAY = 24.0 * NANOS_PER_HOUR;
+    // Multipliers to convert units to MILLISECONDS
+    private static final double MILLIS_PER_NANOSECOND = 1.0 / 1_000_000.0;
+    private static final double MILLIS_PER_MICROSECOND = 1.0 / 1_000.0;
+    private static final double MILLIS_PER_SECOND = 1_000.0;
+    private static final double MILLIS_PER_MINUTE = 60.0 * MILLIS_PER_SECOND;
+    private static final double MILLIS_PER_HOUR = 60.0 * MILLIS_PER_MINUTE;
+    private static final double MILLIS_PER_DAY = 24.0 * MILLIS_PER_HOUR;
 
-    private final long value; // Store final value in nanoseconds as long
+    // Store final value in milliseconds as double for precision
+    private final double value;
 
     /**
      * Constructs a TimeDuration by parsing the given duration string.
@@ -50,14 +52,14 @@ public class TimeDuration implements Token {
     }
 
     /**
-     * Parses the given duration string and converts it into nanoseconds.
+     * Parses the given duration string and converts it into milliseconds.
      * Handles integer and floating-point numbers.
      *
      * @param durationString The duration string to parse.
-     * @return The duration in nanoseconds (truncated to long).
+     * @return The duration in milliseconds.
      * @throws IllegalArgumentException If the duration string format or unit is invalid.
      */
-    private long parseDuration(String durationString) {
+    private double parseDuration(String durationString) {
         if (durationString == null || durationString.trim().isEmpty()) {
             throw new IllegalArgumentException("Duration string must not be null or empty.");
         }
@@ -70,30 +72,29 @@ public class TimeDuration implements Token {
         try {
             if (durationString.endsWith("ns")) {
                 numericPart = durationString.substring(0, durationString.length() - 2);
-                multiplier = 1.0;
+                multiplier = MILLIS_PER_NANOSECOND;
             } else if (durationString.endsWith("us")) {
                 numericPart = durationString.substring(0, durationString.length() - 2);
-                multiplier = NANOS_PER_MICROSECOND;
+                multiplier = MILLIS_PER_MICROSECOND;
             } else if (durationString.endsWith("ms")) {
                 numericPart = durationString.substring(0, durationString.length() - 2);
-                multiplier = NANOS_PER_MILLISECOND;
+                multiplier = 1.0; // Already in milliseconds
             } else if (durationString.endsWith("s")) {
                 numericPart = durationString.substring(0, durationString.length() - 1);
-                multiplier = NANOS_PER_SECOND;
-            } else if (durationString.endsWith("min")) { // Support "min" as requested by test
+                multiplier = MILLIS_PER_SECOND;
+            } else if (durationString.endsWith("min")) {
                 numericPart = durationString.substring(0, durationString.length() - 3);
-                multiplier = NANOS_PER_MINUTE;
-            } else if (durationString.endsWith("m")) { // Also support "m" for minutes
+                multiplier = MILLIS_PER_MINUTE;
+            } else if (durationString.endsWith("m")) {
                 numericPart = durationString.substring(0, durationString.length() - 1);
-                multiplier = NANOS_PER_MINUTE;
+                multiplier = MILLIS_PER_MINUTE;
             } else if (durationString.endsWith("h")) {
                 numericPart = durationString.substring(0, durationString.length() - 1);
-                multiplier = NANOS_PER_HOUR;
+                multiplier = MILLIS_PER_HOUR;
             } else if (durationString.endsWith("d")) {
                 numericPart = durationString.substring(0, durationString.length() - 1);
-                multiplier = NANOS_PER_DAY;
+                multiplier = MILLIS_PER_DAY;
             } else {
-                // Match the test's expected generic message format
                 throw new IllegalArgumentException("Invalid time duration format or unsupported unit in string: " + durationString);
             }
 
@@ -105,8 +106,8 @@ public class TimeDuration implements Token {
             if (parsedValue < 0) {
                 throw new IllegalArgumentException("Duration value cannot be negative: " + durationString);
             }
-            // Cast to long truncates fractional nanoseconds.
-            return (long) (parsedValue * multiplier);
+            // Calculate the value in milliseconds
+            return parsedValue * multiplier;
 
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid numeric value in duration string: " + durationString, e);
@@ -115,28 +116,29 @@ public class TimeDuration implements Token {
 
     /**
      * Returns the duration in the specified TimeUnit.
-     * Note: Conversion might lose precision due to integer division.
+     * Note: Conversion might lose precision due to intermediate long conversion.
      *
      * @param unit The TimeUnit to convert to.
      * @return The duration in the specified unit.
      */
     public long getDuration(TimeUnit unit) {
-        return unit.convert(this.value, TimeUnit.NANOSECONDS);
+        // Convert internal milliseconds value to the target unit
+        return unit.convert((long) this.value, TimeUnit.MILLISECONDS);
     }
 
     /**
-     * Returns the duration in nanoseconds.
+     * Returns the duration in milliseconds.
      * This is the canonical value.
      *
-     * @return The duration in nanoseconds.
+     * @return The duration in milliseconds.
      */
-    public long getValue() {
+    public double getValue() {
         return value;
     }
 
     @Override
     public Object value() {
-        return value; // Return the canonical long value (nanoseconds)
+        return value; // Return the canonical double value (milliseconds)
     }
 
     @Override
@@ -148,14 +150,13 @@ public class TimeDuration implements Token {
     public JsonElement toJson() {
         JsonObject object = new JsonObject();
         object.addProperty("type", TokenType.TIME_DURATION.name());
-        object.addProperty("value", value); // Store the canonical long value
+        object.addProperty("value", value); // Store the canonical double value
         return object;
     }
 
     @Override
     public String toString() {
-        // Provide a reasonable string representation, maybe the original input if stored,
-        // or reconstruct. For simplicity, just return nanoseconds.
-        return value + "ns";
+        // Provide a reasonable string representation
+        return value + "ms";
     }
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
 package io.cdap.wrangler.api.parser;
 
 import com.google.gson.JsonElement;

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,197 @@
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents a Token for TimeDuration, capable of parsing a duration string
+ * (e.g., "150ms", "2h") and converting it to a canonical unit (nanoseconds).
+ */
+@PublicEvolving
+public class TimeDuration implements Token {
+
+    // Pattern supports common time units: ns, us, ms, s, m, h, d
+    // Allows optional whitespace between number and unit
+    private static final Pattern DURATION_PATTERN = Pattern.compile(
+            "(\\d+)\\s*(ns|us|ms|s|m|h|d)", Pattern.CASE_INSENSITIVE);
+
+    private final long value;
+
+    /**
+     * Constructs a TimeDuration token by parsing the given duration string.
+     *
+     * @param durationString The duration string to parse (e.g., "150ms", "2h", "1d"). Case-insensitive.
+     * @throws IllegalArgumentException If the duration string format is invalid or results in overflow.
+     */
+    public TimeDuration(String durationString) {
+        this.value = parseDuration(durationString);
+    }
+
+    /**
+     * Parses the given duration string and converts it into nanoseconds.
+     *
+     * @param token The duration string to parse.
+     * @return The duration in nanoseconds.
+     * @throws IllegalArgumentException If the duration string format is invalid or results in overflow.
+     */
+    private long parseDuration(String token) {
+        if (token.trim().isEmpty()) {
+            throw new IllegalArgumentException("Duration string must not be empty.");
+        }
+
+        Matcher matcher = DURATION_PATTERN.matcher(token.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid time duration format: '%s'. Expected format like '10s', '150ms', '2h'.", token)
+            );
+        }
+
+        try {
+            long value = Long.parseLong(matcher.group(1));
+            String unit = matcher.group(2).toLowerCase();
+            long calculatedNanos;
+
+            switch (unit) {
+                case "ns":
+                    calculatedNanos = value;
+                    break;
+                case "us":
+                    calculatedNanos = TimeUnit.MICROSECONDS.toNanos(value);
+                    // Check for overflow: if input > 0 and output <= 0 (and not the trivial 0 case)
+                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
+                    break;
+                case "ms":
+                    calculatedNanos = TimeUnit.MILLISECONDS.toNanos(value);
+                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
+                    break;
+                case "s":
+                    calculatedNanos = TimeUnit.SECONDS.toNanos(value);
+                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
+                    break;
+                case "m":
+                    calculatedNanos = TimeUnit.MINUTES.toNanos(value);
+                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
+                    break;
+                case "h":
+                    calculatedNanos = TimeUnit.HOURS.toNanos(value);
+                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
+                    break;
+                case "d":
+                    calculatedNanos = TimeUnit.DAYS.toNanos(value);
+                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
+                    break;
+                default:
+                    // Should not be reachable due to regex, but included for safety
+                    throw new IllegalArgumentException("Unsupported time unit: " + unit);
+            }
+            return calculatedNanos;
+
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid numeric value in duration string: '%s'", token), e);
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException(
+                    String.format("Duration value '%s' resulted in overflow when converting to nanoseconds.", token), e);
+        }
+    }
+
+    /**
+     * Returns the duration value in the canonical unit (nanoseconds).
+     * Note: The Token interface returns Object, but this implementation
+     * specifically returns a Long representing nanoseconds.
+     *
+     * @return The duration in nanoseconds as a Long.
+     */
+    @Override
+    public Long value() {
+        return value;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    /**
+     * Returns the duration in nanoseconds.
+     *
+     * @return The duration in nanoseconds.
+     */
+    public long getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the duration in microseconds.
+     * Note: Conversion from nanoseconds might truncate.
+     *
+     * @return The duration in microseconds.
+     */
+    public long getMicroseconds() {
+        return TimeUnit.NANOSECONDS.toMicros(value);
+    }
+
+    /**
+     * Returns the duration in milliseconds.
+     * Note: Conversion from nanoseconds might truncate.
+     *
+     * @return The duration in milliseconds.
+     */
+    public long getMilliseconds() {
+        return TimeUnit.NANOSECONDS.toMillis(value);
+    }
+
+    /**
+     * Returns the duration in seconds.
+     * Note: Conversion from nanoseconds might truncate.
+     *
+     * @return The duration in seconds.
+     */
+    public long getSeconds() {
+        return TimeUnit.NANOSECONDS.toSeconds(value);
+    }
+
+    /**
+     * Returns the duration in minutes.
+     * Note: Conversion from nanoseconds might truncate.
+     *
+     * @return The duration in minutes.
+     */
+    public long getMinutes() {
+        return TimeUnit.NANOSECONDS.toMinutes(value);
+    }
+
+    /**
+     * Returns the duration in hours.
+     * Note: Conversion from nanoseconds might truncate.
+     *
+     * @return The duration in hours.
+     */
+    public long getHours() {
+        return TimeUnit.NANOSECONDS.toHours(value);
+    }
+
+    /**
+     * Returns the duration in days.
+     * Note: Conversion from nanoseconds might truncate.
+     *
+     * @return The duration in days.
+     */
+    public long getDays() {
+        return TimeUnit.NANOSECONDS.toDays(value);
+    }
+
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.TIME_DURATION.name());
+        object.addProperty("value", value);
+        return object;
+    }
+
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -3,121 +3,114 @@ package io.cdap.wrangler.api.parser;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.cdap.wrangler.api.annotations.PublicEvolving;
+
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Represents a Token for TimeDuration, capable of parsing a duration string
- * (e.g., "150ms", "2h") and converting it to a canonical unit (nanoseconds).
+ * (e.g., "5ms", "2.1s") and converting it to a canonical unit (nanoseconds).
  */
 @PublicEvolving
 public class TimeDuration implements Token {
 
-    // Pattern supports common time units: ns, us, ms, s, m, h, d
-    // Allows optional whitespace between number and unit
-    private static final Pattern DURATION_PATTERN = Pattern.compile(
-            "(\\d+)\\s*(ns|us|ms|s|m|h|d)", Pattern.CASE_INSENSITIVE);
+    // Multipliers to convert units to nanoseconds (use double for accuracy with fractions)
+    private static final double NANOS_PER_MICROSECOND = 1_000.0;
+    private static final double NANOS_PER_MILLISECOND = 1_000_000.0;
+    private static final double NANOS_PER_SECOND = 1_000_000_000.0;
+    private static final double NANOS_PER_MINUTE = 60.0 * NANOS_PER_SECOND;
+    private static final double NANOS_PER_HOUR = 60.0 * NANOS_PER_MINUTE;
+    private static final double NANOS_PER_DAY = 24.0 * NANOS_PER_HOUR;
 
-    private final long value;
+    private final long value; // Store final value in nanoseconds as long
 
     /**
-     * Constructs a TimeDuration token by parsing the given duration string.
+     * Constructs a TimeDuration by parsing the given duration string.
      *
-     * @param durationString The duration string to parse (e.g., "150ms", "2h", "1d"). Case-insensitive.
-     * @throws IllegalArgumentException If the duration string format is invalid or results in overflow.
+     * @param value The duration string to parse (e.g., "5ms", "2.1s").
+     * @throws IllegalArgumentException If the duration string is invalid.
      */
-    public TimeDuration(String durationString) {
-        this.value = parseDuration(durationString);
+    public TimeDuration(String value) {
+        this.value = parseDuration(value);
     }
 
     /**
      * Parses the given duration string and converts it into nanoseconds.
+     * Handles integer and floating-point numbers.
      *
-     * @param token The duration string to parse.
-     * @return The duration in nanoseconds.
-     * @throws IllegalArgumentException If the duration string format is invalid or results in overflow.
+     * @param durationString The duration string to parse.
+     * @return The duration in nanoseconds (truncated to long).
+     * @throws IllegalArgumentException If the duration string format or unit is invalid.
      */
-    private long parseDuration(String token) {
-        if (token.trim().isEmpty()) {
-            throw new IllegalArgumentException("Duration string must not be empty.");
+    private long parseDuration(String durationString) {
+        if (durationString == null || durationString.trim().isEmpty()) {
+            throw new IllegalArgumentException("Duration string must not be null or empty.");
         }
 
-        Matcher matcher = DURATION_PATTERN.matcher(token.trim());
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException(
-                    String.format("Invalid time duration format: '%s'. Expected format like '10s', '150ms', '2h'.", token)
-            );
-        }
+        // Use lowercase for units consistency
+        durationString = durationString.trim().toLowerCase();
+        String numericPart;
+        double multiplier;
 
         try {
-            long value = Long.parseLong(matcher.group(1));
-            String unit = matcher.group(2).toLowerCase();
-            long calculatedNanos;
-
-            switch (unit) {
-                case "ns":
-                    calculatedNanos = value;
-                    break;
-                case "us":
-                    calculatedNanos = TimeUnit.MICROSECONDS.toNanos(value);
-                    // Check for overflow: if input > 0 and output <= 0 (and not the trivial 0 case)
-                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
-                    break;
-                case "ms":
-                    calculatedNanos = TimeUnit.MILLISECONDS.toNanos(value);
-                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
-                    break;
-                case "s":
-                    calculatedNanos = TimeUnit.SECONDS.toNanos(value);
-                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
-                    break;
-                case "m":
-                    calculatedNanos = TimeUnit.MINUTES.toNanos(value);
-                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
-                    break;
-                case "h":
-                    calculatedNanos = TimeUnit.HOURS.toNanos(value);
-                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
-                    break;
-                case "d":
-                    calculatedNanos = TimeUnit.DAYS.toNanos(value);
-                    if (value > 0 && calculatedNanos <= 0) throw new ArithmeticException("long overflow");
-                    break;
-                default:
-                    // Should not be reachable due to regex, but included for safety
-                    throw new IllegalArgumentException("Unsupported time unit: " + unit);
+            if (durationString.endsWith("ns")) {
+                numericPart = durationString.substring(0, durationString.length() - 2);
+                multiplier = 1.0;
+            } else if (durationString.endsWith("us")) {
+                numericPart = durationString.substring(0, durationString.length() - 2);
+                multiplier = NANOS_PER_MICROSECOND;
+            } else if (durationString.endsWith("ms")) {
+                numericPart = durationString.substring(0, durationString.length() - 2);
+                multiplier = NANOS_PER_MILLISECOND;
+            } else if (durationString.endsWith("s")) {
+                numericPart = durationString.substring(0, durationString.length() - 1);
+                multiplier = NANOS_PER_SECOND;
+            } else if (durationString.endsWith("min")) { // Support "min" as requested by test
+                numericPart = durationString.substring(0, durationString.length() - 3);
+                multiplier = NANOS_PER_MINUTE;
+            } else if (durationString.endsWith("m")) { // Also support "m" for minutes
+                numericPart = durationString.substring(0, durationString.length() - 1);
+                multiplier = NANOS_PER_MINUTE;
+            } else if (durationString.endsWith("h")) {
+                numericPart = durationString.substring(0, durationString.length() - 1);
+                multiplier = NANOS_PER_HOUR;
+            } else if (durationString.endsWith("d")) {
+                numericPart = durationString.substring(0, durationString.length() - 1);
+                multiplier = NANOS_PER_DAY;
+            } else {
+                // Match the test's expected generic message format
+                throw new IllegalArgumentException("Invalid time duration format or unsupported unit in string: " + durationString);
             }
-            return calculatedNanos;
+
+            if (numericPart.isEmpty()) {
+                throw new IllegalArgumentException("Missing numeric value in duration string: " + durationString);
+            }
+
+            double parsedValue = Double.parseDouble(numericPart);
+            if (parsedValue < 0) {
+                throw new IllegalArgumentException("Duration value cannot be negative: " + durationString);
+            }
+            // Cast to long truncates fractional nanoseconds.
+            return (long) (parsedValue * multiplier);
 
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(
-                    String.format("Invalid numeric value in duration string: '%s'", token), e);
-        } catch (ArithmeticException e) {
-            throw new IllegalArgumentException(
-                    String.format("Duration value '%s' resulted in overflow when converting to nanoseconds.", token), e);
+            throw new IllegalArgumentException("Invalid numeric value in duration string: " + durationString, e);
         }
     }
 
     /**
-     * Returns the duration value in the canonical unit (nanoseconds).
-     * Note: The Token interface returns Object, but this implementation
-     * specifically returns a Long representing nanoseconds.
+     * Returns the duration in the specified TimeUnit.
+     * Note: Conversion might lose precision due to integer division.
      *
-     * @return The duration in nanoseconds as a Long.
+     * @param unit The TimeUnit to convert to.
+     * @return The duration in the specified unit.
      */
-    @Override
-    public Long value() {
-        return value;
-    }
-
-    @Override
-    public TokenType type() {
-        return TokenType.TIME_DURATION;
+    public long getDuration(TimeUnit unit) {
+        return unit.convert(this.value, TimeUnit.NANOSECONDS);
     }
 
     /**
      * Returns the duration in nanoseconds.
+     * This is the canonical value.
      *
      * @return The duration in nanoseconds.
      */
@@ -125,73 +118,28 @@ public class TimeDuration implements Token {
         return value;
     }
 
-    /**
-     * Returns the duration in microseconds.
-     * Note: Conversion from nanoseconds might truncate.
-     *
-     * @return The duration in microseconds.
-     */
-    public long getMicroseconds() {
-        return TimeUnit.NANOSECONDS.toMicros(value);
+    @Override
+    public Object value() {
+        return value; // Return the canonical long value (nanoseconds)
     }
 
-    /**
-     * Returns the duration in milliseconds.
-     * Note: Conversion from nanoseconds might truncate.
-     *
-     * @return The duration in milliseconds.
-     */
-    public long getMilliseconds() {
-        return TimeUnit.NANOSECONDS.toMillis(value);
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
     }
-
-    /**
-     * Returns the duration in seconds.
-     * Note: Conversion from nanoseconds might truncate.
-     *
-     * @return The duration in seconds.
-     */
-    public long getSeconds() {
-        return TimeUnit.NANOSECONDS.toSeconds(value);
-    }
-
-    /**
-     * Returns the duration in minutes.
-     * Note: Conversion from nanoseconds might truncate.
-     *
-     * @return The duration in minutes.
-     */
-    public long getMinutes() {
-        return TimeUnit.NANOSECONDS.toMinutes(value);
-    }
-
-    /**
-     * Returns the duration in hours.
-     * Note: Conversion from nanoseconds might truncate.
-     *
-     * @return The duration in hours.
-     */
-    public long getHours() {
-        return TimeUnit.NANOSECONDS.toHours(value);
-    }
-
-    /**
-     * Returns the duration in days.
-     * Note: Conversion from nanoseconds might truncate.
-     *
-     * @return The duration in days.
-     */
-    public long getDays() {
-        return TimeUnit.NANOSECONDS.toDays(value);
-    }
-
 
     @Override
     public JsonElement toJson() {
         JsonObject object = new JsonObject();
         object.addProperty("type", TokenType.TIME_DURATION.name());
-        object.addProperty("value", value);
+        object.addProperty("value", value); // Store the canonical long value
         return object;
     }
 
+    @Override
+    public String toString() {
+        // Provide a reasonable string representation, maybe the original input if stored,
+        // or reconstruct. For simplicity, just return nanoseconds.
+        return value + "ns";
+    }
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -40,6 +40,8 @@ import java.io.Serializable;
  * @see Expression
  * @see Text
  * @see TextList
+ * @see ByteSize
+ * @see TimeDuration
  */
 @PublicEvolving
 public enum TokenType implements Serializable {
@@ -152,5 +154,18 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
-}
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for the object of type {@code ByteSize}.
+   * This type is associated with a token representing a data size (e.g., "10KB", "1GB").
+   */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for the object of type {@code TimeDuration}.
+   * This type is associated with a token representing a time duration (e.g., "150ms", "2h").
+   */
+  TIME_DURATION
+
+  }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -126,6 +126,10 @@ public final class UsageDefinition implements Serializable {
           sb.append("prop:{key:value,[key:value]*");
         } else if (token.type().equals(TokenType.RANGES)) {
           sb.append("start:end=[bool|text|numeric][,start:end=[bool|text|numeric]*");
+        } else if (token.type().equals(TokenType.BYTE_SIZE)) {
+          sb.append(":").append(token.name());
+        } else if (token.type().equals(TokenType.TIME_DURATION)) {
+          sb.append(":").append(token.name());
         }
       }
 

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
@@ -41,21 +41,29 @@ public class ByteSizeAndTimeDurationTest {
 
     @Test
     public void testTimeDurationParsing() {
-        // Test parsing valid inputs to canonical time units
-        // Assuming TimeDuration.getValue() returns nanoseconds
+        // Test parsing valid inputs to canonical time units (milliseconds as double)
+        double delta = 0.0001; // Tolerance for double comparison
 
-        // 5ms -> 5 * 1,000,000 = 5,000,000 ns. Correct.
-        Assert.assertEquals(5000000L, new TimeDuration("5ms").getValue());
+        // 5ms -> 5.0 ms
+        Assert.assertEquals(5.0, new TimeDuration("5ms").getValue(), delta);
 
-        // 2.1s -> 2.1 * 1,000,000,000 = 2,100,000,000 ns. Correct.
-        Assert.assertEquals(2100000000L, new TimeDuration("2.1s").getValue());
+        // 2.1s -> 2.1 * 1000.0 = 2100.0 ms
+        Assert.assertEquals(2100.0, new TimeDuration("2.1s").getValue(), delta);
 
-        // 1h -> 1 * 60 * 60 * 1,000,000,000 = 3,600,000,000,000 ns. Correct.
-        Assert.assertEquals(3600000000000L, new TimeDuration("1h").getValue());
+        // 1h -> 1.0 * 60.0 * 60.0 * 1000.0 = 3,600,000.0 ms
+        Assert.assertEquals(3600000.0, new TimeDuration("1h").getValue(), delta);
 
         // Test for case insensitivity (using "min")
-        // 1.5min -> 1.5 * 60 * 1,000,000,000 = 90,000,000,000 ns. Correct.
-        Assert.assertEquals(90000000000L, new  TimeDuration("1.5min").getValue());
+        // 1.5min -> 1.5 * 60.0 * 1000.0 = 90,000.0 ms
+        Assert.assertEquals(90000.0, new TimeDuration("1.5min").getValue(), delta);
 
+        // Test other units (assuming they were added to TimeDuration)
+        // 1000us -> 1000.0 / 1000.0 = 1.0 ms
+        Assert.assertEquals(1.0, new TimeDuration("1000us").getValue(), delta);
+        // 5000000ns -> 5000000.0 / 1000000.0 = 5.0 ms
+        Assert.assertEquals(5.0, new TimeDuration("5000000ns").getValue(), delta);
+        // 1d -> 1.0 * 24.0 * 60.0 * 60.0 * 1000.0 = 86,400,000.0 ms
+        Assert.assertEquals(86400000.0, new TimeDuration("1d").getValue(), delta);
     }
+
 }

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
 package io.cdap.wrangler.api.parser;
 
 import io.cdap.wrangler.api.parser.ByteSize;

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
@@ -1,0 +1,45 @@
+package io.cdap.wrangler.api.parser;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for ByteSize and TimeDuration classes.
+ */
+public class ByteSizeAndTimeDurationTest {
+
+    @Test
+    public void testByteSizeParsing() {
+        // Test parsing valid inputs to canonical byte units
+        Assert.assertEquals(1024L, new ByteSize("1KB").getBytes());
+        Assert.assertEquals(1048576L, new ByteSize("1MB").getBytes());
+        Assert.assertEquals(1073741824L, new ByteSize("1GB").getBytes());
+        Assert.assertEquals(10, new ByteSize("10B").getBytes());
+
+        // Test for case insensitivity
+        Assert.assertEquals(1572864L, new ByteSize("1.5MB").getBytes());
+
+    }
+
+    @Test
+    public void testTimeDurationParsing() {
+        // Test parsing valid inputs to canonical time units
+        // Assuming TimeDuration.getValue() returns nanoseconds
+
+        // 5ms -> 5 * 1,000,000 = 5,000,000 ns. Correct.
+        Assert.assertEquals(5000000L, new TimeDuration("5ms").getValue());
+
+        // 2.1s -> 2.1 * 1,000,000,000 = 2,100,000,000 ns. Correct.
+        Assert.assertEquals(2100000000L, new TimeDuration("2.1s").getValue());
+
+        // 1h -> 1 * 60 * 60 * 1,000,000,000 = 3,600,000,000,000 ns. Correct.
+        Assert.assertEquals(3600000000000L, new TimeDuration("1h").getValue());
+
+        // Test for case insensitivity (using "min")
+        // 1.5min -> 1.5 * 60 * 1,000,000,000 = 90,000,000,000 ns. Correct.
+        Assert.assertEquals(90000000000L, new  TimeDuration("1.5min").getValue());
+
+    }
+}

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION
  ;
 
 ecommand
@@ -310,4 +310,20 @@ fragment Int
 
 fragment Digit
  : [0-9]
+ ;
+
+BYTE_SIZE
+ : Digit BYTE_UNIT
+ ;
+
+fragment BYTE_UNIT
+ : 'B' | 'KB' | 'MB' | 'GB' | 'TB'
+ ;
+
+TIME_DURATION
+ : Digit TIME_UNIT
+ ;
+
+fragment TIME_UNIT
+ : 's' | 'ms' | 'us' | 'ns' | 'm' | 'h' | 'd'
  ;

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,159 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Directive for aggregating statistics.
+ */
+@Plugin(type = Directive.TYPE)
+@Name(AggregateStats.NAME)
+@Categories(categories = { "data-aggregation"})
+public class AggregateStats implements Directive {
+    public static final String NAME = "aggregate-stats";
+    private String byteCol;
+    private String timeCol;
+    private String outputSizeCol;
+    private String outputTimeCol;
+    private double totalBytes = 0.0;
+    private double totalTimeMs = 0.0;
+    private int count = 0;
+
+    /**
+     * Defines the usage of the directive, specifying the required arguments.
+     *
+     * @return UsageDefinition object containing the directive's argument definitions.
+     */
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+        builder.define("byteCol", TokenType.COLUMN_NAME);
+        builder.define("timeCol", TokenType.COLUMN_NAME);
+        builder.define("outputSizeCol", TokenType.TEXT);
+        builder.define("outputTimeCol", TokenType.TEXT);
+        return builder.build();
+    }
+
+    /**
+     * Initializes the directive with the provided arguments.
+     *
+     * @param args Arguments object containing the directive's parameters.
+     * @throws DirectiveParseException if there is an error parsing the arguments.
+     */
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        byteCol = ((ColumnName) args.value("byteCol")).value();
+        timeCol = ((ColumnName) args.value("timeCol")).value();
+        outputSizeCol = ((Text) args.value("outputSizeCol")).value();
+        outputTimeCol = ((Text) args.value("outputTimeCol")).value();
+    }
+
+    /**
+     * Executes the directive on a list of rows, aggregating statistics based on the specified columns.
+     *
+     * @param rows List of Row objects to process.
+     * @param ctx ExecutorContext providing execution context information.
+     * @return List of Row objects containing the aggregated results.
+     * @throws DirectiveExecutionException if there is an error during execution.
+     */
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext ctx) throws DirectiveExecutionException {
+        try {
+            for (Row row : rows) {
+                if (row.find(byteCol) != -1 && row.find(timeCol) != -1) {
+                    String byteVal = row.getValue(byteCol).toString();
+                    String timeVal = row.getValue(timeCol).toString();
+
+                    // Use ByteSize and TimeDuration classes for parsing
+                    ByteSize byteSize = new ByteSize(byteVal);
+                    TimeDuration duration = new TimeDuration(timeVal);
+
+                    totalBytes += byteSize.getBytes();
+                    totalTimeMs += duration.getValue();
+                    count++;
+                }
+            }
+
+            if (count == 0) {
+                return new ArrayList<>();
+            }
+
+            List<Row> results = new ArrayList<>();
+            Row result = new Row();
+
+            // Convert bytes to MB and milliseconds to seconds
+            result.add(outputSizeCol, totalBytes / (1024.0 * 1024.0));
+            result.add(outputTimeCol, totalTimeMs / 1000.0);
+
+            results.add(result);
+            return results;
+
+        } catch (Exception e) {
+            throw new DirectiveExecutionException(
+                    String.format("Error aggregating stats: %s", e.getMessage())
+            );
+        }
+    }
+
+    /**
+     * Provides the output schema for the directive based on the input schema.
+     *
+     * @param inputSchema Schema object representing the input schema.
+     * @return Schema object representing the output schema.
+     */
+    public Schema getOutputSchema(Schema inputSchema) {
+        List<Schema.Field> fields = new ArrayList<>();
+        fields.add(Schema.Field.of(outputSizeCol, Schema.of(Schema.Type.DOUBLE)));
+        fields.add(Schema.Field.of(outputTimeCol, Schema.of(Schema.Type.DOUBLE)));
+        return Schema.recordOf("aggregate-stats", fields);
+    }
+
+    /**
+     * Cleans up resources and resets the directive's state.
+     */
+    @Override
+    public void destroy() {
+        // Reset all accumulated values
+        totalBytes = 0.0;
+        totalTimeMs = 0.0;
+        count = 0;
+
+        // Clear column references
+        byteCol = null;
+        timeCol = null;
+        outputSizeCol = null;
+        outputTimeCol = null;
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -20,20 +20,7 @@ import io.cdap.wrangler.api.LazyNumber;
 import io.cdap.wrangler.api.RecipeSymbol;
 import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
-import io.cdap.wrangler.api.parser.Bool;
-import io.cdap.wrangler.api.parser.BoolList;
-import io.cdap.wrangler.api.parser.ColumnName;
-import io.cdap.wrangler.api.parser.ColumnNameList;
-import io.cdap.wrangler.api.parser.DirectiveName;
-import io.cdap.wrangler.api.parser.Expression;
-import io.cdap.wrangler.api.parser.Identifier;
-import io.cdap.wrangler.api.parser.Numeric;
-import io.cdap.wrangler.api.parser.NumericList;
-import io.cdap.wrangler.api.parser.Properties;
-import io.cdap.wrangler.api.parser.Ranges;
-import io.cdap.wrangler.api.parser.Text;
-import io.cdap.wrangler.api.parser.TextList;
-import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.*;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -325,5 +312,27 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     int lineno = ctx.getStart().getLine();
     int column = ctx.getStart().getCharPositionInLine();
     return new SourceInfo(lineno, column, text);
+  }
+
+  @Override
+  public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
+    Token token;
+    if (ctx.Number() != null) {
+      token = new Numeric(new LazyNumber(ctx.Number().getText()));
+    } else if (ctx.Column() != null) {
+      token = new ColumnName(ctx.Column().getText().substring(1));
+    } else if (ctx.Bool() != null) {
+      token = new Bool(Boolean.valueOf(ctx.Bool().getText()));
+    } else if (ctx.BYTE_SIZE() != null) {
+      token = new ByteSize(ctx.BYTE_SIZE().getText());
+    } else if (ctx.TIME_DURATION() != null) {
+      token = new TimeDuration(ctx.TIME_DURATION().getText());
+    } else {
+      String text = ctx.String().getText();
+      token = new Text(text.substring(1, text.length() - 1));
+    }
+
+    builder.addToken(token);
+    return builder;
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,203 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import com.google.gson.JsonElement;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.TokenType;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AggregateStatsTest {
+
+    @Test
+    public void testAggregateStatsDirective() throws Exception {
+        // Step 1: Prepare input rows
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "10KB").add("response_time", "2s"));
+        rows.add(new Row().add("data_transfer_size", "5KB").add("response_time", "500ms"));
+
+        // Step 2: Create an instance of the directive
+        AggregateStats directive = new AggregateStats();
+
+        // Step 3: Manually mock Arguments
+        Arguments args = createMockArguments();
+
+        // Step 4: Initialize and execute the directive
+        directive.initialize(args);
+        List<Row> result = directive.execute(rows, null);
+
+        // Step 5: Validate output
+        Assert.assertEquals(1, result.size());
+
+        Row output = result.get(0);
+
+        // Size: 10KB + 5KB = 15KB = 15 * 1024 bytes = 15360 bytes
+        // MB = bytes / (1024 * 1024)
+        double expectedMB = 15360.0 / (1024 * 1024);
+        double actualMB = (Double) output.getValue("total_size_mb");
+
+        // Time: 2s + 500ms = 2500ms = 2.5s
+        double expectedSeconds = 2.5;
+        double actualSeconds = (Double) output.getValue("total_time_sec");
+
+        Assert.assertEquals(expectedMB, actualMB, 0.001);
+        Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+    }
+
+    @Test
+    public void testEmptyInputRows() throws Exception {
+        List<Row> rows = new ArrayList<>();
+
+        AggregateStats directive = new AggregateStats();
+        Arguments args = createMockArguments();
+
+        directive.initialize(args);
+        List<Row> result = directive.execute(rows, null);
+
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testInvalidData() throws Exception {
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "invalidKB").add("response_time", "invalidTime"));
+
+        AggregateStats directive = new AggregateStats();
+        Arguments args = createMockArguments();
+
+        directive.initialize(args);
+        try {
+            directive.execute(rows, null);
+            Assert.fail("Expected an exception for invalid data");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Error aggregating stats"));
+        }
+    }
+
+    @Test
+    public void testLargeData() throws Exception {
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "1024MB").add("response_time", "1h"));
+        rows.add(new Row().add("data_transfer_size", "512MB").add("response_time", "30m"));
+
+        AggregateStats directive = new AggregateStats();
+        Arguments args = createMockArguments();
+
+        directive.initialize(args);
+        List<Row> result = directive.execute(rows, null);
+
+        Assert.assertEquals(1, result.size());
+
+        Row output = result.get(0);
+
+        double expectedMB = 1536.0; // 1024MB + 512MB
+        double actualMB = (Double) output.getValue("total_size_mb");
+
+        double expectedSeconds = 5400.0; // 1h + 30m = 5400 seconds
+        double actualSeconds = (Double) output.getValue("total_time_sec");
+
+        Assert.assertEquals(expectedMB, actualMB, 0.001);
+        Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+    }
+
+    @Test
+    public void testEdgeCases() throws Exception {
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "0KB").add("response_time", "0s"));
+
+        AggregateStats directive = new AggregateStats();
+        Arguments args = createMockArguments();
+
+        directive.initialize(args);
+        List<Row> result = directive.execute(rows, null);
+
+        Assert.assertEquals(1, result.size());
+
+        Row output = result.get(0);
+
+        double expectedMB = 0.0;
+        double actualMB = (Double) output.getValue("total_size_mb");
+
+        double expectedSeconds = 0.0;
+        double actualSeconds = (Double) output.getValue("total_time_sec");
+
+        Assert.assertEquals(expectedMB, actualMB, 0.001);
+        Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+    }
+
+    private Arguments createMockArguments() {
+        return new Arguments() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T extends Token> T value(String name) {
+                switch (name) {
+                    case "byteCol":
+                        return (T) new ColumnName("data_transfer_size");
+                    case "timeCol":
+                        return (T) new ColumnName("response_time");
+                    case "outputSizeCol":
+                        return (T) new Text("total_size_mb");
+                    case "outputTimeCol":
+                        return (T) new Text("total_time_sec");
+                }
+                return null;
+            }
+
+            @Override
+            public int size() {
+                return 4;
+            }
+
+            @Override
+            public boolean contains(String name) {
+                return true;
+            }
+
+            @Override
+            public TokenType type(String name) {
+                return null;
+            }
+
+            @Override
+            public int line() {
+                return 1;
+            }
+
+            @Override
+            public int column() {
+                return 0;
+            }
+
+            @Override
+            public String source() {
+                return "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec";
+            }
+
+            @Override
+            public JsonElement toJson() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Integrate new lexer tokens (BYTE_SIZE, TIME_DURATION) into the Wrangler grammar. 
- Update the relevant Java code (wrangler-api, wrangler-core) to handle these new token types. 
- Implement a new aggregate directive (aggregate-stats) that utilizes these new types. 
- Develop comprehensive test cases, including aggregation scenarios using the new units. 
