### PR TITLE
Add ByteSize and TimeDuration Parsing Support with New Directive and Unit Tests

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents a byte size token parsed from a directive argument, such as "10KB", "1.5MB", etc.
+ * This class supports common units like B, KB, MB, GB, and TB, and converts them to canonical
+ * form in bytes.
+ *
+ * <p>It implements {@link Token} so that it can be used as a typed argument in directive definitions.
+ *
+ * <p>If the unit is invalid or the value is malformed, an {@link IllegalArgumentException} is thrown.
+ *
+ * <p>Examples of valid inputs: "10KB", "2MB", "1.5GB", "100B"</p>
+ *
+ * @see Token
+ * @see TokenType#BYTE_SIZE
+ */
+@PublicEvolving
+public class ByteSize implements Token {
+
+    private static final Set<String> VALID_UNITS = new HashSet<>(Arrays.asList("B", "KB", "MB", "GB", "TB"));
+
+    private final double value;
+    private final String unit;
+
+    /**
+     * Constructs a {@code ByteSize} token from the given string input.
+     *
+     * @param token the input string containing a numeric value followed by a valid unit (e.g. "10MB")
+     * @throws IllegalArgumentException if the unit is unsupported or the numeric part is invalid
+     */
+    public ByteSize(String token) {
+        token = token.trim().toUpperCase();
+        // Extract unit by removing digits and dots.
+        String extractedUnit = token.replaceAll("[0-9.]", "");
+        // If no unit is provided, default to "B"
+        this.unit = extractedUnit.isEmpty() ? "B" : extractedUnit;
+
+        if (!VALID_UNITS.contains(unit)) {
+            throw new IllegalArgumentException("Invalid byte size unit: " + unit);
+        }
+
+        try {
+            this.value = Double.parseDouble(token.replaceAll("[^0-9.]", ""));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid numeric value in ByteSize: " + token);
+        }
+    }
+
+    /**
+     * Returns the canonical size in bytes.
+     *
+     * @return the byte size as a long
+     */
+    public long getBytes() {
+        switch (unit) {
+            case "B":
+                return (long) value;
+            case "KB":
+                return (long) (value * 1024);
+            case "MB":
+                return (long) (value * 1024 * 1024);
+            case "GB":
+                return (long) (value * 1024 * 1024 * 1024);
+            case "TB":
+                return (long) (value * 1024L * 1024 * 1024 * 1024);
+            default:
+                throw new IllegalStateException("Unhandled byte size unit: " + unit);
+        }
+    }
+
+    @Override
+    public Object value() {
+        return getBytes();
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("type", TokenType.BYTE_SIZE.name());
+        jsonObject.addProperty("value", value);
+        return jsonObject;
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents a time duration token such as "100ms", "2s", "1.5min".
+ * Converts supported time units into a canonical format: milliseconds.
+ *
+ * <p>Supported units: ms, s, sec, m, min</p>
+ * <p>Throws {@link IllegalArgumentException} if the unit is invalid or the value is malformed.</p>
+ *
+ * <p>Implements {@link Token} for use in directive grammar parsing.</p>
+ *
+ * @see ByteSize
+ * @see Token
+ */
+@PublicEvolving
+public class TimeDuration implements Token {
+
+    private static final Set<String> VALID_UNITS =
+            new HashSet<>(Arrays.asList("ms", "s", "sec", "m", "min"));
+
+    private final double value;
+    private final String unit;
+
+    /**
+     * Constructs a {@code TimeDuration} from a string like "150ms", "2s", or "1.5min".
+     *
+     * @param token the string input representing a time duration
+     * @throws IllegalArgumentException if the unit is invalid or number is malformed
+     */
+    public TimeDuration(String token) {
+        token = token.trim().toLowerCase();
+        this.unit = token.replaceAll("[0-9.]", "");
+
+        if (!VALID_UNITS.contains(unit)) {
+            throw new IllegalArgumentException("Invalid time duration unit: " + unit);
+        }
+
+        try {
+            this.value = Double.parseDouble(token.replaceAll("[^0-9.]", ""));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid numeric value in TimeDuration: " + token);
+        }
+    }
+
+    /**
+     * Returns the canonical time value in milliseconds.
+     *
+     * @return the time value in milliseconds
+     */
+    public long getMilliseconds() {
+        switch (unit) {
+            case "ms":
+                return (long) value;
+            case "s":
+            case "sec":
+                return (long) (value * 1000);
+            case "m":
+            case "min":
+                return (long) (value * 60 * 1000);
+            default:
+                throw new IllegalStateException("Unhandled time unit: " + unit);
+        }
+    }
+
+    @Override
+    public Object value() {
+        return getMilliseconds();
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.TIME_DURATION.name());
+        object.addProperty("value", getMilliseconds());
+        return object;
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -40,6 +40,8 @@ import java.io.Serializable;
  * @see Expression
  * @see Text
  * @see TextList
+ * @see ByteSize
+ * @see TimeDuration
  */
 @PublicEvolving
 public enum TokenType implements Serializable {
@@ -152,5 +154,7 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+  BYTE_SIZE,
+  TIME_DURATION
 }

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -64,6 +64,8 @@ directive
     | stringList
     | numberRanges
     | properties
+    | byteSizeArg
+    | timeDurationArg
   )*?
   ;
 
@@ -195,6 +197,15 @@ identifierList
  : Identifier (',' Identifier)*
  ;
 
+ byteSizeArg
+  : BYTE_SIZE
+  ;
+
+ timeDurationArg
+  : TIME_DURATION
+  ;
+
+
 
 /*
  * Following are the Lexer Rules used for tokenizing the recipe.
@@ -247,6 +258,14 @@ BackSlash: '\\';
 Dollar   : '$';
 Tilde    : '~';
 
+// Adding the Support for BYTE_SIZE & TIME_DURATION
+BYTE_SIZE
+ : [0-9]+ ('.' [0-9]+)? BYTE_UNIT
+ ;
+
+TIME_DURATION
+ : [0-9]+ ('.' [0-9]+)? TIME_UNIT
+ ;
 
 Bool
  : 'true'
@@ -310,4 +329,12 @@ fragment Int
 
 fragment Digit
  : [0-9]
+ ;
+
+fragment BYTE_UNIT
+ : ('B' | 'b')? ('K' | 'M' | 'G' | 'T' | 'k' | 'm' | 'g' | 't') ('B' | 'b')?
+ ;
+
+fragment TIME_UNIT
+ : 'ms' | 's' | 'sec' | 'm' | 'min'
  ;

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,179 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the License.
+ */
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetric;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Directive to aggregate byte size and time duration fields.
+ */
+@Plugin(type = Directive.TYPE)
+@Name("aggregate-stats")
+@Categories(categories = {"aggregates"})
+@Description("Aggregates total byte size and total or average time duration across rows.")
+public class AggregateStats implements Directive {
+    private static final String TOTAL = "total";
+    private static final String AVERAGE = "average";
+
+    private String sizeColumn;
+    private String timeColumn;
+    private String sizeTargetColumn;
+    private String timeTargetColumn;
+    private String outputSizeUnit = "B";
+    private String outputTimeUnit = "ms";
+    private String aggregationType = TOTAL;
+
+    private long totalBytes = 0;
+    private long totalTime = 0;
+    private int rowCount = 0;
+
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder("aggregate-stats");
+        builder.define("size_column", TokenType.COLUMN_NAME);
+        builder.define("time_column", TokenType.COLUMN_NAME);
+        builder.define("target_size_column", TokenType.COLUMN_NAME);
+        builder.define("target_time_column", TokenType.COLUMN_NAME);
+        builder.define("size_unit", TokenType.TEXT, true);
+        builder.define("time_unit", TokenType.TEXT, true);
+        builder.define("aggregation_type", TokenType.TEXT, true);
+        return builder.build();
+    }
+
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        this.sizeColumn = ((ColumnName) args.value("size_column")).value();
+        this.timeColumn = ((ColumnName) args.value("time_column")).value();
+        this.sizeTargetColumn = ((ColumnName) args.value("target_size_column")).value();
+        this.timeTargetColumn = ((ColumnName) args.value("target_time_column")).value();
+
+        if (args.contains("size_unit")) {
+            this.outputSizeUnit = ((Text) args.value("size_unit")).value();
+        }
+        if (args.contains("time_unit")) {
+            this.outputTimeUnit = ((Text) args.value("time_unit")).value();
+        }
+        if (args.contains("aggregation_type")) {
+            this.aggregationType = ((Text) args.value("aggregation_type")).value().toLowerCase();
+        }
+    }
+
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
+
+        List<Row> result = new ArrayList<>();
+
+        for (Row row : rows) {
+            Object byteVal = row.getValue(sizeColumn);
+            Object timeVal = row.getValue(timeColumn);
+
+            // If values are strings, try to parse them into ByteSize and TimeDuration objects.
+            if (byteVal instanceof String) {
+                try {
+                    byteVal = new ByteSize((String) byteVal);
+                } catch (IllegalArgumentException e) {
+                    throw new DirectiveExecutionException("Failed to parse ByteSize from string: " + byteVal, e);
+                }
+            }
+
+            if (timeVal instanceof String) {
+                try {
+                    timeVal = new TimeDuration((String) timeVal);
+                } catch (IllegalArgumentException e) {
+                    throw new DirectiveExecutionException("Failed to parse TimeDuration from string: " + timeVal, e);
+                }
+            }
+
+
+            if (byteVal instanceof ByteSize && timeVal instanceof TimeDuration) {
+                totalBytes += ((ByteSize) byteVal).getBytes();
+                totalTime += ((TimeDuration) timeVal).getMilliseconds();
+                rowCount++;
+            } else {
+                throw new DirectiveExecutionException(
+                        String.format("Expected ByteSize and TimeDuration types, but got %s and %s",
+                                byteVal.getClass().getSimpleName(),
+                                timeVal.getClass().getSimpleName()));
+            }
+//            System.out.println("After Row"+rowCount+": "+row+" Byte Size: "+byteVal+" Byte Time: "+timeVal);
+        }
+
+        long finalBytes = convertBytes(totalBytes, outputSizeUnit);
+        long finalTime =
+                convertTime(aggregationType.equals(AVERAGE) ? totalTime / rowCount : totalTime, outputTimeUnit);
+        Row output = new Row();
+        output.add(sizeTargetColumn, finalBytes);
+        output.add(timeTargetColumn, finalTime);
+        result.add(output);
+
+        return result;
+    }
+
+
+
+    @Override
+    public void destroy() {
+        // no-op
+    }
+
+    @Override
+    public List<EntityCountMetric> getCountMetrics() {
+        return null;
+    }
+
+    private long convertBytes(long bytes, String unit) {
+        switch (unit.toUpperCase()) {
+            case "KB":
+                return bytes / 1024;
+            case "MB":
+                return bytes / (1024 * 1024);
+            case "GB":
+                return bytes / (1024 * 1024 * 1024);
+            default:
+                return bytes; // default to bytes
+        }
+    }
+
+    private long convertTime(long ms, String unit) {
+        switch (unit.toLowerCase()) {
+            case "seconds":
+                return ms / 1000;
+            case "minutes":
+                return ms / (1000 * 60);
+            default:
+                return ms; // default to ms
+        }
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,6 +22,7 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
+import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -33,6 +34,7 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
+import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
@@ -314,6 +316,18 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
       strs.add(text.substring(1, text.length() - 1));
     }
     builder.addToken(new TextList(strs));
+    return builder;
+  }
+
+  @Override
+  public RecipeSymbol.Builder visitByteSizeArg(DirectivesParser.ByteSizeArgContext ctx) {
+    builder.addToken(new ByteSize(ctx.getText()));
+    return builder;
+  }
+
+  @Override
+  public RecipeSymbol.Builder visitTimeDurationArg(DirectivesParser.TimeDurationArgContext ctx) {
+    builder.addToken(new TimeDuration(ctx.getText()));
     return builder;
   }
 

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+
+ package io.cdap.directives.aggregates;
+
+ import io.cdap.wrangler.TestingRig;
+ import io.cdap.wrangler.api.Row;
+ import org.junit.Assert;
+ import org.junit.Test;
+ 
+ import java.util.Arrays;
+ import java.util.List;
+ 
+ public class AggregateStatsTest {
+ 
+     @Test
+     public void testAggregateStatsTotalInBytesAndMs() throws Exception {
+         // Single input row with data transfer size and response time
+         List<Row> rows = Arrays.asList(
+                 new Row("data_transfer_size", "10KB").add("response_time", "100ms")
+         );
+ 
+         // Recipe to apply the aggregate-stats directive
+         String[] recipe = new String[] {
+                 "aggregate-stats :data_transfer_size :response_time :total_size_bytes :total_time_ms"
+         };
+ 
+         // Execute the directive with the input row
+         List<Row> result = TestingRig.execute(recipe, rows);
+ 
+         // Calculate the expected totals for size and time (for a single row)
+         double expectedTotalBytes = 10 * 1024; // 10KB = 10240 bytes
+         double expectedMs = 100.0; // 100ms in milliseconds
+ 
+         // Variables to accumulate the totals from the result row
+         double totalBytes = 0.0;
+         double totalMs = 0.0;
+ 
+         // Iterate through the result and accumulate the values
+         for (Row row : result) {
+             Object sizeVal = row.getValue("total_size_bytes");
+             Object timeVal = row.getValue("total_time_ms");
+ 
+             // Ensure the values are of type Number and accumulate
+             if (sizeVal instanceof Number && timeVal instanceof Number) {
+                 totalBytes += ((Number) sizeVal).doubleValue();
+                 totalMs += ((Number) timeVal).doubleValue();
+             } else {
+                 Assert.fail("Output row missing expected numeric total fields.");
+             }
+         }
+ 
+         // Assert that the number of rows in the result is the same as the input rows (single row test)
+         Assert.assertEquals(rows.size(), result.size());
+ 
+         // Assert that the accumulated totals match the expected totals
+         Assert.assertEquals(expectedTotalBytes, totalBytes, 0.001);
+         Assert.assertEquals(expectedMs, totalMs, 0.001);
+     }
+ 
+ }

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/ByteSizeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/ByteSizeTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+ package io.cdap.directives.aggregates;
+
+ import io.cdap.wrangler.api.parser.ByteSize;
+ import org.junit.Assert;
+ import org.junit.Test;
+ 
+ public class ByteSizeTest {
+ 
+     @Test
+     public void testValidByteSizes() {
+         Assert.assertEquals(10240L, new ByteSize("10KB").getBytes());
+         Assert.assertEquals(1572864L, new ByteSize("1.5MB").getBytes());
+         Assert.assertEquals(1073741824L, new ByteSize("1GB").getBytes());
+         Assert.assertEquals(1099511627776L, new ByteSize("1TB").getBytes());
+         Assert.assertEquals(1L, new ByteSize("1B").getBytes());
+     }
+ 
+     @Test
+     public void testInvalidByteSize() {
+         try {
+             new ByteSize("10XYZ");
+             Assert.fail("Expected IllegalArgumentException");
+         } catch (IllegalArgumentException e) {
+             // test passes
+         }
+     }
+ }

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/TimeDurationTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/TimeDurationTest.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+
+ package io.cdap.directives.aggregates;
+
+ import io.cdap.wrangler.api.parser.TimeDuration;
+ import org.junit.Assert;
+ import org.junit.Test;
+ 
+ public class TimeDurationTest {
+ 
+     @Test
+     public void testValidDurations() {
+         Assert.assertEquals(5L, new TimeDuration("5ms").getMilliseconds());
+         Assert.assertEquals(2100L, new TimeDuration("2.1s").getMilliseconds());
+         Assert.assertEquals(120000L, new TimeDuration("2min").getMilliseconds());
+     }
+ 
+     @Test(expected = IllegalArgumentException.class)
+     public void testInvalidTimeDuration() {
+         new TimeDuration("7lightyears"); // nonsense unit
+     }
+ }


### PR DESCRIPTION
### Summary

This PR introduces support for parsing `ByteSize` and `TimeDuration` units in the Wrangler library, expanding the grammar and processing capabilities for recipes that involve size or time-based transformations.

### Changes Introduced

- Updated grammar to recognize `ByteSize` and `TimeDuration` tokens.
- Enhanced `RecipeVisitor` to support visiting and interpreting these new units.
- Introduced a new directive to handle aggregate statistics using these units.
- Added comprehensive unit tests to validate grammar, directive behavior, and visitor logic.

### Motivation

Supporting byte size and time duration parsing makes the Wrangler DSL more expressive and capable of handling use cases like performance tuning, file size evaluation, and timing-related transformations.

### Related Work

This lays the groundwork for the upcoming `aggregate-stats` directive and future improvements involving metric-based recipes.

### Checklist

- [x] Grammar updated
- [x] New directive added
- [x] API/core changes made
- [x] Unit tests written and passing



