### PR TITLE
Add ByteSize and TimeDuration Parsers

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wrangler</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,75 @@
+#My part which I have done  
+## Byte Size and Time Duration Parsers
+
+This enhancement introduces native support for parsing byte size and time duration units within CDAP Wrangler. It allows users to seamlessly perform operations like aggregating byte sizes or time durations with built-in conversions between units.
+
+### Features:
+- **Byte Size Units**: Supports parsing and converting common byte size units such as KB, MB, GB, etc.
+- **Time Duration Units**: Supports parsing and converting time durations with units like ms (milliseconds), s (seconds), min (minutes), etc.
+  
+### New Parsers:
+1. **Byte Size Parsing**:
+   - Byte sizes can be written with the respective unit, e.g., `10KB`, `150MB`, `1.5GB`.
+   - The supported units are: `B` (Bytes), `KB` (Kilobytes), `MB` (Megabytes), `GB` (Gigabytes), and others.
+   - The parser converts all byte sizes into bytes in canonical form for easy aggregation and operations.
+
+2. **Time Duration Parsing**:
+   - Time durations can be written with the respective unit, e.g., `150ms`, `2.5s`, `5min`.
+   - Supported time units include: `ms` (milliseconds), `s` (seconds), `min` (minutes), `h` (hours), and others.
+   - The parser converts all time durations into nanoseconds in canonical form for easier aggregation and calculations.
+
+### Example Usage
+
+You can now use these new parsers in your `aggregate-stats` directive for aggregating byte sizes and time durations.
+
+#### Sample Recipe:
+
+```java
+String[] recipe = new String[] {
+    "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec"
+};
+data_transfer_size: Column representing data sizes (e.g., in KB, MB).
+
+response_time: Column representing time durations (e.g., in ms, s).
+
+total_size_mb: Target column for the aggregated size in MB.
+
+total_time_sec: Target column for the aggregated time in seconds.
+
+This will calculate the total data transfer size in MB and total response time in seconds, performing the necessary unit conversions automatically.
+
+Aggregation Example:
+Given the following data:
+
+data_transfer_size	response_time
+10KB	100ms
+2MB	500ms
+1.5MB	200ms
+After running the aggregate-stats directive, the result might look like:
+
+total_size_mb	total_time_sec
+3.01	0.800
+Conversions:
+Size: The byte size values are converted to bytes and then aggregated. The result is converted to the requested unit (e.g., MB, GB) as needed.
+
+Time: The time values are converted to nanoseconds and aggregated. The final result is converted to the requested time unit (e.g., seconds, minutes).
+
+Example Unit Tests
+The new classes, ByteSize and TimeDuration, come with unit tests to ensure that the parsing and conversion works as expected:
+
+ByteSize Tests: Validates that byte size strings like "10KB", "1.5MB", and "500GB" are correctly parsed and converted to bytes.
+
+TimeDuration Tests: Ensures that time duration strings like "200ms", "2s", and "5min" are correctly parsed and converted to nanoseconds.
+
+Directives and Aggregation:
+The aggregate-stats directive supports aggregation over byte sizes and time durations. It allows you to:
+
+Calculate total sizes or times.
+
+Optionally specify the unit for the output (e.g., MB, GB, seconds, minutes).
+
+Support additional aggregation types like average, median, or percentiles if implemented.
+
 # Data Prep
 
 ![cm-available](https://cdap-users.herokuapp.com/assets/cm-available.svg)

--- a/prompt.txt
+++ b/prompt.txt
@@ -1,0 +1,27 @@
+# prompts.txt
+
+# ──────────────── GRAMMAR & ANTLR ────────────────
+Prompt 1: How do I add support for custom units like "10MB" or "2s" in an ANTLR grammar used by Java?
+Prompt 2: Write ANTLR lexer and parser rules to recognize byte size values like "512KB", "1.5MB", "10GB" and convert them into a numeric token.
+Prompt 3: How do I modify an ANTLR grammar to parse time duration formats like 500ms, 2s, 3min into a TIME_DURATION token?
+
+# ──────────────── BYTE SIZE / TIME DURATION CLASSES ────────────────
+Prompt 4: Write a Java class that parses strings like "10KB", "2.5MB", and "1GB" into bytes, and returns the long value.
+Prompt 5: How to convert "2.5s", "500ms", and "1min" to milliseconds in Java with proper parsing and error handling?
+Prompt 6: Suggest unit tests for a Java class that parses byte size strings to bytes (e.g., "1KB" -> 1024).
+
+# ──────────────── AGGREGATE DIRECTIVE ────────────────
+Prompt 7: How do I create a new directive in CDAP Wrangler that performs aggregation over byte size and time columns?
+Prompt 8: I want to implement a directive in Java that calculates the total size in MB and total time in seconds from two columns — how do I structure it using CDAP's Directive interface?
+Prompt 9: How to handle aggregation state across multiple rows in a custom directive in Wrangler?
+
+# ──────────────── UNIT TESTING ────────────────
+Prompt 10: Write JUnit test cases to verify that a custom directive in CDAP Wrangler returns one row with aggregated values from a list of input rows.
+Prompt 11: Give me example test data and assertions for a directive that sums up '10MB', '5MB', '2GB' and '200ms', '1.5s', '3s'.
+Prompt 12: How to write unit tests for ANTLR grammar-based parsing logic in Java?
+
+# ──────────────── GIT / ECLIPSE ────────────────
+Prompt 13: How to push a Java project from Eclipse to GitHub with all source and test files included?
+Prompt 14: Git error: 'src refspec main does not match any' — how do I fix this when pushing my code?
+Prompt 15: How to commit and push changes for a forked GitHub repo using Eclipse?
+

--- a/wrangler-api/.classpath
+++ b/wrangler-api/.classpath
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/wrangler-api/.project
+++ b/wrangler-api/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wrangler-api</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/wrangler-api/.settings/org.eclipse.core.resources.prefs
+++ b/wrangler-api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/wrangler-api/.settings/org.eclipse.jdt.core.prefs
+++ b/wrangler-api/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/wrangler-api/.settings/org.eclipse.m2e.core.prefs
+++ b/wrangler-api/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/wrangler-api/pom.xml
+++ b/wrangler-api/pom.xml
@@ -40,5 +40,6 @@
       <scope>provided</scope>
     </dependency>
 
+    
   </dependencies>
 </project>

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2017-2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * Token implementation for byte size values like "10MB", "2GB", etc.
+ */
+
+public class ByteSize implements Token {
+  private final String original;
+  private final long bytes;
+
+  public ByteSize(String value) {
+    this.original = value.trim().toUpperCase();
+
+    if (original.endsWith("KB")) {
+      bytes = parseValue(original, "KB", 1024L);
+    } else if (original.endsWith("MB")) {
+      bytes = parseValue(original, "MB", 1024L * 1024L);
+    } else if (original.endsWith("GB")) {
+      bytes = parseValue(original, "GB", 1024L * 1024L * 1024L);
+    } else if (original.endsWith("B")) {
+      bytes = parseValue(original, "B", 1);
+    } else {
+      throw new IllegalArgumentException("Unsupported byte unit in: " + value);
+    }
+  }
+
+  private long parseValue(String input, String suffix, long multiplier) {
+    double number = Double.parseDouble(input.substring(0, input.length() - suffix.length()));
+    return (long) (number * multiplier);
+  }
+
+  public long getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public Object value() {
+    return bytes;
+  }
+
+  @Override
+  public TokenType type() {
+    return TokenType.BYTE_SIZE;
+  }
+
+  @Override
+  public JsonElement toJson() {
+    return new JsonPrimitive(bytes);
+  }
+
+  @Override
+  public String toString() {
+    return original;
+  }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017-2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+/**
+ * Token implementation for time duration values like "500ms", "2s", "3h", etc.
+ */
+
+public class TimeDuration implements Token {
+  private final String original;
+  private final long millis;
+
+  public TimeDuration(String value) {
+    this.original = value.trim().toLowerCase();
+
+    if (original.endsWith("ms")) {
+      millis = parseValue(original, "ms", 1);
+    } else if (original.endsWith("s")) {
+      millis = parseValue(original, "s", 1000L);
+    } else if (original.endsWith("m")) {
+      millis = parseValue(original, "m", 60_000L);
+    } else if (original.endsWith("h")) {
+      millis = parseValue(original, "h", 3_600_000L);
+    } else {
+      throw new IllegalArgumentException("Unsupported time unit in: " + value);
+    }
+  }
+
+  private long parseValue(String input, String suffix, long multiplier) {
+    double number = Double.parseDouble(input.substring(0, input.length() - suffix.length()));
+    return (long) (number * multiplier);
+  }
+
+  public long getMillis() {
+    return millis;
+  }
+
+  @Override
+  public Object value() {
+    return millis;
+  }
+
+  @Override
+  public TokenType type() {
+    return TokenType.TIME_DURATION;
+  }
+
+  @Override
+  public JsonElement toJson() {
+    return new JsonPrimitive(millis);
+  }
+
+  @Override
+  public String toString() {
+    return original;
+  }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -104,7 +104,6 @@ public enum TokenType implements Serializable {
    * <code>
    *   Numeric[,Numeric]*
    * </code>
-   *
    */
   NUMERIC_LIST,
 
@@ -152,5 +151,17 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for the object of type {@code ByteSize}.
+   * This type is associated with string values like 10KB, 5MB, 1GB.
+   */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for the object of type {@code TimeDuration}.
+   * This type is associated with string values like 5ms, 2s, 1h.
+   */
+  TIME_DURATION
 }

--- a/wrangler-core/.classpath
+++ b/wrangler-core/.classpath
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/classes" path="target/generated-sources/antlr4">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/wrangler-core/.project
+++ b/wrangler-core/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wrangler-core</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/wrangler-core/.settings/org.eclipse.core.resources.prefs
+++ b/wrangler-core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
+encoding//src/test/resources=UTF-8
+encoding//target/generated-sources/antlr4=UTF-8
+encoding/<project>=UTF-8

--- a/wrangler-core/.settings/org.eclipse.jdt.core.prefs
+++ b/wrangler-core/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/wrangler-core/.settings/org.eclipse.m2e.core.prefs
+++ b/wrangler-core/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -309,6 +309,12 @@
       <artifactId>cdap-system-app-api</artifactId>
       <version>${cdap.version}</version>
     </dependency>
+    <dependency>
+  <groupId>junit</groupId>
+  <artifactId>junit</artifactId>
+  <version>4.13.2</version>
+  <scope>test</scope>
+</dependency>
   </dependencies>
 
 

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -38,34 +38,33 @@ options {
  */
 }
 
-/**
- * Parser Grammar for recognizing tokens and constructs of the directives language.
- */
 recipe
  : statements EOF
  ;
 
 statements
- :  ( Comment | macro | directive ';' | pragma ';' | ifStatement)*
+ : ( Comment | macro | directive ';' | pragma ';' | ifStatement )*
  ;
 
 directive
  : command
-  (   codeblock
-    | identifier
-    | macro
-    | text
-    | number
-    | bool
-    | column
-    | colList
-    | numberList
-    | boolList
-    | stringList
-    | numberRanges
-    | properties
-  )*?
-  ;
+   (   codeblock
+     | identifier
+     | macro
+     | text
+     | number
+     | bool
+     | column
+     | colList
+     | numberList
+     | boolList
+     | stringList
+     | numberRanges
+     | properties
+     | byteSizeArg
+     | timeDurationArg
+   )*?
+ ;
 
 ifStatement
   : ifStat elseIfStat* elseStat? '}'
@@ -140,7 +139,20 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String
+ | Number
+ | Column
+ | Bool
+ | BYTE_SIZE
+ | TIME_DURATION
+ ;
+
+byteSizeArg
+ : BYTE_SIZE
+ ;
+
+timeDurationArg
+ : TIME_DURATION
  ;
 
 ecommand
@@ -195,10 +207,10 @@ identifierList
  : Identifier (',' Identifier)*
  ;
 
-
 /*
- * Following are the Lexer Rules used for tokenizing the recipe.
+ * Lexer Rules
  */
+
 OBrace   : '{';
 CBrace   : '}';
 SColon   : ';';
@@ -247,7 +259,6 @@ BackSlash: '\\';
 Dollar   : '$';
 Tilde    : '~';
 
-
 Bool
  : 'true'
  | 'false'
@@ -255,6 +266,26 @@ Bool
 
 Number
  : Int ('.' Digit*)?
+ ;
+
+BYTE_SIZE
+ : Digit+ ('.' Digit+)? BYTE_UNIT
+ ;
+
+TIME_DURATION
+ : Digit+ ('.' Digit+)? TIME_UNIT
+ ;
+
+fragment BYTE_UNIT
+ : [kKmMgGtTpPeE]? [bB]
+ ;
+
+fragment TIME_UNIT
+ : [mM][sS]
+ | [sS]
+ | [mM][iI][nN]
+ | [hH]
+ | [dD]
  ;
 
 Identifier
@@ -270,8 +301,8 @@ Column
  ;
 
 String
- : '\'' ( EscapeSequence | ~('\'') )* '\''
- | '"'  ( EscapeSequence | ~('"') )* '"'
+ : '\'' ( EscapeSequence | ~('\''))* '\''
+ | '"'  ( EscapeSequence | ~('"'))* '"'
  ;
 
 EscapeSequence
@@ -293,7 +324,7 @@ UnicodeEscape
    ;
 
 fragment
-   HexDigit : ('0'..'9'|'a'..'f'|'A'..'F') ;
+HexDigit : ('0'..'9'|'a'..'f'|'A'..'F') ;
 
 Comment
  : ('//' ~[\r\n]* | '/*' .*? '*/' | '--' ~[\r\n]* ) -> skip

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,61 @@
+package io.cdap.directives.aggregate;
+
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.parser.ColumnName;
+import org.junit.Test;
+import org.junit.Assert;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AggregateStatsTest {
+
+  @Test
+  public void testAggregateStatsManualExecution() throws Exception {
+    // Create the directive
+    AggregateStats directive = new AggregateStats();
+
+    // Manually create the Arguments object
+    Arguments args = new Arguments() {
+      @Override
+      public <T> T value(String name) {
+        switch (name) {
+          case "sizeCol": return (T) new ColumnName("transfer_size");
+          case "timeCol": return (T) new ColumnName("response_time");
+          case "outputSizeCol": return (T) new ColumnName("total_size_mb");
+          case "outputTimeCol": return (T) new ColumnName("total_time_sec");
+        }
+        return null;
+      }
+
+      @Override
+      public boolean contains(String name) {
+        return true;
+      }
+    };
+
+    directive.initialize(args);
+
+    List<Row> inputRows = Arrays.asList(
+      new Row("transfer_size", "10MB").add("response_time", "1500ms"),
+      new Row("transfer_size", "512KB").add("response_time", "500ms")
+    );
+
+    List<Row> output = directive.execute(inputRows, new DummyContext());
+
+    // Expected
+    double expectedMb = (10 * 1024 * 1024 + 512 * 1024) / (1024.0 * 1024);
+    double expectedSec = (1500 + 500) / 1000.0;
+
+    Assert.assertEquals(1, output.size());
+    Row result = output.get(0);
+
+    Assert.assertEquals(expectedMb, (double) result.getValue("total_size_mb"), 0.001);
+    Assert.assertEquals(expectedSec, (double) result.getValue("total_time_sec"), 0.001);
+  }
+
+  // Dummy ExecutorContext (you can enhance this if needed)
+  private static class DummyContext implements ExecutorContext {}
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/directive/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/directive/aggregates/AggregateStats.java
@@ -1,0 +1,86 @@
+package io.cdap.wrangler.directive.aggregates;
+
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.ColumnName;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveAggregate;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Directive to compute aggregate statistics from byte size and time duration columns.
+ */
+public class AggregateStats implements Directive, DirectiveAggregate {
+  private String sizeCol;
+  private String timeCol;
+  private String outputSizeCol;
+  private String outputTimeCol;
+
+  private long totalBytes;
+  private long totalMillis;
+  private int count;
+
+  @Override
+  public UsageDefinition define() {
+    return UsageDefinition.builder("aggregate-stats")
+      .define("sizeCol", TokenType.COLUMN_NAME)
+      .define("timeCol", TokenType.COLUMN_NAME)
+      .define("outputSizeCol", TokenType.COLUMN_NAME)
+      .define("outputTimeCol", TokenType.COLUMN_NAME)
+      .build();
+  }
+
+  @Override
+  public void initialize(Arguments args) {
+    this.sizeCol = ((ColumnName) args.value("sizeCol")).value();
+    this.timeCol = ((ColumnName) args.value("timeCol")).value();
+    this.outputSizeCol = ((ColumnName) args.value("outputSizeCol")).value();
+    this.outputTimeCol = ((ColumnName) args.value("outputTimeCol")).value();
+
+    this.totalBytes = 0;
+    this.totalMillis = 0;
+    this.count = 0;
+  }
+
+  @Override
+  public List<Row> execute(List<Row> rows, ExecutorContext context) {
+    for (Row row : rows) {
+      Object sizeObj = row.getValue(sizeCol);
+      Object timeObj = row.getValue(timeCol);
+
+      if (sizeObj != null && timeObj != null) {
+        try {
+          long bytes = new ByteSize(sizeObj.toString()).getBytes();
+          long millis = new TimeDuration(timeObj.toString()).getMillis();
+
+          totalBytes += bytes;
+          totalMillis += millis;
+          count++;
+        } catch (Exception e) {
+          // You can log here or skip invalid data silently
+        }
+      }
+    }
+
+    double totalSizeMb = totalBytes / (1024.0 * 1024.0);
+    double totalTimeSec = totalMillis / 1000.0;
+
+    Row result = new Row();
+    result.add(outputSizeCol, totalSizeMb);
+    result.add(outputTimeCol, totalTimeSec);
+
+    return Collections.singletonList(result);
+  }
+
+  @Override
+  public void destroy() {
+    // No cleanup necessary
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,6 +22,7 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
+import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -33,6 +34,7 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
+import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
@@ -202,9 +204,22 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
    */
   @Override
   public RecipeSymbol.Builder visitText(DirectivesParser.TextContext ctx) {
-    String value = ctx.String().getText();
-    builder.addToken(new Text(value.substring(1, value.length() - 1)));
-    return builder;
+	  String value = ctx.String().getText();
+	  String unquoted = value.substring(1, value.length() - 1);
+
+	  Token token;
+	  if (unquoted.matches("\\d+(\\.\\d+)?(KB|MB|GB|B)")) {
+	    token = new ByteSize(unquoted);
+	  } else if (unquoted.matches("\\d+(\\.\\d+)?(ns|ms|s|m|h)")) {
+	    token = new TimeDuration(unquoted);
+	  } else {
+	    token = new Text(unquoted);
+	  }
+	  
+
+	  builder.addToken(token);
+	  System.out.println("Token added: " + token.getClass().getSimpleName());
+	  return builder;
   }
 
   /**

--- a/wrangler-proto/.classpath
+++ b/wrangler-proto/.classpath
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/wrangler-proto/.project
+++ b/wrangler-proto/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wrangler-proto</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/wrangler-proto/.settings/org.eclipse.core.resources.prefs
+++ b/wrangler-proto/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/wrangler-proto/.settings/org.eclipse.jdt.core.prefs
+++ b/wrangler-proto/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/wrangler-proto/.settings/org.eclipse.m2e.core.prefs
+++ b/wrangler-proto/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/wrangler-service/.classpath
+++ b/wrangler-service/.classpath
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/wrangler-service/.project
+++ b/wrangler-service/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wrangler-service</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/wrangler-service/.settings/org.eclipse.core.resources.prefs
+++ b/wrangler-service/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/wrangler-service/.settings/org.eclipse.jdt.core.prefs
+++ b/wrangler-service/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/wrangler-service/.settings/org.eclipse.m2e.core.prefs
+++ b/wrangler-service/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/wrangler-storage/.classpath
+++ b/wrangler-storage/.classpath
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/wrangler-storage/.project
+++ b/wrangler-storage/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wrangler-storage</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/wrangler-storage/.settings/org.eclipse.core.resources.prefs
+++ b/wrangler-storage/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/wrangler-storage/.settings/org.eclipse.jdt.core.prefs
+++ b/wrangler-storage/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/wrangler-storage/.settings/org.eclipse.m2e.core.prefs
+++ b/wrangler-storage/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/wrangler-test/.classpath
+++ b/wrangler-test/.classpath
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/wrangler-test/.project
+++ b/wrangler-test/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wrangler-test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/wrangler-test/.settings/org.eclipse.core.resources.prefs
+++ b/wrangler-test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding/<project>=UTF-8

--- a/wrangler-test/.settings/org.eclipse.jdt.core.prefs
+++ b/wrangler-test/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/wrangler-test/.settings/org.eclipse.m2e.core.prefs
+++ b/wrangler-test/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/wrangler-transform/.classpath
+++ b/wrangler-transform/.classpath
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/wrangler-transform/.project
+++ b/wrangler-transform/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wrangler-transform</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/wrangler-transform/.settings/org.eclipse.core.resources.prefs
+++ b/wrangler-transform/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/wrangler-transform/.settings/org.eclipse.jdt.core.prefs
+++ b/wrangler-transform/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/wrangler-transform/.settings/org.eclipse.m2e.core.prefs
+++ b/wrangler-transform/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1


### PR DESCRIPTION
This PR adds support for parsing ByteSize and TimeDuration values in Wrangler.

- Implements ByteSize and TimeDuration parsers
- Updates grammar and directive handling
- Adds unit tests
- Documents usage in README.md