### PR TITLE
Assignment: Add BYTE_SIZE and TIME_DURATION directives 

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+public class ByteSize implements Token {
+
+    private final long bytes;
+
+    public ByteSize(String input) {
+        // Normalize input
+        String valuePart = input.replaceAll("[^0-9.]", "");
+        String unitPart = input.replaceAll("[0-9.]", "").toUpperCase();
+
+        double value = Double.parseDouble(valuePart);
+
+        switch (unitPart) {
+            case "B":
+                this.bytes = (long) value;
+                break;
+            case "KB":
+                this.bytes = (long) (value * 1024);
+                break;
+            case "MB":
+                this.bytes = (long) (value * 1024 * 1024);
+                break;
+            case "GB":
+                this.bytes = (long) (value * 1024 * 1024 * 1024);
+                break;
+            case "TB":
+                this.bytes = (long) (value * 1024L * 1024 * 1024 * 1024);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown byte unit: " + unitPart);
+        }
+    }
+
+    public long getBytes() {
+        return bytes;
+    }
+
+    @Override
+    public Object value() {
+        return bytes;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE ;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(bytes);
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+public class TimeDuration implements Token{
+    private final long millis;
+
+    public TimeDuration(String input) {
+        String valuePart = input.replaceAll("[^0-9.]", "");
+        String unitPart = input.replaceAll("[0-9.]", "").toLowerCase();
+
+        double value = Double.parseDouble(valuePart);
+
+        switch (unitPart) {
+            case "ms":
+                this.millis = (long) value;
+                break;
+            case "s":
+            case "sec":
+                this.millis = (long) (value * 1000);
+                break;
+            case "m":
+            case "min":
+                this.millis = (long) (value * 60 * 1000);
+                break;
+            case "h":
+                this.millis = (long) (value * 60 * 60 * 1000);
+                break;
+            case "d":
+                this.millis = (long) (value * 24 * 60 * 60 * 1000);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown time unit: " + unitPart);
+        }
+    }
+
+    public long getMilliseconds() {
+        return millis;
+    }
+
+    @Override
+    public Object value() {
+        return millis;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(millis);
+    }
+
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -40,6 +40,8 @@ import java.io.Serializable;
  * @see Expression
  * @see Text
  * @see TextList
+ * @see ByteSize
+ * @see TimeDuration
  */
 @PublicEvolving
 public enum TokenType implements Serializable {
@@ -152,5 +154,18 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for the object of type {@code ByteSize}.
+   * This type is associated with a token representing a data size (e.g., "10KB", "1GB").
+   */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for the object of type {@code TimeDuration}.
+   * This type is associated with a token representing a time duration (e.g., "150ms", "2h").
+   */
+  TIME_DURATION
+
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -126,6 +126,10 @@ public final class UsageDefinition implements Serializable {
           sb.append("prop:{key:value,[key:value]*");
         } else if (token.type().equals(TokenType.RANGES)) {
           sb.append("start:end=[bool|text|numeric][,start:end=[bool|text|numeric]*");
+        } else if (token.type().equals(TokenType.BYTE_SIZE)) {
+          sb.append(":").append(token.name());
+        } else if (token.type().equals(TokenType.TIME_DURATION)) {
+          sb.append(":").append(token.name());
         }
       }
 

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for ByteSize and TimeDuration classes.
+ */
+public class ByteSizeAndTimeDurationTest {
+
+    @Test
+    public void testByteSizeParsing() {
+        // Test parsing valid inputs to canonical byte units
+        Assert.assertEquals(1024L, new ByteSize("1KB").getBytes());
+        Assert.assertEquals(1048576L, new ByteSize("1MB").getBytes());
+        Assert.assertEquals(1073741824L, new ByteSize("1GB").getBytes());
+        Assert.assertEquals(10, new ByteSize("10B").getBytes());
+
+        // Test for case insensitivity
+        Assert.assertEquals(1572864L, new ByteSize("1.5MB").getBytes());
+
+    }
+
+    @Test
+    public void testTimeDurationParsing() {
+        // Test parsing valid inputs to canonical time units (milliseconds as double)
+        double delta = 0.0001; // Tolerance for double comparison
+
+        // 5ms -> 5.0 ms
+        Assert.assertEquals(5.0, new TimeDuration("5ms").getMilliseconds(), delta);
+
+        // 2.1s -> 2.1 * 1000.0 = 2100.0 ms
+        Assert.assertEquals(2100.0, new TimeDuration("2.1s").getMilliseconds(), delta);
+
+        // 1h -> 1.0 * 60.0 * 60.0 * 1000.0 = 3,600,000.0 ms
+        Assert.assertEquals(3600000.0, new TimeDuration("1h").getMilliseconds(), delta);
+
+        // Test for case insensitivity (using "min")
+        // 1.5min -> 1.5 * 60.0 * 1000.0 = 90,000.0 ms
+        Assert.assertEquals(90000.0, new TimeDuration("1.5min").getMilliseconds(), delta);
+
+        // Test other units (assuming they were added to TimeDuration)
+        // 1d -> 1.0 * 24.0 * 60.0 * 60.0 * 1000.0 = 86,400,000.0 ms
+        Assert.assertEquals(86400000.0, new TimeDuration("1d").getMilliseconds(), delta);
+    }
+
+}

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION
  ;
 
 ecommand
@@ -311,3 +311,9 @@ fragment Int
 fragment Digit
  : [0-9]
  ;
+
+BYTE_SIZE     : Digit+ ('.' Digit+)? BYTE_UNIT;
+TIME_DURATION : Digit+ ('.' Digit+)? TIME_UNIT;
+
+fragment BYTE_UNIT : [kKmMgGtT] [bB];
+fragment TIME_UNIT : 'ms' | 's' | 'sec' | 'm' | 'min' | 'h' | 'd' ;

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,144 @@
+
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Directive for aggregating statistics.
+ */
+@Plugin(type = Directive.TYPE)
+@Name(AggregateStats.NAME)
+@Categories(categories = { "data-aggregation"})
+public class AggregateStats implements Directive {
+    public static final String NAME = "aggregate-stats";
+    private String byteCol;
+    private String timeCol;
+    private String outputSizeCol;
+    private String outputTimeCol;
+    private double totalBytes = 0.0;
+    private double totalTimeMs = 0.0;
+    private int count = 0;
+
+    /**
+     * Defines the usage of the directive, specifying the required arguments.
+     *
+     * @return UsageDefinition object containing the directive's argument definitions.
+     */
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+        builder.define("byteCol", TokenType.COLUMN_NAME);
+        builder.define("timeCol", TokenType.COLUMN_NAME);
+        builder.define("outputSizeCol", TokenType.TEXT);
+        builder.define("outputTimeCol", TokenType.TEXT);
+        return builder.build();
+    }
+
+    /**
+     * Initializes the directive with the provided arguments.
+     *
+     * @param args Arguments object containing the directive's parameters.
+     * @throws DirectiveParseException if there is an error parsing the arguments.
+     */
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        byteCol = ((ColumnName) args.value("byteCol")).value();
+        timeCol = ((ColumnName) args.value("timeCol")).value();
+        outputSizeCol = ((Text) args.value("outputSizeCol")).value();
+        outputTimeCol = ((Text) args.value("outputTimeCol")).value();
+    }
+
+    /**
+     * Executes the directive on a list of rows, aggregating statistics based on the specified columns.
+     *
+     * @param rows List of Row objects to process.
+     * @param ctx ExecutorContext providing execution context information.
+     * @return List of Row objects containing the aggregated results.
+     * @throws DirectiveExecutionException if there is an error during execution.
+     */
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext ctx) throws DirectiveExecutionException {
+        try {
+            for (Row row : rows) {
+                if (row.find(byteCol) != -1 && row.find(timeCol) != -1) {
+                    String byteVal = row.getValue(byteCol).toString();
+                    String timeVal = row.getValue(timeCol).toString();
+
+                    // Use ByteSize and TimeDuration classes for parsing
+                    ByteSize byteSize = new ByteSize(byteVal);
+                    TimeDuration duration = new TimeDuration(timeVal);
+
+                    totalBytes += byteSize.getBytes();
+                    totalTimeMs += duration.getMilliseconds();
+                    count++;
+                }
+            }
+
+            if (count == 0) {
+                return new ArrayList<>();
+            }
+
+            List<Row> results = new ArrayList<>();
+            Row result = new Row();
+
+            // Convert bytes to MB and milliseconds to seconds
+            result.add(outputSizeCol, totalBytes / (1024.0 * 1024.0));
+            result.add(outputTimeCol, totalTimeMs / 1000.0);
+
+            results.add(result);
+            return results;
+
+        } catch (Exception e) {
+            throw new DirectiveExecutionException(
+                    String.format("Error aggregating stats: %s", e.getMessage())
+            );
+        }
+    }
+
+    /**
+     * Provides the output schema for the directive based on the input schema.
+     *
+     * @param inputSchema Schema object representing the input schema.
+     * @return Schema object representing the output schema.
+     */
+    public Schema getOutputSchema(Schema inputSchema) {
+        List<Schema.Field> fields = new ArrayList<>();
+        fields.add(Schema.Field.of(outputSizeCol, Schema.of(Schema.Type.DOUBLE)));
+        fields.add(Schema.Field.of(outputTimeCol, Schema.of(Schema.Type.DOUBLE)));
+        return Schema.recordOf(NAME, fields);
+    }
+
+    /**
+     * Cleans up resources and resets the directive's state.
+     */
+    @Override
+    public void destroy() {
+        // Reset all accumulated values
+        totalBytes = 0.0;
+        totalTimeMs = 0.0;
+        count = 0;
+
+        // Clear column references
+        byteCol = null;
+        timeCol = null;
+        outputSizeCol = null;
+        outputTimeCol = null;
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -34,6 +34,7 @@ import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
 import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.*;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -326,4 +327,27 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     int column = ctx.getStart().getCharPositionInLine();
     return new SourceInfo(lineno, column, text);
   }
+
+  @Override
+  public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
+    Token token;
+    if (ctx.Number() != null) {
+      token = new Numeric(new LazyNumber(ctx.Number().getText()));
+    } else if (ctx.Column() != null) {
+      token = new ColumnName(ctx.Column().getText().substring(1));
+    } else if (ctx.Bool() != null) {
+      token = new Bool(Boolean.valueOf(ctx.Bool().getText()));
+    } else if (ctx.BYTE_SIZE() != null) {
+      token = new ByteSize(ctx.BYTE_SIZE().getText());
+    } else if (ctx.TIME_DURATION() != null) {
+      token = new TimeDuration(ctx.TIME_DURATION().getText());
+    } else {
+      String text = ctx.String().getText();
+      token = new Text(text.substring(1, text.length() - 1));
+    }
+
+    builder.addToken(token);
+    return builder;
+  }
+
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,203 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import com.google.gson.JsonElement;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.TokenType;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AggregateStatsTest {
+
+    @Test
+    public void testAggregateStatsDirective() throws Exception {
+        // Step 1: Prepare input rows
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "10KB").add("response_time", "2s"));
+        rows.add(new Row().add("data_transfer_size", "5KB").add("response_time", "500ms"));
+
+        // Step 2: Create an instance of the directive
+        AggregateStats directive = new AggregateStats();
+
+        // Step 3: Manually mock Arguments
+        Arguments args = createMockArguments();
+
+        // Step 4: Initialize and execute the directive
+        directive.initialize(args);
+        List<Row> result = directive.execute(rows, null);
+
+        // Step 5: Validate output
+        Assert.assertEquals(1, result.size());
+
+        Row output = result.get(0);
+
+        // Size: 10KB + 5KB = 15KB = 15 * 1024 bytes = 15360 bytes
+        // MB = bytes / (1024 * 1024)
+        double expectedMB = 15360.0 / (1024 * 1024);
+        double actualMB = (Double) output.getValue("total_size_mb");
+
+        // Time: 2s + 500ms = 2500ms = 2.5s
+        double expectedSeconds = 2.5;
+        double actualSeconds = (Double) output.getValue("total_time_sec");
+
+        Assert.assertEquals(expectedMB, actualMB, 0.001);
+        Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+    }
+
+    @Test
+    public void testEmptyInputRows() throws Exception {
+        List<Row> rows = new ArrayList<>();
+
+        AggregateStats directive = new AggregateStats();
+        Arguments args = createMockArguments();
+
+        directive.initialize(args);
+        List<Row> result = directive.execute(rows, null);
+
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testInvalidData() throws Exception {
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "invalidKB").add("response_time", "invalidTime"));
+
+        AggregateStats directive = new AggregateStats();
+        Arguments args = createMockArguments();
+
+        directive.initialize(args);
+        try {
+            directive.execute(rows, null);
+            Assert.fail("Expected an exception for invalid data");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Error aggregating stats"));
+        }
+    }
+
+    @Test
+    public void testLargeData() throws Exception {
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "1024MB").add("response_time", "1h"));
+        rows.add(new Row().add("data_transfer_size", "512MB").add("response_time", "30m"));
+
+        AggregateStats directive = new AggregateStats();
+        Arguments args = createMockArguments();
+
+        directive.initialize(args);
+        List<Row> result = directive.execute(rows, null);
+
+        Assert.assertEquals(1, result.size());
+
+        Row output = result.get(0);
+
+        double expectedMB = 1536.0; // 1024MB + 512MB
+        double actualMB = (Double) output.getValue("total_size_mb");
+
+        double expectedSeconds = 5400.0; // 1h + 30m = 5400 seconds
+        double actualSeconds = (Double) output.getValue("total_time_sec");
+
+        Assert.assertEquals(expectedMB, actualMB, 0.001);
+        Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+    }
+
+    @Test
+    public void testEdgeCases() throws Exception {
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "0KB").add("response_time", "0s"));
+
+        AggregateStats directive = new AggregateStats();
+        Arguments args = createMockArguments();
+
+        directive.initialize(args);
+        List<Row> result = directive.execute(rows, null);
+
+        Assert.assertEquals(1, result.size());
+
+        Row output = result.get(0);
+
+        double expectedMB = 0.0;
+        double actualMB = (Double) output.getValue("total_size_mb");
+
+        double expectedSeconds = 0.0;
+        double actualSeconds = (Double) output.getValue("total_time_sec");
+
+        Assert.assertEquals(expectedMB, actualMB, 0.001);
+        Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+    }
+
+    private Arguments createMockArguments() {
+        return new Arguments() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T extends Token> T value(String name) {
+                switch (name) {
+                    case "byteCol":
+                        return (T) new ColumnName("data_transfer_size");
+                    case "timeCol":
+                        return (T) new ColumnName("response_time");
+                    case "outputSizeCol":
+                        return (T) new Text("total_size_mb");
+                    case "outputTimeCol":
+                        return (T) new Text("total_time_sec");
+                }
+                return null;
+            }
+
+            @Override
+            public int size() {
+                return 4;
+            }
+
+            @Override
+            public boolean contains(String name) {
+                return true;
+            }
+
+            @Override
+            public TokenType type(String name) {
+                return null;
+            }
+
+            @Override
+            public int line() {
+                return 1;
+            }
+
+            @Override
+            public int column() {
+                return 0;
+            }
+
+            @Override
+            public String source() {
+                return "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec";
+            }
+
+            @Override
+            public JsonElement toJson() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Added unit tests for ByteSize and TimeDuration to verify correct parsing and edge cases, including invalid input handling.

- Also added comprehensive tests for the new AggregateStats directive to ensure it works correctly with valid, empty, and malformed input rows.

- Ensured backward compatibility and followed the existing testing patterns used in Wrangler.