### PR TITLE
Add BYTE_SIZE and TIME_DURATION support with aggregate-stats directive

### DIFF
--- a/README copy.md
+++ b/README copy.md
@@ -83,8 +83,6 @@ These directives are currently available:
 | [Parse XML To JSON](wrangler-docs/directives/parse-xml-to-json.md)              | Parses an XML document into a JSON structure                     |
 | [Parse as Currency](wrangler-docs/directives/parse-as-currency.md)              | Parses a string representation of currency into a number.        |
 | [Parse as Datetime](wrangler-docs/directives/parse-as-datetime.md)              | Parses strings with datetime values to CDAP datetime type        |
-| [Parse as ByteSize](wrangler-docs/directives/parse-as-bytesize.md)              | Parses a string representation of byte size into a numeric value |
-| [Parse as TimeDuration](wrangler-docs/directives/parse-as-timeduration.md)      | Parses a string representation of time duration into a numeric value |
 | **Output Formatters**                                                  |                                                                  |
 | [Write as CSV](wrangler-docs/directives/write-as-csv.md)                        | Converts a record into CSV format                                |
 | [Write as JSON](wrangler-docs/directives/write-as-json-map.md)                  | Converts the record into a JSON map                              |

--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/prompts.txt
+++ b/prompts.txt
@@ -1,0 +1,28 @@
+1. Develop a function to convert byte size strings (e.g., '10KB', '5MB') into their byte equivalents.
+2. Implement byte size string parsing in the `AggregateStats` class.
+3. Enhance the `RecipeVisitor` class to process byte size strings for specific directives.
+4. Create tests for the byte size parser to check inputs like '10KB', '5MB', '1GB', and edge cases like '0B' or invalid formats.
+
+5. Build a function to parse time duration strings (e.g., '10s', '5m', '2h') into milliseconds.
+6. Add functionality to parse time duration strings in the `AggregateStats` class.
+7. Update the `RecipeVisitor` class to handle time duration strings for specific directives.
+8. Write tests for the time duration parser to validate inputs like '10s', '5m', '2h', and edge cases like '0ms' or invalid formats.
+
+9. Incorporate the byte size and time duration parsers into Wrangler directives that need these features.
+10. Update the `AggregateStats` class to aggregate data based on parsed byte sizes and time durations.
+11. Modify the `RecipeVisitor` class to process recipes containing byte size and time duration parsing.
+12. Ensure older recipes without byte size or time duration parsing remain compatible.
+
+13. Add test cases in `AggregateStatsTest` to verify byte size and time duration parsing.
+14. Include test cases in `RecipeVisitorTest` to validate recipes with byte size and time duration parsing.
+15. Create integration tests to confirm the complete functionality of byte size and time duration parsing in Wrangler.
+
+16. Update Wrangler documentation with examples of byte size and time duration parsing in recipes.
+17. Add a cheatsheet entry listing supported byte size and time duration formats.
+
+18. Implement error handling for invalid byte size strings in the byte size parser.
+19. Add error handling for invalid time duration strings in the time duration parser.
+20. Log meaningful error messages for invalid byte size or time duration strings in recipes.
+
+21. Refactor the `AggregateStats` class to support future parsers like byte size and time duration.
+22. Redesign the `RecipeVisitor` class to separate parsing logic from recipe traversal.

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.Locale;
+
+/**
+ * Represents a token for byte size values with units (e.g., KB, MB, GB).
+ */
+public class ByteSize implements Token {
+
+    private Double bytes;
+
+    /**
+     * Constructs a ByteSize token.
+     *
+     * @param value The string representation of byte size (e.g., "10KB").
+     */
+    public ByteSize(String value) {
+        this.bytes = parseBytes(value);
+    }
+
+    /**
+     * Returns the value of this {@code ByteSize} object as a {@code Double}
+     * representing the size in bytes.
+     *
+     * @return the byte size value of this object.
+     */
+    @Override
+    public Double value() {
+        return getBytes();
+    }
+
+    /**
+     * Returns the value in bytes.
+     *
+     * @return Byte size in long.
+     */
+    public double getBytes() {
+        return this.bytes;
+    }
+
+    /**
+     * Returns the type of this {@code BYTE_SIZE} object as a {@code TokenType}
+     * enum.
+     *
+     * @return the enumerated {@code TokenType} of this object.
+     */
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    /**
+     * Parses the input string and converts it to bytes.
+     *
+     * @param value The input byte size string.
+     * @return The size in bytes.
+     * @throws IllegalArgumentException if input is not a valid byte size
+     * string.
+     */
+    private Double parseBytes(String value) {
+        String normalize = value.trim().toLowerCase(Locale.ENGLISH);
+        double valueDouble = Double.parseDouble(normalize.replaceAll("[^0-9.-]", ""));
+        String unit = normalize.replaceAll("[^a-zA-Z]+", "");
+        System.out.println(unit);
+
+        if (valueDouble < 0) {
+            throw new IllegalArgumentException("Negative byte size values are not allowed: " + value);
+        }
+
+        if (unit.equals("bytes")) {
+            return valueDouble;
+        } else if (unit.equals("b")) {
+            return valueDouble;
+        } else if (unit.equals("kb")) {
+            return valueDouble * 1024;
+        } else if (unit.equals("mb")) {
+            return valueDouble * 1024 * 1024;
+        } else if (unit.equals("gb")) {
+            return valueDouble * 1024 * 1024 * 1024;
+        } else if (unit.equals("tb")) {
+            return valueDouble * 1024 * 1024 * 1024 * 1024;
+        } else {
+            throw new IllegalArgumentException("Unsupported byte unit in: " + value);
+        }
+    }
+
+    /**
+     * Returns the members of this {@code BYTE_SIZE} object as a
+     * {@code JsonElement}.
+     *
+     * @return Json representation of this {@code BYTE_SIZE} object as
+     * {@code JsonElement}
+     */
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.BYTE_SIZE.name());
+        object.addProperty("value", this.bytes);
+        return object;
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.Locale;
+
+/**
+ * Represents a token for time duration values with units (e.g., ms, s, m, h).
+ */
+public class TimeDuration implements Token {
+
+    private Double time;
+
+    /**
+     * Constructs a TimeDuration token.
+     *
+     * @param value The string representation of time value (e.g., "10sec").
+     */
+    public TimeDuration(String value) {
+        this.time = parseMilliSeconds(value);
+    }
+
+    /**
+     * Returns the value of this {@code TIME_DURATION} object as a
+     * {@code Double} representing the time in milliseconds.
+     *
+     * @return the time (milliseconds) value of this object.
+     */
+    @Override
+    public Double value() {
+        return getTime();
+    }
+
+    /**
+     * Returns the value in milliseconds.
+     *
+     * @return time value in double.
+     */
+    public double getTime() {
+        return this.time;
+    }
+
+    /**
+     * Returns the type of this {@code TIME_DURATION} object as a
+     * {@code TokenType} enum.
+     *
+     * @return the enumerated {@code TokenType} of this object.
+     */
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    /**
+     * Parses the input string and converts it to milliseconds.
+     *
+     * @param value The input time duration string.
+     * @return The time in milliseconds.
+     * @throws IllegalArgumentException if input is not a valid time duration
+     * string.
+     */
+    private Double parseMilliSeconds(String value) {
+        String normalize = value.trim().toLowerCase(Locale.ENGLISH);
+        double valueDouble = Double.parseDouble(normalize.replaceAll("[^0-9.\\-]", ""));
+        String unit = normalize.replaceAll("[^a-zA-Z]+", "");
+        if (valueDouble < 0) {
+            throw new IllegalArgumentException("Negative time values are not allowed: " + value);
+        }
+
+        if (unit.equals("ms")) {
+            return valueDouble;
+        } else if (unit.equals("s") 
+                || unit.equals("sec") 
+                || unit.equals("secs")) {
+            return valueDouble * 1000;
+        } else if (unit.equals("m") || unit.equals("min")) {
+            return valueDouble * 1000 * 60;
+        } else if (unit.equals("hours") || normalize.contains("hours")) { // Adjusted condition
+            System.out.println(valueDouble + " valueDouble");
+            return valueDouble * 1000 * 60 * 60;
+        } else if (unit.equals("hour")) {
+            return valueDouble * 1000 * 60 * 60;
+        } else if (unit.equals("hr")) {
+            return valueDouble * 1000 * 60 * 60;
+        } else if (unit.equals("h")) {
+            return valueDouble * 1000 * 60 * 60;
+        } else {
+            throw new IllegalArgumentException("Unsupported time unit in: " + value);
+        }
+    }
+
+    /**
+     * Returns the members of this {@code TIME_DURATION} object as a
+     * {@code JsonElement}.
+     *
+     * @return Json representation of this {@code TIME_DURATION} object as
+     * {@code JsonElement}
+     */
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.TIME_DURATION.name());
+        object.addProperty("value", this.time);
+        return object;
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,20 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for the object of type {@code ByteSize}.
+   * This type is associated with byte size values with units (KB, MB, GB, TB).
+   * E.g. "1.5MB", "500KB", "2.1GB"
+  */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for the object of type {@code TimeDuration}.
+   * This type is associated with time duration values with units (ms, s, m, h, d).
+   * E.g. "500ms", "1.5s", "2h"
+  */
+  TIME_DURATION,
+
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -126,6 +126,10 @@ public final class UsageDefinition implements Serializable {
           sb.append("prop:{key:value,[key:value]*");
         } else if (token.type().equals(TokenType.RANGES)) {
           sb.append("start:end=[bool|text|numeric][,start:end=[bool|text|numeric]*");
+        } else if (token.type().equals(TokenType.BYTE_SIZE)) {
+          sb.append(token.name()).append(" ([FLOAT|INT][KB|MB|GB|TB])");
+        } else if (token.type().equals(TokenType.TIME_DURATION)) {
+          sb.append(token.name()).append(" ([FLOAT|INT][ms|s|m|h])");
         }
       }
 

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author tomar-ayush
+ * Created on: 2025-04-11 15:16:14
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ByteSize}.
+ */
+public class ByteSizeTest {
+
+  @Test
+  public void testValidByteSizes() {
+    Assert.assertEquals(1024, new ByteSize("1KB").getBytes(), 0.001);
+    Assert.assertEquals(2048, new ByteSize("2kb").getBytes(), 0.001); // case-insensitive
+    Assert.assertEquals(1048576, new ByteSize("1MB").getBytes(), 0.001);
+    Assert.assertEquals(1073741824L, new ByteSize("1GB").getBytes(), 0.001);
+    Assert.assertEquals(1099511627776L, new ByteSize("1TB").getBytes(), 0.001);
+  }
+
+  @Test
+  public void testDecimalByteSizes() {
+    Assert.assertEquals(1536, new ByteSize("1.5KB").getBytes(), 0.001);
+    Assert.assertEquals(1572864, new ByteSize("1.5MB").getBytes(), 0.001);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidUnit() {
+    new ByteSize("50XY");
+  }
+
+  @Test(expected = NumberFormatException.class)
+  public void testMalformedNumber() {
+    new ByteSize("abcMB");
+  }
+
+  @Test
+  public void testWhitespaceHandling() {
+    Assert.assertEquals(1024, new ByteSize(" 1KB ").getBytes(), 0.001);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+    public void testNegativeValue() {
+      new ByteSize("-1KB");
+  }
+}

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/TimeDurationTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/TimeDurationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author tomar-ayush
+ * Created on: 2025-04-11 14:46:08
+ */
+package io.cdap.wrangler.api.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TimeDurationTest {
+
+    @Test
+    public void testValidDurations() {
+        Assert.assertEquals(1000.0, new TimeDuration("1s").getTime(), 0.01);
+        Assert.assertEquals(1000.0, new TimeDuration("1sec").getTime(), 0.01);
+        Assert.assertEquals(1000.0, new TimeDuration("1secs").getTime(), 0.01);
+        Assert.assertEquals(100.0, new TimeDuration("100ms").getTime(), 0.01);
+        Assert.assertEquals(60000.0, new TimeDuration("1m").getTime(), 0.01);
+        Assert.assertEquals(60000.0, new TimeDuration("1min").getTime(), 0.01);
+        Assert.assertEquals(3600000.0, new TimeDuration("1h").getTime(), 0.01);
+        Assert.assertEquals(3600000.0, new TimeDuration("1hr").getTime(), 0.01);
+        Assert.assertEquals(3600000.0, new TimeDuration("1hour").getTime(), 0.01);
+        Assert.assertEquals(7200000.0, new TimeDuration("2hours").getTime(), 0.01);
+    }
+
+    @Test
+    public void testDecimalDurations() {
+        Assert.assertEquals(1500.0, new TimeDuration("1.5s").getTime(), 0.01);
+        Assert.assertEquals(90000.0, new TimeDuration("1.5min").getTime(), 0.01);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidFormat() {
+        new TimeDuration("invalid");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidUnit() {
+        new TimeDuration("1d");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeValue() {
+        new TimeDuration("-1s");
+    }
+}

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -54,7 +54,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -319,6 +318,7 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+    <sourceDirectory>target/generated-sources/antlr4</sourceDirectory>
     <plugins>
       <plugin>
         <groupId>org.antlr</groupId>

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION
  ;
 
 ecommand
@@ -280,6 +280,21 @@ EscapeSequence
    |   OctalEscape
    ;
 
+BYTE_SIZE 
+    : (FLOAT | Int) BYTE_UNIT; 
+
+TIME_DURATION: (FLOAT | Int) TIME_UNIT;
+
+fragment BYTE_UNIT 
+  : ('K' | 'k') ('B' | 'b')?
+  | ('M' | 'm') ('B' | 'b')? 
+  | ('G' | 'g') ('B' | 'b')? 
+  | ('T' | 't') ('B' | 'b')?   
+;
+
+fragment TIME_UNIT: 'ms' | 's' | 'sec' | 'secs' | 'm' | 'min' | 'h' | 'hr' | 'hour' | 'hours';
+
+
 fragment
 OctalEscape
    :   '\\' ('0'..'3') ('0'..'7') ('0'..'7')
@@ -307,6 +322,10 @@ fragment Int
  : '-'? [1-9] Digit* [L]*
  | '0'
  ;
+
+fragment FLOAT   
+  : [0-9]+ '.' [0-9]+   
+  ;  
 
 fragment Digit
  : [0-9]

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import java.util.ArrayList;
+import java.util.List;
+/**
+ * Directive for aggregating statistics.
+ */
+@Categories(categories = { "data-aggregation"})
+
+public class AggregateStats implements Directive {
+    public static final String NAME = "aggregate-stats";
+    private String byteCol;
+    private String timeCol;
+    private String outputSizeCol;
+    private String outputTimeCol;
+    private double totalBytes = 0.0;
+    private double totalTimeMs = 0.0;
+    private int count = 0;
+
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+        builder.define("byteCol", TokenType.COLUMN_NAME);
+        builder.define("timeCol", TokenType.COLUMN_NAME);
+        builder.define("outputSizeCol", TokenType.TEXT);
+        builder.define("outputTimeCol", TokenType.TEXT);
+        return builder.build();
+    }
+
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        byteCol = ((ColumnName) args.value("byteCol")).value();
+        timeCol = ((ColumnName) args.value("timeCol")).value();
+        outputSizeCol = ((Text) args.value("outputSizeCol")).value();
+        outputTimeCol = ((Text) args.value("outputTimeCol")).value();
+    }
+
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext ctx) throws DirectiveExecutionException {
+        try {
+            for (Row row : rows) {
+                if (row.find(byteCol) != -1 && row.find(timeCol) != -1) {
+                    String byteVal = row.getValue(byteCol).toString();
+                    String timeVal = row.getValue(timeCol).toString();
+                    
+                    // Use ByteSize and TimeDuration classes for parsing
+                    ByteSize byteSize = new ByteSize(byteVal);
+                    TimeDuration duration = new TimeDuration(timeVal);
+                    
+                    totalBytes += byteSize.getBytes();
+                    totalTimeMs += duration.getTime();
+                    count++;
+                }
+            }
+
+            if (count == 0) {
+                return new ArrayList<>(); // Return an empty list if no valid rows were processed
+            }
+
+            List<Row> results = new ArrayList<>();
+            Row result = new Row();
+            
+            // Convert bytes to MB and milliseconds to seconds
+            result.add(outputSizeCol, totalBytes / (1024.0 * 1024.0));  // Convert to MB
+            result.add(outputTimeCol, totalTimeMs / 1000.0);            // Convert to seconds
+            
+            results.add(result);
+            return results;
+            
+        } catch (Exception e) {
+            throw new DirectiveExecutionException(
+                String.format("Error aggregating stats: %s", e.getMessage())
+            );
+        }
+    }
+
+    // @Override
+    public Schema getOutputSchema(Schema inputSchema) {
+        List<Schema.Field> fields = new ArrayList<>();
+        fields.add(Schema.Field.of(outputSizeCol, Schema.of(Schema.Type.DOUBLE)));
+        fields.add(Schema.Field.of(outputTimeCol, Schema.of(Schema.Type.DOUBLE)));
+        return Schema.recordOf("aggregate-stats", fields);
+    }
+
+    @Override
+    public void destroy() {
+      // Reset all accumulated values
+      totalBytes = 0.0;
+      totalTimeMs = 0.0;
+      count = 0;
+
+      // Clear column references
+      byteCol = null;
+      timeCol = null;
+      outputSizeCol = null;
+      outputTimeCol = null;
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,6 +22,7 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
+import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -33,12 +34,15 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
+import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -325,5 +329,22 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     int lineno = ctx.getStart().getLine();
     int column = ctx.getStart().getCharPositionInLine();
     return new SourceInfo(lineno, column, text);
+  }
+  
+  @Override
+  public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
+    if (ctx.BYTE_SIZE() != null) {
+        String value = ctx.BYTE_SIZE().getText();
+        builder.addToken(new ByteSize(value));
+        return builder;
+    }
+
+    if (ctx.TIME_DURATION() != null) {
+        String value = ctx.TIME_DURATION().getText();
+        builder.addToken(new TimeDuration(value));
+        return builder;
+    }
+
+    return super.visitValue(ctx);
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+// Reorder imports to follow checkstyle rules
+import com.google.gson.JsonElement;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AggregateStatsTest {
+
+  @Test
+  public void testAggregateStatsDirective() throws Exception {
+    // Step 1: Prepare input rows
+    List<Row> rows = new ArrayList<>();
+    rows.add(new Row().add("data_transfer_size", "10KB").add("response_time", "2s"));
+    rows.add(new Row().add("data_transfer_size", "5KB").add("response_time", "500ms"));
+
+    // Step 2: Create an instance of the directive
+    AggregateStats directive = new AggregateStats();
+
+    // Step 3: Manually mock Arguments
+    Arguments args = createMockArguments();
+
+    // Step 4: Initialize and execute the directive
+    directive.initialize(args);
+    List<Row> result = directive.execute(rows, null);
+
+    // Step 5: Validate output
+    Assert.assertEquals(1, result.size());
+
+    Row output = result.get(0);
+
+    // Size: 10KB + 5KB = 15KB = 15 * 1024 bytes = 15360 bytes
+    // MB = bytes / (1024 * 1024)
+    double expectedMB = 15360.0 / (1024 * 1024);
+    double actualMB = (Double) output.getValue("total_size_mb");
+
+    // Time: 2s + 500ms = 2500ms = 2.5s
+    double expectedSeconds = 2.5;
+    double actualSeconds = (Double) output.getValue("total_time_sec");
+
+    Assert.assertEquals(expectedMB, actualMB, 0.001);
+    Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+  }
+
+  @Test
+  public void testEmptyInputRows() throws Exception {
+    List<Row> rows = new ArrayList<>();
+
+    AggregateStats directive = new AggregateStats();
+    Arguments args = createMockArguments();
+
+    directive.initialize(args);
+    List<Row> result = directive.execute(rows, null);
+
+    Assert.assertEquals(0, result.size());
+  }
+
+  @Test
+  public void testInvalidData() throws Exception {
+    List<Row> rows = new ArrayList<>();
+    rows.add(new Row().add("data_transfer_size", "invalidKB").add("response_time", "invalidTime"));
+
+    AggregateStats directive = new AggregateStats();
+    Arguments args = createMockArguments();
+
+    directive.initialize(args);
+    try {
+      directive.execute(rows, null);
+      Assert.fail("Expected an exception for invalid data");
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Error aggregating stats"));
+    }
+  }
+
+  @Test
+  public void testLargeData() throws Exception {
+    List<Row> rows = new ArrayList<>();
+    rows.add(new Row().add("data_transfer_size", "1024MB").add("response_time", "1h"));
+    rows.add(new Row().add("data_transfer_size", "512MB").add("response_time", "30m"));
+
+    AggregateStats directive = new AggregateStats();
+    Arguments args = createMockArguments();
+
+    directive.initialize(args);
+    List<Row> result = directive.execute(rows, null);
+
+    Assert.assertEquals(1, result.size());
+
+    Row output = result.get(0);
+
+    double expectedMB = 1536.0; // 1024MB + 512MB
+    double actualMB = (Double) output.getValue("total_size_mb");
+
+    double expectedSeconds = 5400.0; // 1h + 30m = 5400 seconds
+    double actualSeconds = (Double) output.getValue("total_time_sec");
+
+    Assert.assertEquals(expectedMB, actualMB, 0.001);
+    Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+  }
+
+  @Test
+  public void testEdgeCases() throws Exception {
+    List<Row> rows = new ArrayList<>();
+    rows.add(new Row().add("data_transfer_size", "0KB").add("response_time", "0s"));
+
+    AggregateStats directive = new AggregateStats();
+    Arguments args = createMockArguments();
+
+    directive.initialize(args);
+    List<Row> result = directive.execute(rows, null);
+
+    Assert.assertEquals(1, result.size());
+
+    Row output = result.get(0);
+
+    double expectedMB = 0.0;
+    double actualMB = (Double) output.getValue("total_size_mb");
+
+    double expectedSeconds = 0.0;
+    double actualSeconds = (Double) output.getValue("total_time_sec");
+
+    Assert.assertEquals(expectedMB, actualMB, 0.001);
+    Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+  }
+
+  private Arguments createMockArguments() {
+    return new Arguments() {
+      @SuppressWarnings("unchecked")
+      @Override
+      public <T extends Token> T value(String name) {
+        switch (name) {
+          case "byteCol":
+            return (T) new ColumnName("data_transfer_size");
+          case "timeCol":
+            return (T) new ColumnName("response_time");
+          case "outputSizeCol":
+            return (T) new Text("total_size_mb");
+          case "outputTimeCol":
+            return (T) new Text("total_time_sec");
+        }
+        return null;
+      }
+
+      @Override
+      public int size() {
+        return 4;
+      }
+
+      @Override
+      public boolean contains(String name) {
+        return true;
+      }
+
+      @Override
+      public TokenType type(String name) {
+        return null;
+      }
+
+      @Override
+      public int line() {
+        return 1;
+      }
+
+      @Override
+      public int column() {
+        return 0;
+      }
+
+      @Override
+      public String source() {
+        return "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec";
+      }
+
+      @Override
+      public JsonElement toJson() {
+        return null;
+      }
+    };
+  }
+}

--- a/wrangler-docs/directives/parse-as-bytesize.md
+++ b/wrangler-docs/directives/parse-as-bytesize.md
@@ -1,0 +1,17 @@
+# Parse as ByteSize
+
+The PARSE-AS-BYTESIZE directive parses a string representation of byte size into a numeric value.
+
+## Syntax
+```
+parse-as-bytesize <column>
+```
+
+## Usage Notes
+
+The PARSE-AS-BYTESIZE directive will parse strings representing byte sizes (e.g., "10KB", "5MB") into numeric values in bytes. The column to be parsed should be of type string.
+
+If the column is `null` or is already a numeric field, applying this directive is a no-op.
+
+## Examples
+Input: "10KB" → Output: 10240 (bytes)

--- a/wrangler-docs/directives/parse-as-timeduration.md
+++ b/wrangler-docs/directives/parse-as-timeduration.md
@@ -1,0 +1,17 @@
+# Parse as TimeDuration
+
+The PARSE-AS-TIMEDURATION directive parses a string representation of time duration into a numeric value.
+
+## Syntax
+```
+parse-as-timeduration <column>
+```
+
+## Usage Notes
+
+The PARSE-AS-TIMEDURATION directive will parse strings representing time durations (e.g., "2h", "30m") into numeric values in milliseconds. The column to be parsed should be of type string.
+
+If the column is `null` or is already a numeric field, applying this directive is a no-op.
+
+## Examples
+Input: "2h" → Output: 7200000 (milliseconds)


### PR DESCRIPTION
This pull request adds native support for parsing BYTE_SIZE and TIME_DURATION units in the CDAP Wrangler library.

Lexer rules for BYTE_SIZE and TIME_DURATION have been added.
New Java classes ByteSize.java and TimeDuration.java were created to handle the parsing and canonical unit conversion.
A new aggregate directive aggregate-stats was implemented to calculate totals and averages for byte sizes and time durations.
Comprehensive tests have been added for parsing and aggregation functionality.
Please review the changes and let me know if any further modifications are needed.
![PHOTO-2025-04-13-18-44-09](https://github.com/user-attachments/assets/02dcf8b3-a0df-4647-a910-289689fc5786)
