### PR TITLE
Add support for ByteSize and TimeDuration parsing with aggregate-stats directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,23 @@ Cask is a trademark of Cask Data, Inc. All rights reserved.
 
 Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
 permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.
+
+
+## 🔧 New Feature: Byte Size & Time Duration Parsing Support
+
+Wrangler now supports native parsing of **Byte Size** and **Time Duration** values directly within directives using the enhanced grammar and custom token types.
+
+### ✨ Supported Formats
+
+- **Byte Sizes**: `10KB`, `1.5MB`, `500B`, `2GB`, `3TB`, etc.
+- **Time Durations**: `100ms`, `1.5s`, `3h`, `2m`, etc.
+
+These values are parsed using the `ByteSize` and `TimeDuration` classes and automatically converted to base units (bytes and milliseconds) for processing.
+
+---
+
+### 🧪 Example Directive Usage
+
+```wrangler
+aggregate-stats :data_transfer :response_time total_size_mb total_time_sec
+

--- a/prompts.txt
+++ b/prompts.txt
@@ -1,0 +1,11 @@
+Prompt:
+Enhance CDAP Wrangler to support parsing and handling of Byte Size and Time Duration units in directives.
+
+Files Added / Modified:
+- ByteSize.java and TimeDuration.java in wrangler-api
+- Grammar updated in Directives.g4 (added BYTE_SIZE, TIME_DURATION)
+- New directive: AggregateStats in wrangler-core
+- New test: AggregateStatsTest.java
+
+Description:
+This change introduces support for parsing human-readable byte sizes (e.g., "1KB", "5MB") and time durations (e.g., "100ms", "2s") in the Wrangler recipe language. It also adds a new directive `aggregate-stats` to compute total size (in MB) and total time (in seconds) from columns containing such values. Grammar and test coverage are included.

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+/**
+ * Token implementation for parsing byte size values like "10KB", "1.5MB", "2GB", etc.
+ */
+@PublicEvolving
+public class ByteSize implements Token {
+  private final long bytes;
+  private final String original;
+
+  public ByteSize(String value) {
+    this.original = value;
+    String lower = value.trim().toLowerCase();
+    double numericValue;
+
+    if (lower.endsWith("kb")) {
+      numericValue = Double.parseDouble(lower.replace("kb", ""));
+      this.bytes = (long) (numericValue * 1024);
+    } else if (lower.endsWith("mb")) {
+      numericValue = Double.parseDouble(lower.replace("mb", ""));
+      this.bytes = (long) (numericValue * 1024 * 1024);
+    } else if (lower.endsWith("gb")) {
+      numericValue = Double.parseDouble(lower.replace("gb", ""));
+      this.bytes = (long) (numericValue * 1024 * 1024 * 1024);
+    } else if (lower.endsWith("tb")) {
+      numericValue = Double.parseDouble(lower.replace("tb", ""));
+      this.bytes = (long) (numericValue * 1024L * 1024 * 1024 * 1024);
+    } else if (lower.endsWith("b")) {
+      numericValue = Double.parseDouble(lower.replace("b", ""));
+      this.bytes = (long) numericValue;
+    } else {
+      throw new IllegalArgumentException("Unsupported byte unit. Supported units: B, KB, MB, GB, TB. Input: " + value);
+    }
+  }
+
+  public long getBytes() {
+    return bytes;
+  }
+
+  @Override
+  public Object value() {
+    return original;
+  }
+
+  @Override
+  public TokenType type() {
+    return TokenType.BYTE_SIZE;
+  }
+
+  @Override
+  public JsonElement toJson() {
+    return new JsonPrimitive(original);
+  }
+
+  @Override
+  public String toString() {
+    return bytes + " bytes";
+  }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+/**
+ * Token implementation for parsing time durations like "100ms", "2s", "1.5m", "3h".
+ */
+@PublicEvolving
+public class TimeDuration implements Token {
+  private final long milliseconds;
+  private final String original;
+
+  public TimeDuration(String value) {
+    this.original = value;
+    String lower = value.trim().toLowerCase();
+    double numericValue;
+
+    if (lower.endsWith("ms")) {
+      numericValue = Double.parseDouble(lower.replace("ms", ""));
+      this.milliseconds = (long) numericValue;
+    } else if (lower.endsWith("s")) {
+      numericValue = Double.parseDouble(lower.replace("s", ""));
+      this.milliseconds = (long) (numericValue * 1000);
+    } else if (lower.endsWith("m")) {
+      numericValue = Double.parseDouble(lower.replace("m", ""));
+      this.milliseconds = (long) (numericValue * 60 * 1000);
+    } else if (lower.endsWith("h")) {
+      numericValue = Double.parseDouble(lower.replace("h", ""));
+      this.milliseconds = (long) (numericValue * 60 * 60 * 1000);
+    } else {
+      throw new IllegalArgumentException(
+        "Unsupported time unit. Supported units: ms, s, m, h. Input: " + value
+      );
+    }
+  }
+
+  public long getMilliseconds() {
+    return milliseconds;
+  }
+
+  @Override
+  public Object value() {
+    return original;
+  }
+
+  @Override
+  public TokenType type() {
+    return TokenType.TIME_DURATION;
+  }
+
+  @Override
+  public JsonElement toJson() {
+    return new JsonPrimitive(original);
+  }
+
+  @Override
+  public String toString() {
+    return milliseconds + " ms";
+  }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,15 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+  
+   /**
+   * Custom token for byte size like "10KB", "1.5MB"
+   */
+  BYTE_SIZE,
+
+  /**
+   * Custom token for time duration like "500ms", "2.5s"
+   */
+  TIME_DURATION
 }

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | byteSize | timeDuration
  ;
 
 ecommand
@@ -165,6 +165,14 @@ number
 
 bool
  : Bool
+ ;
+
+byteSize
+ : BYTE_SIZE
+ ;
+
+timeDuration
+ : TIME_DURATION
  ;
 
 condition
@@ -311,3 +319,30 @@ fragment Int
 fragment Digit
  : [0-9]
  ;
+ 
+// Byte size values like 10KB, 1.5MB
+BYTE_SIZE
+  : Digit+ ('.' Digit+)? BYTE_UNIT
+  ;
+
+// Time duration values like 100ms, 2s
+TIME_DURATION
+  : Digit+ ('.' Digit+)? TIME_UNIT
+  ;
+
+// Byte units: B, KB, MB, GB, TB (case insensitive)
+fragment BYTE_UNIT
+  : [kK]?[bB]      // B, KB
+  | [mM][bB]       // MB
+  | [gG][bB]       // GB
+  | [tT][bB]       // TB
+  ;
+
+// Time units: ms, s, m, h (case insensitive)
+fragment TIME_UNIT
+  : [mM][sS]       // ms
+  | [sS]           // s
+  | [mM]           // minutes (if desired)
+  | [hH]           // hours (if desired)
+  ;
+

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,136 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Directive that aggregates byte size and time duration columns
+ * and returns total/average in desired units.
+ */
+@PublicEvolving
+public final class AggregateStats implements Directive {
+
+   /** Number of bytes in a kilobyte. */
+  private static final double KB = 1024.0;
+
+  /** Number of bytes in a megabyte. */
+  private static final double MB = KB * KB;
+
+  /** Number of milliseconds in one second. */
+  private static final double MS_IN_SEC = 1000.0;
+
+  /** Input column containing byte size strings. */
+  private String sizeColumn;
+
+  /** Input column containing time duration strings. */
+  private String timeColumn;
+
+  /** Output column name for total size in megabytes. */
+  private String targetSizeColumn;
+
+  /** Output column name for total time in seconds. */
+  private String targetTimeColumn;
+
+  /** Total number of bytes aggregated from all rows. */
+  private long totalBytes;
+
+  /** Total number of milliseconds aggregated from all rows. */
+  private long totalMillis;
+
+  /** Total number of rows processed. */
+  private int rowCount;
+
+  @Override
+  public UsageDefinition define() {
+    UsageDefinition.Builder builder =
+    UsageDefinition.builder("aggregate-stats");
+    builder.define("sizeColumn", TokenType.COLUMN_NAME);
+    builder.define("timeColumn", TokenType.COLUMN_NAME);
+    builder.define("targetSizeColumn", TokenType.COLUMN_NAME);
+    builder.define("targetTimeColumn", TokenType.COLUMN_NAME);
+    return builder.build();
+  }
+
+  @Override
+  public void initialize(final Arguments arguments) {
+    sizeColumn = ((ColumnName) arguments.value("sizeColumn")).value();
+    timeColumn = ((ColumnName) arguments.value("timeColumn")).value();
+    targetSizeColumn = ((ColumnName) arguments.value(
+                         "targetSizeColumn")).value();
+    targetTimeColumn = ((ColumnName) arguments.value(
+                         "targetTimeColumn")).value();
+  }
+
+  @Override
+  public List<Row> execute(final List<Row> rows,
+  final ExecutorContext context) {
+    for (Row row : rows) {
+      Object sizeValue = row.getValue(sizeColumn);
+      Object timeValue = row.getValue(timeColumn);
+
+      if (sizeValue instanceof String) {
+        try {
+          ByteSize byteSize = new ByteSize((String) sizeValue);
+          totalBytes += byteSize.getBytes();
+        } catch (Exception e) {
+          System.err.println("Invalid byte size: " + sizeValue);
+        }
+      }
+
+      if (timeValue instanceof String) {
+        try {
+          TimeDuration duration = new TimeDuration((String) timeValue);
+          totalMillis += duration.getMilliseconds();
+        } catch (Exception e) {
+          System.err.println("Invalid time duration: " + timeValue);
+        }
+      }
+
+      rowCount++;
+    }
+
+    List<Row> output = new ArrayList<>();
+    Row aggregatedRow = new Row();
+
+    double totalSizeMb = totalBytes / MB;
+    double totalTimeSec = totalMillis / MS_IN_SEC;
+
+    aggregatedRow.add(targetSizeColumn, totalSizeMb);
+    aggregatedRow.add(targetTimeColumn, totalTimeSec);
+
+    output.add(aggregatedRow);
+    return output;
+  }
+
+  @Override
+  public void destroy() {
+    // No cleanup necessary
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/package-info.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/package-info.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Package for aggregate directives.
+ */
+package io.cdap.directives.aggregates;

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -316,6 +316,24 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     builder.addToken(new TextList(strs));
     return builder;
   }
+  
+  /**
+ * A Directive can contain a ByteSize literal (e.g., 10KB, 1.5MB).
+ */
+  @Override
+  public RecipeSymbol.Builder visitByteSize(DirectivesParser.ByteSizeContext ctx) {
+    builder.addToken(new io.cdap.wrangler.api.parser.ByteSize(ctx.getText()));
+    return builder;
+  }
+
+  /**
+ * A Directive can contain a TimeDuration literal (e.g., 100ms, 2s).
+ */
+  @Override
+  public RecipeSymbol.Builder visitTimeDuration(DirectivesParser.TimeDurationContext ctx) {
+    builder.addToken(new io.cdap.wrangler.api.parser.TimeDuration(ctx.getText()));
+    return builder;
+  }
 
   private SourceInfo getOriginalSource(ParserRuleContext ctx) {
     int a = ctx.getStart().getStartIndex();

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.etl.api.Lookup;
+import io.cdap.cdap.etl.api.StageMetrics;
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.ExecutorContext.Environment;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.TransientStore;
+import io.cdap.wrangler.proto.Contexts;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests {@link AggregateStats}.
+ */
+public class AggregateStatsTest {
+
+  static {
+    try {
+      Class.forName("io.cdap.directives.aggregates.AggregateStats");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Failed to load AggregateStats directive", e);
+    }
+  }
+
+  @Test
+  public void testAggregateStatsDirective() throws Exception {
+    List<Row> inputRows = Arrays.asList(
+      new Row("data_size", "10KB").add("duration", "500ms"),
+      new Row("data_size", "2MB").add("duration", "1.5s"),
+      new Row("data_size", "512KB").add("duration", "250ms")
+    );
+
+    String[] recipe = new String[] {
+      "aggregate-stats :data_size :duration total_size_mb total_time_sec"
+    };
+
+    ExecutorContext context = new ExecutorContext() {
+      @Override
+      public Environment getEnvironment() {
+        return Environment.TESTING;
+      }
+
+      @Override
+      public String getNamespace() {
+        return Contexts.SYSTEM;
+      }
+
+      @Override
+      public StageMetrics getMetrics() {
+        return null;
+      }
+
+      @Override
+      public String getContextName() {
+        return "test";
+      }
+
+      @Override
+      public Map<String, String> getProperties() {
+        return new HashMap<>();
+      }
+
+      @Override
+      public URL getService(final String applicationId, final String serviceId) {
+        return null;
+      }
+
+      @Override
+      public TransientStore getTransientStore() {
+        return null;
+      }
+
+      @Override
+      public <T> Lookup<T> provide(final String name, final Map<String, String> map) {
+        return null;
+      }
+    };
+
+    List<Row> result = TestingRig.execute(recipe, inputRows, context);
+
+    Assert.assertEquals(1, result.size());
+    Row output = result.get(0);
+
+    long totalBytes = 10 * 1024 + 2 * 1024 * 1024 + 512 * 1024;
+    double expectedSizeMb = totalBytes / (1024.0 * 1024.0);
+
+    long totalMillis = 500 + 1500 + 250;
+    double expectedTimeSec = totalMillis / 1000.0;
+
+    Assert.assertEquals(expectedSizeMb,
+                        (double) output.getValue("total_size_mb"), 0.001);
+    Assert.assertEquals(expectedTimeSec,
+                        (double) output.getValue("total_time_sec"), 0.001);
+  }
+}


### PR DESCRIPTION
### Summary

Added support for parsing byte sizes (e.g., `10KB`, `2MB`) and time durations (e.g., `5s`, `300ms`) in CDAP Wrangler.

### Files Added / Modified
- `ByteSize.java` and `TimeDuration.java` in `wrangler-api`
- Updated grammar in `Directives.g4` (added `BYTE_SIZE`, `TIME_DURATION`)
- New directive: `AggregateStats.java` in `wrangler-core`
- New test: `AggregateStatsTest.java`
- Created `prompts.txt` in project root
- Updated `.github/ISSUE_TEMPLATE/assignment.md`

### Notes
- Checkstyle passed ✅
- Tests passed ✅
