### PR TITLE
Byte Size & Time Duration Unit Support in Wrangler

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,11 @@ Cask is a trademark of Cask Data, Inc. All rights reserved.
 
 Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
 permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.
+
+## 📦 New Feature: ByteSize & TimeDuration Parsing
+
+Wrangler now supports native parsing of data sizes and time durations!
+
+### ✅ New Directive:
+```wrangler
+aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,40 @@
+package io.cdap.wrangler.api.parser;
+
+/**
+ * A class to parse byte size strings like "10KB", "2MB", "1.5GB", etc.
+ */
+
+public class ByteSize {
+    private final long bytes;
+
+    public ByteSize(String value) {
+        this.bytes = parseByteSize(value.trim());
+    }
+
+    private long parseByteSize(String value) {
+        value = value.toUpperCase();
+
+        if (value.endsWith("KB")) {
+            return (long) (Double.parseDouble(value.replace("KB", "")) * 1024);
+        } else if (value.endsWith("MB")) {
+            return (long) (Double.parseDouble(value.replace("MB", "")) * 1024 * 1024);
+        } else if (value.endsWith("GB")) {
+            return (long) (Double.parseDouble(value.replace("GB", "")) * 1024 * 1024 * 1024);
+        } else if (value.endsWith("TB")) {
+            return (long) (Double.parseDouble(value.replace("TB", "")) * 1024L * 1024 * 1024 * 1024);
+        } else if (value.endsWith("B")) {
+            return (long) (Double.parseDouble(value.replace("B", "")));
+        } else {
+            throw new IllegalArgumentException("Invalid byte size format: " + value);
+        }
+    }
+
+    public long getBytes() {
+        return bytes;
+    }
+
+    @Override
+    public String toString() {
+        return bytes + " bytes";
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,39 @@
+package io.cdap.wrangler.api.parser;
+
+/**
+ * A class to parse time duration strings like "500ms", "2s", "3.5m", "1h", etc.
+ */
+public class TimeDuration {
+    private final long milliseconds;
+
+    public TimeDuration(String value) {
+        this.milliseconds = parseTime(value.trim());
+    }
+
+    private long parseTime(String value) {
+        value = value.toLowerCase();
+
+        if (value.endsWith("ms")) {
+            return (long) Double.parseDouble(value.replace("ms", ""));
+        } else if (value.endsWith("s")) {
+            return (long) (Double.parseDouble(value.replace("s", "")) * 1000);
+        } else if (value.endsWith("m")) {
+            return (long) (Double.parseDouble(value.replace("m", "")) * 60 * 1000);
+        } else if (value.endsWith("h")) {
+            return (long) (Double.parseDouble(value.replace("h", "")) * 60 * 60 * 1000);
+        } else if (value.endsWith("d")) {
+            return (long) (Double.parseDouble(value.replace("d", "")) * 24 * 60 * 60 * 1000);
+        } else {
+            throw new IllegalArgumentException("Invalid time duration format: " + value);
+        }
+    }
+
+    public long getMilliseconds() {
+        return milliseconds;
+    }
+
+    @Override
+    public String toString() {
+        return milliseconds + " ms";
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,18 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for the object of type {@code ByteSize}.
+   * Supports values like 10KB, 5MB, etc.
+   */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for the object of type {@code TimeDuration}.
+   * Supports values like 100ms, 2s, 5min, etc.
+   */
+  TIME_DURATION
+
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -126,6 +126,10 @@ public final class UsageDefinition implements Serializable {
           sb.append("prop:{key:value,[key:value]*");
         } else if (token.type().equals(TokenType.RANGES)) {
           sb.append("start:end=[bool|text|numeric][,start:end=[bool|text|numeric]*");
+        } else if (token.type().equals(TokenType.BYTE_SIZE)) {
+          sb.append(token.name()).append(" (e.g., 10MB, 500KB)");
+        } else if (token.type().equals(TokenType.TIME_DURATION)) {
+          sb.append(token.name()).append(" (e.g., 5s, 120ms)");
         }
       }
 

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -64,6 +64,8 @@ directive
     | stringList
     | numberRanges
     | properties
+    | byteSize  //->Added
+    | timeDuration //->Added
   )*?
   ;
 
@@ -310,4 +312,12 @@ fragment Int
 
 fragment Digit
  : [0-9]
+ ;
+
+BYTE_SIZE
+ : Int? [0-9]+ (('KB' | 'MB' | 'GB' | 'TB' | 'B') | ('kb' | 'mb' | 'gb' | 'tb' | 'b'))
+ ;
+
+TIME_DURATION
+ : Int? [0-9]+ (('MS' | 'S' | 'M' | 'H' | 'D') | ('ms' | 's' | 'm' | 'h' | 'd'))
  ;

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,110 @@
+package io.cdap.wrangler.directives.aggregates;
+
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.DirectiveContext;
+import io.cdap.wrangler.api.parser.DirectiveParseException;
+import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.Value;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.DirectiveArgument;
+import io.cdap.wrangler.api.parser.DirectiveDefinition;
+
+import io.cdap.wrangler.api.parser.Arguments;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import io.cdap.wrangler.api.parser.OutputType;
+
+import io.cdap.wrangler.api.parser.AssertionException;
+import io.cdap.wrangler.api.parser.Assertion;
+import io.cdap.wrangler.api.parser.Column;
+
+import io.cdap.wrangler.api.parser.AssertionException;
+import io.cdap.wrangler.api.parser.Assertion;
+
+import io.cdap.wrangler.api.parser.ValueException;
+import io.cdap.wrangler.api.parser.TextException;
+
+import io.cdap.wrangler.api.parser.ColumnException;
+
+import io.cdap.wrangler.api.parser.StringValue;
+
+import io.cdap.wrangler.api.parser.IntegerValue;
+
+import io.cdap.wrangler.api.parser.StringList;
+
+import io.cdap.wrangler.api.parser.BooleanValue;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A custom directive to aggregate total byte size and time duration over multiple rows.
+ */
+public class AggregateStats implements Directive {
+    private String sourceByteCol;
+    private String sourceTimeCol;
+    private String outputByteCol;
+    private String outputTimeCol;
+
+    private long totalBytes = 0;
+    private long totalMilliseconds = 0;
+
+    @Override
+    public UsageDefinition define() {
+        return UsageDefinition.builder("aggregate-stats")
+            .usage("aggregate-stats <byte-col> <time-col> <output-byte-col> <output-time-col>")
+            .arguments(
+                Arguments.of("byte-col", ColumnName.class),
+                Arguments.of("time-col", ColumnName.class),
+                Arguments.of("output-byte-col", Text.class),
+                Arguments.of("output-time-col", Text.class)
+            )
+            .output(OutputType.AGGREGATE)
+            .build();
+    }
+
+    @Override
+    public void initialize(DirectiveContext ctx, Arguments args) throws DirectiveParseException {
+        sourceByteCol = ((ColumnName) args.value("byte-col")).value();
+        sourceTimeCol = ((ColumnName) args.value("time-col")).value();
+        outputByteCol = ((Text) args.value("output-byte-col")).value();
+        outputTimeCol = ((Text) args.value("output-time-col")).value();
+    }
+
+    @Override
+    public void execute(Row row, ExecutorContext context) {
+        Object byteObj = row.getValue(sourceByteCol);
+        Object timeObj = row.getValue(sourceTimeCol);
+
+        if (byteObj instanceof String) {
+            ByteSize byteSize = new ByteSize((String) byteObj);
+            totalBytes += byteSize.getBytes();
+        }
+
+        if (timeObj instanceof String) {
+            TimeDuration timeDuration = new TimeDuration((String) timeObj);
+            totalMilliseconds += timeDuration.getMilliseconds();
+        }
+    }
+
+    @Override
+    public List<Row> finalize(ExecutorContext context) {
+        List<Row> results = new ArrayList<>();
+        Row row = new Row();
+
+        double totalMB = totalBytes / (1024.0 * 1024.0); // Convert bytes to MB
+        double totalSeconds = totalMilliseconds / 1000.0; // Convert ms to sec
+
+        row.add(outputByteCol, totalMB);
+        row.add(outputTimeCol, totalSeconds);
+
+        results.add(row);
+        return results;
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,41 @@
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.test.TestingRig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AggregateStatsTest {
+
+  @Test
+  public void testAggregateStatsSum() throws Exception {
+    List<Row> inputRows = Arrays.asList(
+      new Row("data_transfer_size", "1MB").add("response_time", "500ms"),
+      new Row("data_transfer_size", "2MB").add("response_time", "1500ms"),
+      new Row("data_transfer_size", "512KB").add("response_time", "2000ms")
+    );
+
+    String[] recipe = new String[] {
+      "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec"
+    };
+
+    List<Row> results = TestingRig.execute(recipe, inputRows);
+
+    // Assert a single aggregated output row
+    Assert.assertEquals(1, results.size());
+
+    Row result = results.get(0);
+
+    // Expected: Total Size in MB
+    // 1MB + 2MB + 0.5MB = 3.5MB (using 1024-based conversion)
+    double expectedTotalSizeMB = 1 + 2 + 512.0 / 1024;
+
+    // Expected: Total Time in seconds
+    // 0.5 + 1.5 + 2.0 = 4.0 seconds
+    double expectedTotalTimeSec = (500 + 1500 + 2000) / 1000.0;
+
+    Assert.assertEquals(expectedTotalSizeMB, (double) result.getValue("total_size_mb"), 0.001);
+    Assert.assertEquals(expectedTotalTimeSec, (double) result.getValue("total_time_sec"), 0.001);
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/ByteSizeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/ByteSizeTest.java
@@ -1,0 +1,43 @@
+package io.cdap.wrangler;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteSizeTest {
+
+    @Test
+    public void testBytes() {
+        ByteSize b = new ByteSize("100B");
+        Assert.assertEquals(100, b.getBytes());
+    }
+
+    @Test
+    public void testKB() {
+        ByteSize b = new ByteSize("1KB");
+        Assert.assertEquals(1024, b.getBytes());
+    }
+
+    @Test
+    public void testMB() {
+        ByteSize b = new ByteSize("1.5MB");
+        Assert.assertEquals(1572864, b.getBytes());
+    }
+
+    @Test
+    public void testGB() {
+        ByteSize b = new ByteSize("2GB");
+        Assert.assertEquals(2L * 1024 * 1024 * 1024, b.getBytes());
+    }
+
+    @Test
+    public void testTB() {
+        ByteSize b = new ByteSize("1TB");
+        Assert.assertEquals(1L * 1024 * 1024 * 1024 * 1024, b.getBytes());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidFormat() {
+        new ByteSize("15XY");
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/TimeDurationTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/TimeDurationTest.java
@@ -1,0 +1,43 @@
+package io.cdap.wrangler;
+
+import io.cdap.wrangler.api.parser.TimeDuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TimeDurationTest {
+
+    @Test
+    public void testMilliseconds() {
+        TimeDuration t = new TimeDuration("500ms");
+        Assert.assertEquals(500, t.getMilliseconds());
+    }
+
+    @Test
+    public void testSeconds() {
+        TimeDuration t = new TimeDuration("2s");
+        Assert.assertEquals(2000, t.getMilliseconds());
+    }
+
+    @Test
+    public void testMinutes() {
+        TimeDuration t = new TimeDuration("1.5m");
+        Assert.assertEquals(90000, t.getMilliseconds());
+    }
+
+    @Test
+    public void testHours() {
+        TimeDuration t = new TimeDuration("1h");
+        Assert.assertEquals(3600000, t.getMilliseconds());
+    }
+
+    @Test
+    public void testDays() {
+        TimeDuration t = new TimeDuration("2d");
+        Assert.assertEquals(2L * 24 * 60 * 60 * 1000, t.getMilliseconds());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidDuration() {
+        new TimeDuration("10xyz");
+    }
+}


### PR DESCRIPTION
This PR introduces native support for handling byte size (e.g., 10KB, 1.5MB) and time duration (e.g., 500ms, 2s) units in the CDAP Wrangler framework.
A new directive aggregate-stats has been added to demonstrate aggregation capabilities using these units.