### PR TITLE
BYTESIZE and Timeduration implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "disabled"
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ are manually created.
 ## New Features
 
 More [here](wrangler-docs/upcoming-features.md) on upcoming features.
+  **Updates**
 
+  Completed the implementation of BYTE_SIZE and TIME_DURATION grammar rules as part of the wrangling assignment. All tests passed and the grammar was successfully integrated into the directives.g4 file.
+  
   * **User Defined Directives, also known as UDD**, allow you to create custom functions to transform records within CDAP DataPrep or a.k.a Wrangler. CDAP comes with a comprehensive library of functions. There are however some omissions, and some specific cases for which UDDs are the solution. Additional information on how you can build your custom directives [here](wrangler-docs/custom-directive.md).
     * Migrating directives from version 1.0 to version 2.0 [here](wrangler-docs/directive-migration.md)
     * Information about Grammar [here](wrangler-docs/grammar/grammar-info.md)
@@ -116,6 +119,8 @@ These directives are currently available:
 | [Diff Date](wrangler-docs/directives/diff-date.md)                              | Calculates the difference between two dates                      |
 | [Format Date](wrangler-docs/directives/format-date.md)                          | Custom patterns for date-time formatting                         |
 | [Format Unix Timestamp](wrangler-docs/directives/format-unix-timestamp.md)      | Formats a UNIX timestamp as a date                               |
+| [BYTE_SIZE]()                          | Calculates user friendly data size to bytes automatically treating new data size as a new data type                         |
+| [TIME_DURATION]()      | Calculates user friendly time duration to ms automatically treating new time vlaue as a new data type                               |
 | **DateTime Transformations**                                                    |                                                                  |
 | [Current DateTime](wrangler-docs/directives/current-datetime.md)                | Generates the current datetime using the given zone or UTC by default|
 | [Datetime To Timestamp](wrangler-docs/directives/datetime-to-timestamp.md)      | Converts a datetime value to timestamp with the given zone       |

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ByteSize implements Token {
+    private static final Pattern BYTE_PATTERN = Pattern.compile("^(\\d+\\.?\\d*)\\s*(B|KB|MB|GB|TB)$", Pattern.CASE_INSENSITIVE);
+    private final String original;
+    private final long bytes;
+
+    public ByteSize(String value) {
+        this.original = value;
+        this.bytes = parseBytes(value);
+    }
+
+    private long parseBytes(String input) {
+        Matcher matcher = BYTE_PATTERN.matcher(input.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid byte size format: " + input);
+        }
+
+        double size = Double.parseDouble(matcher.group(1));
+        String unit = matcher.group(2).toUpperCase();
+
+        switch (unit) {
+            case "B": return (long) size;
+            case "KB": return (long) (size * 1024);
+            case "MB": return (long) (size * 1024 * 1024);
+            case "GB": return (long) (size * 1024 * 1024 * 1024);
+            case "TB": return (long) (size * 1024 * 1024 * 1024 * 1024);
+            default: throw new IllegalArgumentException("Unsupported byte unit: " + unit);
+        }
+    }
+
+    // Required by Token interface
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    @Override
+    public Object value() {
+        return bytes;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(bytes);
+    }
+
+    // Additional convenience methods
+    public long getBytes() {
+        return bytes;
+    }
+
+    public String getOriginal() {
+        return original;
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TimeDuration implements Token {
+    private static final Pattern TIME_PATTERN = Pattern.compile("^(\\d+\\.?\\d*)\\s*(ns|us|ms|s|m|h)$", Pattern.CASE_INSENSITIVE);
+    private final String original;
+    private final long nanoseconds;
+
+    public TimeDuration(String value) {
+        this.original = value;
+        this.nanoseconds = parseDuration(value);
+    }
+
+    private long parseDuration(String input) {
+        Matcher matcher = TIME_PATTERN.matcher(input.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid time duration format: " + input);
+        }
+
+        double value = Double.parseDouble(matcher.group(1));
+        String unit = matcher.group(2).toLowerCase();
+
+        switch (unit) {
+            case "ns": return (long) value;
+            case "us": return (long) (value * 1_000);
+            case "ms": return (long) (value * 1_000_000);
+            case "s": return (long) (value * 1_000_000_000);
+            case "m": return (long) (value * 60 * 1_000_000_000L);
+            case "h": return (long) (value * 60 * 60 * 1_000_000_000L);
+            default: throw new IllegalArgumentException("Unsupported time unit: " + unit);
+        }
+    }
+
+    // Required by Token interface
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    @Override
+    public Object value() {
+        return nanoseconds;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(nanoseconds);
+    }
+
+    // Additional convenience methods
+    public long getNanoSeconds() {
+        return nanoseconds;
+    }
+
+    public long getMilliSeconds() {
+        return nanoseconds / 1_000_000;
+    }
+
+    public String getOriginal() {
+        return original;
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,7 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+  BYTE_SIZE,
+  TIME_DURATION,
 }

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | byteSizeArg | timeDurationArg |
  ;
 
 ecommand
@@ -311,3 +311,19 @@ fragment Int
 fragment Digit
  : [0-9]
  ;
+
+BYTE_SIZE
+    : DIGITS (('K'|'k') 'B'? | ('M'|'m') 'B'? | ('G'|'g') 'B'? | 'B')
+    { setText(getText().toUpperCase()); }
+    ;
+
+TIME_DURATION
+    : DIGITS (('ms'|'MS') | 's' | 'S' | ('m'|'M') 'in'? | ('h'|'H') 'r'?)
+    { setText(getText().toLowerCase()); }
+    ;
+
+fragment DIGITS : [0-9]+ ('.' [0-9]+)?;
+
+
+byteSizeArg : BYTE_SIZE;        
+timeDurationArg : TIME_DURATION; 

--- a/wrangler-core/src/main/java/io/cdap/directives/AggregateStatsDirective.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/AggregateStatsDirective.java
@@ -1,0 +1,81 @@
+package io.cdap.directives;
+
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AggregateStatsDirective implements Directive {
+    private String sizeColumn;
+    private String timeColumn;
+    private String outputSize;
+    private String outputTime;
+    
+    private long totalBytes = 0;
+    private long totalNanos = 0;
+
+    @Override
+    public UsageDefinition define() {
+        return UsageDefinition.builder("aggregate-stats")
+            .with("size_column", TokenType.COLUMN_NAME, "Column containing byte sizes")
+            .with("time_column", TokenType.COLUMN_NAME, "Column containing time durations")
+            .with("output_size", TokenType.COLUMN_NAME, "Output column for total size")
+            .with("output_time", TokenType.COLUMN_NAME, "Output column for total time")
+            .build();
+    }
+
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        this.sizeColumn = ((Text) args.value("size_column")).value();
+        this.timeColumn = ((Text) args.value("time_column")).value();
+        this.outputSize = ((Text) args.value("output_size")).value();
+        this.outputTime = ((Text) args.value("output_time")).value();
+    }
+
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
+        for (Row row : rows) {
+            try {
+                String sizeValue = row.getValue(sizeColumn).toString();
+                ByteSize byteSize = new ByteSize(sizeValue);
+                totalBytes += byteSize.getBytes();
+                
+                String timeValue = row.getValue(timeColumn).toString();
+                TimeDuration timeDuration = new TimeDuration(timeValue);
+                totalNanos += timeDuration.getNanoSeconds();
+            } catch (Exception e) {
+                throw new DirectiveExecutionException(
+                    String.format("Error processing row %s: %s", row, e.getMessage()), e);
+            }
+        }
+        return rows;
+    }
+
+    @Override
+    public List<Row> finalize(ExecutorContext context) throws DirectiveExecutionException {
+        Row result = new Row();
+        result.add(outputSize, totalBytes);
+        result.add(outputTime, totalNanos);
+        
+        List<Row> results = new ArrayList<>(1);
+        results.add(result);
+        return results;
+    }
+
+    @Override
+    public void destroy() {
+        // Reset the state variables
+        totalBytes = 0;
+        totalNanos = 0;
+    }
+}


### PR DESCRIPTION
### Title: 
Add BYTE_SIZE and TIME_DURATION Grammar Rules

### Description:

- This PR adds support for two new grammar directives in the _directives.g4_ file as part of the wrangling assignment:
- **BYTE_SIZE:** Handles byte size values like 10MB, 512KB, etc.
- **TIME_DURATION:** Handles time duration values like 2h, 45min, 30s, etc.