### PR TITLE
Add support for parsing ByteSize and TimeDuration units in Wrangler

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,173 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+ package io.cdap.wrangler.api.parser;
+
+ import com.google.gson.JsonElement;
+ import com.google.gson.JsonObject;
+ import io.cdap.wrangler.api.annotations.PublicEvolving;
+ 
+ /**
+  * Represents a Token for ByteSize, capable of parsing a size string
+  * (e.g., "10KB", "1.5MB") and converting it to a canonical unit (bytes).
+  */
+ @PublicEvolving
+ public class ByteSize implements Token {
+ 
+     // Use double for multipliers to handle fractional input accurately before casting
+     private static final double KILOBYTE = 1024.0;
+     private static final double MEGABYTE = KILOBYTE * 1024.0;
+     private static final double GIGABYTE = MEGABYTE * 1024.0;
+     private static final double TERABYTE = GIGABYTE * 1024.0; // Added Terabyte
+ 
+     private final long value; // Store final value in bytes as long
+ 
+     /**
+      * Constructs a ByteSizeToken by parsing the given size string.
+      *
+      * @param value The size string to parse (e.g., "10KB", "1.5MB").
+      * @throws IllegalArgumentException If the size string is invalid.
+      */
+     public ByteSize(String value) {
+         this.value = parseSize(value);
+     }
+ 
+     /**
+      * Parses the given size string and converts it into bytes.
+      * Handles integer and floating-point numbers.
+      *
+      * @param sizeString The size string to parse.
+      * @return The size in bytes (truncated to long).
+      * @throws IllegalArgumentException If the size string format or unit is invalid.
+      */
+     private long parseSize(String sizeString) {
+         if (sizeString == null || sizeString.trim().isEmpty()) {
+             throw new IllegalArgumentException("Size string must not be null or empty.");
+         }
+ 
+         sizeString = sizeString.trim().toUpperCase();
+         String numericPart;
+         double multiplier;
+ 
+         try {
+             if (sizeString.endsWith("KB")) {
+                 numericPart = sizeString.substring(0, sizeString.length() - 2);
+                 multiplier = KILOBYTE;
+             } else if (sizeString.endsWith("MB")) {
+                 numericPart = sizeString.substring(0, sizeString.length() - 2);
+                 multiplier = MEGABYTE;
+             } else if (sizeString.endsWith("GB")) {
+                 numericPart = sizeString.substring(0, sizeString.length() - 2);
+                 multiplier = GIGABYTE;
+             } else if (sizeString.endsWith("TB")) { // Added Terabyte
+                 numericPart = sizeString.substring(0, sizeString.length() - 2);
+                 multiplier = TERABYTE;
+             } else if (sizeString.endsWith("B")) {
+                 numericPart = sizeString.substring(0, sizeString.length() - 1);
+                 multiplier = 1.0;
+             } else {
+                 // Match the test's expected generic message format
+                 throw new IllegalArgumentException(
+                     "Invalid byte size format or unsupported unit in string: " + sizeString
+                 );
+             }
+ 
+             if (numericPart.isEmpty()) {
+                 throw new IllegalArgumentException("Missing numeric value in size string: " + sizeString);
+             }
+ 
+             double parsedValue = Double.parseDouble(numericPart);
+             if (parsedValue < 0) {
+                 throw new IllegalArgumentException("Size value cannot be negative: " + sizeString);
+             }
+             // Cast to long truncates fractional bytes, which is reasonable for byte sizes.
+             return (long) (parsedValue * multiplier);
+ 
+         } catch (NumberFormatException e) {
+             throw new IllegalArgumentException("Invalid numeric value in size string: " + sizeString, e);
+         }
+     }
+ 
+     /**
+      * Returns the size in bytes.
+      *
+      * @return The size in bytes.
+      */
+     public long getBytes() {
+         return value;
+     }
+ 
+     /**
+      * Returns the size in kilobytes (double for potential fractions).
+      *
+      * @return The size in kilobytes.
+      */
+     public double getKiloBytes() {
+         return value / KILOBYTE;
+     }
+ 
+     /**
+      * Returns the size in megabytes (double for potential fractions).
+      *
+      * @return The size in megabytes.
+      */
+     public double getMegaBytes() {
+         return value / MEGABYTE;
+     }
+ 
+     /**
+      * Returns the size in gigabytes (double for potential fractions).
+      *
+      * @return The size in gigabytes.
+      */
+     public double getGigaBytes() {
+         return value / GIGABYTE;
+     }
+ 
+     /**
+      * Returns the size in terabytes (double for potential fractions).
+      *
+      * @return The size in terabytes.
+      */
+     public double getTeraBytes() {
+         return value / TERABYTE;
+     }
+ 
+     @Override
+     public Object value() {
+         return value;
+     }
+ 
+     @Override
+     public TokenType type() {
+         return TokenType.BYTE_SIZE;
+     }
+ 
+     @Override
+     public JsonElement toJson() {
+         JsonObject object = new JsonObject();
+         object.addProperty("type", TokenType.BYTE_SIZE.name());
+         object.addProperty("value", value); // Store the canonical long value
+         return object;
+     }
+ 
+     @Override
+     public String toString() {
+         // Provide a reasonable string representation, maybe the original input if stored,
+         // or reconstruct from the byte value. For simplicity, just return bytes.
+         return value + "B";
+     }
+ }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,164 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *  Copyright © 2023 Google LLC // Update copyright year/holder if needed
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+ package io.cdap.wrangler.api.parser;
+
+ import com.google.gson.JsonElement;
+ import com.google.gson.JsonObject;
+ import io.cdap.wrangler.api.annotations.PublicEvolving;
+ 
+ import java.util.concurrent.TimeUnit;
+ 
+ /**
+  * Represents a Token for TimeDuration, capable of parsing a duration string
+  * (e.g., "5ms", "2.1s") and converting it to a canonical unit (milliseconds).
+  */
+ @PublicEvolving
+ public class TimeDuration implements Token {
+ 
+     // Multipliers to convert units to MILLISECONDS
+     private static final double MILLIS_PER_NANOSECOND = 1.0 / 1_000_000.0;
+     private static final double MILLIS_PER_MICROSECOND = 1.0 / 1_000.0;
+     private static final double MILLIS_PER_SECOND = 1_000.0;
+     private static final double MILLIS_PER_MINUTE = 60.0 * MILLIS_PER_SECOND;
+     private static final double MILLIS_PER_HOUR = 60.0 * MILLIS_PER_MINUTE;
+     private static final double MILLIS_PER_DAY = 24.0 * MILLIS_PER_HOUR;
+ 
+     // Store final value in milliseconds as double for precision
+     private final double value;
+ 
+     /**
+      * Constructs a TimeDuration by parsing the given duration string.
+      *
+      * @param value The duration string to parse (e.g., "5ms", "2.1s").
+      * @throws IllegalArgumentException If the duration string is invalid.
+      */
+     public TimeDuration(String value) {
+         this.value = parseDuration(value);
+     }
+ 
+     /**
+      * Parses the given duration string and converts it into milliseconds.
+      * Handles integer and floating-point numbers.
+      *
+      * @param durationString The duration string to parse.
+      * @return The duration in milliseconds.
+      * @throws IllegalArgumentException If the duration string format or unit is invalid.
+      */
+     private double parseDuration(String durationString) {
+         if (durationString == null || durationString.trim().isEmpty()) {
+             throw new IllegalArgumentException("Duration string must not be null or empty.");
+         }
+ 
+         // Use lowercase for units consistency
+         durationString = durationString.trim().toLowerCase();
+         String numericPart;
+         double multiplier;
+ 
+         try {
+             if (durationString.endsWith("ns")) {
+                 numericPart = durationString.substring(0, durationString.length() - 2);
+                 multiplier = MILLIS_PER_NANOSECOND;
+             } else if (durationString.endsWith("us")) {
+                 numericPart = durationString.substring(0, durationString.length() - 2);
+                 multiplier = MILLIS_PER_MICROSECOND;
+             } else if (durationString.endsWith("ms")) {
+                 numericPart = durationString.substring(0, durationString.length() - 2);
+                 multiplier = 1.0; // Already in milliseconds
+             } else if (durationString.endsWith("s")) {
+                 numericPart = durationString.substring(0, durationString.length() - 1);
+                 multiplier = MILLIS_PER_SECOND;
+             } else if (durationString.endsWith("min")) {
+                 numericPart = durationString.substring(0, durationString.length() - 3);
+                 multiplier = MILLIS_PER_MINUTE;
+             } else if (durationString.endsWith("m")) {
+                 numericPart = durationString.substring(0, durationString.length() - 1);
+                 multiplier = MILLIS_PER_MINUTE;
+             } else if (durationString.endsWith("h")) {
+                 numericPart = durationString.substring(0, durationString.length() - 1);
+                 multiplier = MILLIS_PER_HOUR;
+             } else if (durationString.endsWith("d")) {
+                 numericPart = durationString.substring(0, durationString.length() - 1);
+                 multiplier = MILLIS_PER_DAY;
+             } else {
+                 throw new IllegalArgumentException(
+                    "Invalid time duration format or unsupported unit in string: " + durationString
+                    );
+             }
+ 
+             if (numericPart.isEmpty()) {
+                 throw new IllegalArgumentException("Missing numeric value in duration string: " + durationString);
+             }
+ 
+             double parsedValue = Double.parseDouble(numericPart);
+             if (parsedValue < 0) {
+                 throw new IllegalArgumentException("Duration value cannot be negative: " + durationString);
+             }
+             // Calculate the value in milliseconds
+             return parsedValue * multiplier;
+ 
+         } catch (NumberFormatException e) {
+             throw new IllegalArgumentException("Invalid numeric value in duration string: " + durationString, e);
+         }
+     }
+ 
+     /**
+      * Returns the duration in the specified TimeUnit.
+      * Note: Conversion might lose precision due to intermediate long conversion.
+      *
+      * @param unit The TimeUnit to convert to.
+      * @return The duration in the specified unit.
+      */
+     public long getDuration(TimeUnit unit) {
+         // Convert internal milliseconds value to the target unit
+         return unit.convert((long) this.value, TimeUnit.MILLISECONDS);
+     }
+ 
+     /**
+      * Returns the duration in milliseconds.
+      * This is the canonical value.
+      *
+      * @return The duration in milliseconds.
+      */
+     public double getValue() {
+         return value;
+     }
+ 
+     @Override
+     public Object value() {
+         return value; // Return the canonical double value (milliseconds)
+     }
+ 
+     @Override
+     public TokenType type() {
+         return TokenType.TIME_DURATION;
+     }
+ 
+     @Override
+     public JsonElement toJson() {
+         JsonObject object = new JsonObject();
+         object.addProperty("type", TokenType.TIME_DURATION.name());
+         object.addProperty("value", value); // Store the canonical double value
+         return object;
+     }
+ 
+     @Override
+     public String toString() {
+         // Provide a reasonable string representation
+         return value + "ms";
+     }
+ }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -14,143 +14,157 @@
  * the License.
  */
 
-package io.cdap.wrangler.api.parser;
+ package io.cdap.wrangler.api.parser;
 
-import io.cdap.wrangler.api.annotations.PublicEvolving;
-
-import java.io.Serializable;
-
-/**
- * The TokenType class provides the enumerated types for different types of
- * tokens that are supported by the grammar.
- *
- * Each of the enumerated types specified in this class also has associated
- * object representing it. e.g. {@code DIRECTIVE_NAME} is represented by the
- * object {@code DirectiveName}.
- *
- * @see Bool
- * @see BoolList
- * @see ColumnName
- * @see ColumnNameList
- * @see DirectiveName
- * @see Numeric
- * @see NumericList
- * @see Properties
- * @see Ranges
- * @see Expression
- * @see Text
- * @see TextList
- */
-@PublicEvolving
-public enum TokenType implements Serializable {
-  /**
-   * Represents the enumerated type for the object {@code DirectiveName} type.
-   * This type is associated with the token that is recognized as a directive
-   * name within the recipe.
-   */
-  DIRECTIVE_NAME,
-
-  /**
-   * Represents the enumerated type for the object of {@code ColumnName} type.
-   * This type is associated with token that represents the column as defined
-   * by the grammar as :<column-name>.
-   */
-  COLUMN_NAME,
-
-  /**
-   * Represents the enumerated type for the object of {@code Text} type.
-   * This type is associated with the token that is either enclosed within a single quote(')
-   * or a double quote (") as string.
-   */
-  TEXT,
-
-  /**
-   * Represents the enumerated type for the object of {@code Numeric} type.
-   * This type is associated with the token that is either a integer or real number.
-   */
-  NUMERIC,
-
-  /**
-   * Represents the enumerated type for the object of {@code Bool} type.
-   * This type is associated with the token that either represents string 'true' or 'false'.
-   */
-  BOOLEAN,
-
-  /**
-   * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the rule that is a collection of {@code Boolean} values
-   * separated by comman(,). E.g.
-   * <code>
-   *   ColumnName[,ColumnName]*
-   * </code>
-   */
-  COLUMN_NAME_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code TextList} type.
-   * This type is associated with the comma separated text represented were each text
-   * is enclosed within a single quote (') or double quote (") and each text is separated
-   * by comma (,). E.g.
-   * <code>
-   *   Text[,Text]*
-   * </code>
-   */
-  TEXT_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code NumericList} type.
-   * This type is associated with the collection of {@code Numeric} values separated by
-   * comma(,). E.g.
-   * <code>
-   *   Numeric[,Numeric]*
-   * </code>
-   *
-   */
-  NUMERIC_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the collection of {@code Bool} values separated by
-   * comma(,). E.g.
-   * <code>
-   *   Boolean[,Boolean]*
-   * </code>
-   */
-  BOOLEAN_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code Expression} type.
-   * This type is associated with code block that either represents a condition or
-   * an expression. E.g.
-   * <code>
-   *   exp:{ <expression || condition> }
-   * </code>
-   */
-  EXPRESSION,
-
-  /**
-   * Represents the enumerated type for the object of type {@code Properties} type.
-   * This type is associated with a collection of key and value pairs all separated
-   * by a comma(,). E.g.
-   * <code>
-   *   prop:{ <key>=<value>[,<key>=<value>]*}
-   * </code>
-   */
-  PROPERTIES,
-
-  /**
-   * Represents the enumerated type for the object of type {@code Ranges} types.
-   * This type is associated with a collection of range represented in the form shown
-   * below
-   * <code>
-   *   <start>:<end>=value[,<start>:<end>=value]*
-   * </code>
-   */
-  RANGES,
-
-  /**
-   * Represents the enumerated type for the object of type {@code String} with restrictions
-   * on characters that can be present in a string.
-   */
-  IDENTIFIER
-}
+ import io.cdap.wrangler.api.annotations.PublicEvolving;
+ 
+ import java.io.Serializable;
+ 
+ /**
+  * The TokenType class provides the enumerated types for different types of
+  * tokens that are supported by the grammar.
+  *
+  * Each of the enumerated types specified in this class also has associated
+  * object representing it. e.g. {@code DIRECTIVE_NAME} is represented by the
+  * object {@code DirectiveName}.
+  *
+  * @see Bool
+  * @see BoolList
+  * @see ColumnName
+  * @see ColumnNameList
+  * @see DirectiveName
+  * @see Numeric
+  * @see NumericList
+  * @see Properties
+  * @see Ranges
+  * @see Expression
+  * @see Text
+  * @see TextList
+  * @see ByteSize
+  * @see TimeDuration
+  */
+ @PublicEvolving
+ public enum TokenType implements Serializable {
+   /**
+    * Represents the enumerated type for the object {@code DirectiveName} type.
+    * This type is associated with the token that is recognized as a directive
+    * name within the recipe.
+    */
+   DIRECTIVE_NAME,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code ColumnName} type.
+    * This type is associated with token that represents the column as defined
+    * by the grammar as :<column-name>.
+    */
+   COLUMN_NAME,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code Text} type.
+    * This type is associated with the token that is either enclosed within a single quote(')
+    * or a double quote (") as string.
+    */
+   TEXT,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code Numeric} type.
+    * This type is associated with the token that is either a integer or real number.
+    */
+   NUMERIC,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code Bool} type.
+    * This type is associated with the token that either represents string 'true' or 'false'.
+    */
+   BOOLEAN,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code BoolList} type.
+    * This type is associated with the rule that is a collection of {@code Boolean} values
+    * separated by comman(,). E.g.
+    * <code>
+    *   ColumnName[,ColumnName]*
+    * </code>
+    */
+   COLUMN_NAME_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code TextList} type.
+    * This type is associated with the comma separated text represented were each text
+    * is enclosed within a single quote (') or double quote (") and each text is separated
+    * by comma (,). E.g.
+    * <code>
+    *   Text[,Text]*
+    * </code>
+    */
+   TEXT_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code NumericList} type.
+    * This type is associated with the collection of {@code Numeric} values separated by
+    * comma(,). E.g.
+    * <code>
+    *   Numeric[,Numeric]*
+    * </code>
+    *
+    */
+   NUMERIC_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code BoolList} type.
+    * This type is associated with the collection of {@code Bool} values separated by
+    * comma(,). E.g.
+    * <code>
+    *   Boolean[,Boolean]*
+    * </code>
+    */
+   BOOLEAN_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code Expression} type.
+    * This type is associated with code block that either represents a condition or
+    * an expression. E.g.
+    * <code>
+    *   exp:{ <expression || condition> }
+    * </code>
+    */
+   EXPRESSION,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code Properties} type.
+    * This type is associated with a collection of key and value pairs all separated
+    * by a comma(,). E.g.
+    * <code>
+    *   prop:{ <key>=<value>[,<key>=<value>]*}
+    * </code>
+    */
+   PROPERTIES,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code Ranges} types.
+    * This type is associated with a collection of range represented in the form shown
+    * below
+    * <code>
+    *   <start>:<end>=value[,<start>:<end>=value]*
+    * </code>
+    */
+   RANGES,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code String} with restrictions
+    * on characters that can be present in a string.
+    */
+   IDENTIFIER,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code ByteSize}.
+    * This type is associated with a token representing a data size (e.g., "10KB", "1GB").
+    */
+   BYTE_SIZE,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code TimeDuration}.
+    * This type is associated with a token representing a time duration (e.g., "150ms", "2h").
+    */
+   TIME_DURATION
+ }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -14,231 +14,235 @@
  * the License.
  */
 
-package io.cdap.wrangler.api.parser;
+ package io.cdap.wrangler.api.parser;
 
-import io.cdap.wrangler.api.Optional;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- * This class {@link UsageDefinition} provides a way for users to registers the argument for UDDs.
- *
- * {@link UsageDefinition} is a collection of {@link TokenDefinition} and the name of the directive
- * itself. Each token specification has an associated ordinal that can be used to position the argument
- * within the directive.
- *
- * Following is a example of how this class can be used.
- * <code>
- *   UsageDefinition.Builder builder = UsageDefinition.builder();
- *   builder.add("col1", TypeToken.COLUMN_NAME); // By default, this field is required.
- *   builder.add("col2", TypeToken.COLUMN_NAME, false); // This is a optional field.
- *   builder.add("expression", TypeToken.EXPRESSION);
- *   UsageDefinition definition = builder.build();
- * </code>
- *
- * NOTE: No constraints checks are included in this implementation.
- *
- * @see TokenDefinition
- */
-public final class UsageDefinition implements Serializable {
-  // transient so it doesn't show up when serialized using gson in service endpoint responses
-  private final transient int optionalCnt;
-  private final String directive;
-  private final List<TokenDefinition> tokens;
-
-  private UsageDefinition(String directive, int optionalCnt, List<TokenDefinition> tokens) {
-    this.directive = directive;
-    this.tokens = tokens;
-    this.optionalCnt = optionalCnt;
-  }
-
-  /**
-   * Returns the name of the directive for which the this <code>UsageDefinition</code>
-   * object is created.
-   *
-   * @return name of the directive.
-   */
-  public String getDirectiveName() {
-    return directive;
-  }
-
-  /**
-   * This method returns the list of <code>TokenDefinition</code> that should be
-   * used for parsing the directive into <code>Arguments</code>.
-   *
-   * @return List of <code>TokenDefinition</code>.
-   */
-  public List<TokenDefinition> getTokens() {
-    return tokens;
-  }
-
-  /**
-   * Returns the count of <code>TokenDefinition</code> that have been specified
-   * as optional in the <code>UsageDefinition</code>.
-   *
-   * @return number of tokens in the usage that are optional.
-   */
-  public int getOptionalTokensCount() {
-    return optionalCnt;
-  }
-
-  /**
-   * This method converts the <code>UsageDefinition</code> into a usage string
-   * for this directive. It inspects all the tokens to generate a standard syntax
-   * for the usage of the directive.
-   *
-   * @return a usage representation of this object.
-   */
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(directive).append(" ");
-
-    int count = tokens.size();
-    for (TokenDefinition token : tokens) {
-      if (token.optional()) {
-        sb.append(" [");
-      }
-
-      if (token.label() != null) {
-        sb.append(token.label());
-      } else {
-        if (token.type().equals(TokenType.DIRECTIVE_NAME)) {
-          sb.append(token.name());
-        } else if (token.type().equals(TokenType.COLUMN_NAME)) {
-          sb.append(":").append(token.name());
-        } else if (token.type().equals(TokenType.COLUMN_NAME_LIST)) {
-          sb.append(":").append(token.name()).append(" [,:").append(token.name()).append("  ]*");
-        } else if (token.type().equals(TokenType.BOOLEAN)) {
-          sb.append(token.name()).append(" (true/false)");
-        } else if (token.type().equals(TokenType.TEXT)) {
-          sb.append("'").append(token.name()).append("'");
-        } else if (token.type().equals(TokenType.IDENTIFIER) || token.type().equals(TokenType.NUMERIC)) {
-          sb.append(token.name());
-        } else if (token.type().equals(TokenType.BOOLEAN_LIST) || token.type().equals(TokenType.NUMERIC_LIST)
-          || token.type().equals(TokenType.TEXT_LIST)) {
-          sb.append(token.name()).append("[,").append(token.name()).append(" ...]*");
-        } else if (token.type().equals(TokenType.EXPRESSION)) {
-          sb.append("exp:{<").append(token.name()).append(">}");
-        } else if (token.type().equals(TokenType.PROPERTIES)) {
-          sb.append("prop:{key:value,[key:value]*");
-        } else if (token.type().equals(TokenType.RANGES)) {
-          sb.append("start:end=[bool|text|numeric][,start:end=[bool|text|numeric]*");
-        }
-      }
-
-      count--;
-
-      if (token.optional()) {
-        sb.append("]");
-      } else {
-        if (count > 0) {
-          sb.append(" ");
-        }
-      }
-    }
-    return sb.toString();
-  }
-
-  /**
-   * This is a static method for creating a builder for the <code>UsageDefinition</code>
-   * object. In order to create a <code>UsageDefinition</code>, a builder has to created.
-   *
-   * <p>This builder is provided as user API for constructing the usage specification
-   * for a directive.</p>
-   *
-   * @param directive name of the directive for which the builder is created for.
-   * @return A <code>UsageDefinition.Builder</code> object that can be used to construct
-   * <code>UsageDefinition</code> object.
-   */
-  public static UsageDefinition.Builder builder(String directive) {
-    return new UsageDefinition.Builder(directive);
-  }
-
-  /**
-   * This inner builder class provides a way to create <code>UsageDefinition</code>
-   * object. It exposes different methods that allow users to configure the <code>TokenDefinition</code>
-   * for each token used within the usage of a directive.
-   */
-  public static final class Builder {
+ import java.io.Serializable;
+ import java.util.ArrayList;
+ import java.util.List;
+ 
+ import io.cdap.wrangler.api.Optional; // Corrected import order
+ 
+ /**
+  * This class {@link UsageDefinition} provides a way for users to register the argument for UDDs.
+  *
+  * {@link UsageDefinition} is a collection of {@link TokenDefinition} and the name of the directive
+  * itself. Each token specification has an associated ordinal that can be used to position the argument
+  * within the directive.
+  *
+  * Following is an example of how this class can be used.
+  * <code>
+  *   UsageDefinition.Builder builder = UsageDefinition.builder();
+  *   builder.add("col1", TypeToken.COLUMN_NAME); // By default, this field is required.
+  *   builder.add("col2", TypeToken.COLUMN_NAME, false); // This is an optional field.
+  *   builder.add("expression", TypeToken.EXPRESSION);
+  *   UsageDefinition definition = builder.build();
+  * </code>
+  *
+  * NOTE: No constraints checks are included in this implementation.
+  *
+  * @see TokenDefinition
+  */
+ public final class UsageDefinition implements Serializable {
+    // transient so it doesn't show up when serialized using gson in service endpoint responses
+    private final transient int optionalCnt;
     private final String directive;
     private final List<TokenDefinition> tokens;
-    private int currentOrdinal;
-    private int optionalCnt;
-
-    public Builder(String directive) {
+ 
+    private UsageDefinition(String directive, int optionalCnt, List<TokenDefinition> tokens) {
       this.directive = directive;
-      this.currentOrdinal = 0;
-      this.tokens = new ArrayList<>();
-      this.optionalCnt = 0;
+      this.tokens = tokens;
+      this.optionalCnt = optionalCnt;
     }
-
+ 
     /**
-     * This method provides a way to set the name and the type of token, while
-     * defaulting the label to 'null' and setting the optional to FALSE.
+     * Returns the name of the directive for which this <code>UsageDefinition</code>
+     * object is created.
      *
-     * @param name of the token in the definition of a directive.
-     * @param type of the token to be extracted.
+     * @return name of the directive.
      */
-    public void define(String name, TokenType type) {
-      TokenDefinition spec = new TokenDefinition(name, type, null, currentOrdinal, Optional.FALSE);
-      currentOrdinal++;
-      tokens.add(spec);
+    public String getDirectiveName() {
+      return directive;
     }
-
+ 
     /**
-     * Allows users to define a token with a name, type of the token and additional optional
-     * for the label that is used during creation of the usage for the directive.
+     * This method returns the list of <code>TokenDefinition</code> that should be
+     * used for parsing the directive into <code>Arguments</code>..
      *
-     * @param name of the token in the definition of a directive.
-     * @param type of the token to be extracted.
-     * @param label label that modifies the usage for this field.
+     * @return List of <code>TokenDefinition</code>.
      */
-    public void define(String name, TokenType type, String label) {
-      TokenDefinition spec = new TokenDefinition(name, type, label, currentOrdinal, Optional.FALSE);
-      currentOrdinal++;
-      tokens.add(spec);
+    public List<TokenDefinition> getTokens() {
+      return tokens;
     }
-
+ 
     /**
-     * Method allows users to specify a field as optional in combination to the
-     * name of the token and the type of token.
+     * Returns the count of <code>TokenDefinition</code> that have been specified
+     * as optional in the <code>UsageDefinition</code>.
      *
-     * @param name of the token in the definition of a directive.
-     * @param type of the token to be extracted.
-     * @param optional <code>Optional#TRUE</code> if token is optional, else <code>Optional#FALSE</code>.
+     * @return number of tokens in the usage that are optional.
      */
-    public void define(String name, TokenType type, boolean optional) {
-      TokenDefinition spec = new TokenDefinition(name, type, null, currentOrdinal, optional);
-      optionalCnt = optional ? optionalCnt + 1 : optionalCnt;
-      currentOrdinal++;
-      tokens.add(spec);
+    public int getOptionalTokensCount() {
+      return optionalCnt;
     }
-
+ 
     /**
-     * Method allows users to specify a field as optional in combination to the
-     * name of the token, the type of token and also the ability to specify a label
-     * for the usage.
+     * This method converts the <code>UsageDefinition</code> into a usage string
+     * for this directive. It inspects all the tokens to generate a standard syntax
+     * for the usage of the directive.
      *
-     * @param name of the token in the definition of a directive.
-     * @param type of the token to be extracted.
-     * @param label label that modifies the usage for this field.
-     * @param optional <code>Optional#TRUE</code> if token is optional, else <code>Optional#FALSE</code>.
+     * @return a usage representation of this object.
      */
-    public void define(String name, TokenType type, String label, boolean optional) {
-      TokenDefinition spec = new TokenDefinition(name, type, label, currentOrdinal, optional);
-      optionalCnt = optional ? optionalCnt + 1 : optionalCnt;
-      currentOrdinal++;
-      tokens.add(spec);
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append(directive).append(" ");
+ 
+      int count = tokens.size();
+      for (TokenDefinition token : tokens) {
+        if (token.optional()) {
+          sb.append(" [");
+        }
+ 
+        if (token.label() != null) {
+          sb.append(token.label());
+        } else {
+          if (token.type().equals(TokenType.DIRECTIVE_NAME)) {
+            sb.append(token.name());
+          } else if (token.type().equals(TokenType.COLUMN_NAME)) {
+            sb.append(":").append(token.name());
+          } else if (token.type().equals(TokenType.COLUMN_NAME_LIST)) {
+            sb.append(":").append(token.name()).append(" [,:").append(token.name()).append("  ]*");
+          } else if (token.type().equals(TokenType.BOOLEAN)) {
+            sb.append(token.name()).append(" (true/false)");
+          } else if (token.type().equals(TokenType.TEXT)) {
+            sb.append("'").append(token.name()).append("'");
+          } else if (token.type().equals(TokenType.IDENTIFIER) || token.type().equals(TokenType.NUMERIC)) {
+            sb.append(token.name());
+          } else if (token.type().equals(TokenType.BOOLEAN_LIST) || token.type().equals(TokenType.NUMERIC_LIST)
+            || token.type().equals(TokenType.TEXT_LIST)) {
+            sb.append(token.name()).append("[,").append(token.name()).append(" ...]*");
+          } else if (token.type().equals(TokenType.EXPRESSION)) {
+            sb.append("exp:{<").append(token.name()).append(">}");
+          } else if (token.type().equals(TokenType.PROPERTIES)) {
+            sb.append("prop:{key:value,[key:value]*");
+          } else if (token.type().equals(TokenType.RANGES)) {
+            sb.append("start:end=[bool|text|numeric][,start:end=[bool|text|numeric]*");
+          } else if (token.type().equals(TokenType.BYTE_SIZE)) {
+            sb.append(":").append(token.name());
+          } else if (token.type().equals(TokenType.TIME_DURATION)) {
+            sb.append(":").append(token.name());
+          }
+        }
+ 
+        count--;
+ 
+        if (token.optional()) {
+          sb.append("]");
+        } else {
+          if (count > 0) {
+            sb.append(" ");
+          }
+        }
+      }
+      return sb.toString();
     }
-
+ 
     /**
-     * @return a instance of <code>UsageDefinition</code> object.
+     * This is a static method for creating a builder for the <code>UsageDefinition</code>
+     * object. In order to create a <code>UsageDefinition</code>, a builder has to be created.
+     *
+     * <p>This builder is provided as a user API for constructing the usage specification
+     * for a directive.</p>
+     *
+     * @param directive name of the directive for which the builder is created for.
+     * @return A <code>UsageDefinition.Builder</code> object that can be used to construct
+     * <code>UsageDefinition</code> object.
      */
-    public UsageDefinition build() {
-      return new UsageDefinition(directive, optionalCnt, tokens);
+    public static UsageDefinition.Builder builder(String directive) {
+      return new UsageDefinition.Builder(directive);
     }
-  }
-}
+ 
+    /**
+     * This inner builder class provides a way to create <code>UsageDefinition</code>
+     * object. It exposes different methods that allow users to configure the <code>TokenDefinition</code>
+     * for each token used within the usage of a directive.
+     */
+    public static final class Builder {
+      private final String directive;
+      private final List<TokenDefinition> tokens;
+      private int currentOrdinal;
+      private int optionalCnt;
+ 
+      public Builder(String directive) {
+        this.directive = directive;
+        this.currentOrdinal = 0;
+        this.tokens = new ArrayList<>();
+        this.optionalCnt = 0;
+      }
+ 
+      /**
+       * This method provides a way to set the name and the type of token, while
+       * defaulting the label to 'null' and setting the optional to FALSE.
+       *
+       * @param name of the token in the definition of a directive.
+       * @param type of the token to be extracted.
+       */
+      public void define(String name, TokenType type) {
+        TokenDefinition spec = new TokenDefinition(name, type, null, currentOrdinal, Optional.FALSE);
+        currentOrdinal++;
+        tokens.add(spec);
+      }
+ 
+      /**
+       * Allows users to define a token with a name, type of the token and additional optional
+       * for the label that is used during creation of the usage for the directive.
+       *
+       * @param name of the token in the definition of a directive.
+       * @param type of the token to be extracted.
+       * @param label label that modifies the usage for this field.
+       */
+      public void define(String name, TokenType type, String label) {
+        TokenDefinition spec = new TokenDefinition(name, type, label, currentOrdinal, Optional.FALSE);
+        currentOrdinal++;
+        tokens.add(spec);
+      }
+ 
+      /**
+       * Method allows users to specify a field as optional in combination with the
+       * name of the token and the type of token.
+       *
+       * @param name of the token in the definition of a directive.
+       * @param type of the token to be extracted.
+       * @param optional <code>Optional#TRUE</code> if token is optional, else <code>Optional#FALSE</code>.
+       */
+      public void define(String name, TokenType type, boolean optional) {
+        TokenDefinition spec = new TokenDefinition(name, type, null, currentOrdinal, optional);
+        optionalCnt = optional ? optionalCnt + 1 : optionalCnt;
+        currentOrdinal++;
+        tokens.add(spec);
+      }
+ 
+      /**
+       * Method allows users to specify a field as optional in combination with the
+       * name of the token, the type of token and also the ability to specify a label
+       * for the usage.
+       *
+       * @param name of the token in the definition of a directive.
+       * @param type of the token to be extracted.
+       * @param label label that modifies the usage for this field.
+       * @param optional <code>Optional#TRUE</code> if token is optional, else <code>Optional#FALSE</code>.
+       */
+      public void define(String name, TokenType type, String label, boolean optional) {
+        TokenDefinition spec = new TokenDefinition(name, type, label, currentOrdinal, optional);
+        optionalCnt = optional ? optionalCnt + 1 : optionalCnt;
+        currentOrdinal++;
+        tokens.add(spec);
+      }
+ 
+      /**
+       * @return an instance of <code>UsageDefinition</code> object.
+       */
+      public UsageDefinition build() {
+        return new UsageDefinition(directive, optionalCnt, tokens);
+      }
+    }
+ }

--- a/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
+++ b/wrangler-api/src/test/java/io/cdap/wrangler/api/parser/ByteSizeAndTimeDurationTest.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+ package io.cdap.wrangler.api.parser;
+
+ import org.junit.Assert;
+ import org.junit.Test;
+ 
+ /**
+  * Unit tests for ByteSize and TimeDuration classes.
+  */
+ public class ByteSizeAndTimeDurationTest {
+ 
+     @Test
+     public void testByteSizeParsing() {
+         // Test parsing valid inputs to canonical byte units
+         Assert.assertEquals(1024L, new ByteSize("1KB").getBytes());
+         Assert.assertEquals(1048576L, new ByteSize("1MB").getBytes());
+         Assert.assertEquals(1073741824L, new ByteSize("1GB").getBytes());
+         Assert.assertEquals(10, new ByteSize("10B").getBytes());
+ 
+         // Test for case insensitivity
+         Assert.assertEquals(1572864L, new ByteSize("1.5MB").getBytes());
+ 
+     }
+ 
+     @Test
+     public void testTimeDurationParsing() {
+         // Test parsing valid inputs to canonical time units (milliseconds as double)
+         double delta = 0.0001; // Tolerance for double comparison
+ 
+         // 5ms -> 5.0 ms
+         Assert.assertEquals(5.0, new TimeDuration("5ms").getValue(), delta);
+ 
+         // 2.1s -> 2.1 * 1000.0 = 2100.0 ms
+         Assert.assertEquals(2100.0, new TimeDuration("2.1s").getValue(), delta);
+ 
+         // 1h -> 1.0 * 60.0 * 60.0 * 1000.0 = 3,600,000.0 ms
+         Assert.assertEquals(3600000.0, new TimeDuration("1h").getValue(), delta);
+ 
+         // Test for case insensitivity (using "min")
+         // 1.5min -> 1.5 * 60.0 * 1000.0 = 90,000.0 ms
+         Assert.assertEquals(90000.0, new TimeDuration("1.5min").getValue(), delta);
+ 
+         // Test other units (assuming they were added to TimeDuration)
+         // 1000us -> 1000.0 / 1000.0 = 1.0 ms
+         Assert.assertEquals(1.0, new TimeDuration("1000us").getValue(), delta);
+         // 5000000ns -> 5000000.0 / 1000000.0 = 5.0 ms
+         Assert.assertEquals(5.0, new TimeDuration("5000000ns").getValue(), delta);
+         // 1d -> 1.0 * 24.0 * 60.0 * 60.0 * 1000.0 = 86,400,000.0 ms
+         Assert.assertEquals(86400000.0, new TimeDuration("1d").getValue(), delta);
+     }
+ 
+ }

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION
  ;
 
 ecommand
@@ -310,4 +310,20 @@ fragment Int
 
 fragment Digit
  : [0-9]
+ ;
+
+BYTE_SIZE
+ : Digit BYTE_UNIT
+ ;
+
+fragment BYTE_UNIT
+ : 'B' | 'KB' | 'MB' | 'GB' | 'TB'
+ ;
+
+TIME_DURATION
+ : Digit TIME_UNIT
+ ;
+
+fragment TIME_UNIT
+ : 's' | 'ms' | 'us' | 'ns' | 'm' | 'h' | 'd'
  ;

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,160 @@
+
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+ package io.cdap.directives.aggregates;
+
+ import io.cdap.cdap.api.annotation.Name;
+ import io.cdap.cdap.api.annotation.Plugin;
+ import io.cdap.cdap.api.data.schema.Schema;
+ import io.cdap.wrangler.api.Arguments;
+ import io.cdap.wrangler.api.Directive;
+ import io.cdap.wrangler.api.DirectiveExecutionException;
+ import io.cdap.wrangler.api.DirectiveParseException;
+ import io.cdap.wrangler.api.ExecutorContext;
+ import io.cdap.wrangler.api.Row;
+ import io.cdap.wrangler.api.annotations.Categories;
+ import io.cdap.wrangler.api.parser.ByteSize;
+ import io.cdap.wrangler.api.parser.ColumnName;
+ import io.cdap.wrangler.api.parser.Text;
+ import io.cdap.wrangler.api.parser.TimeDuration;
+ import io.cdap.wrangler.api.parser.TokenType;
+ import io.cdap.wrangler.api.parser.UsageDefinition;
+ import java.util.ArrayList;
+ import java.util.List;
+ 
+ /**
+  * Directive for aggregating statistics.
+  */
+ @Plugin(type = Directive.TYPE)
+ @Name(AggregateStats.NAME)
+ @Categories(categories = { "data-aggregation"})
+ public class AggregateStats implements Directive {
+     public static final String NAME = "aggregate-stats";
+     private String byteCol;
+     private String timeCol;
+     private String outputSizeCol;
+     private String outputTimeCol;
+     private double totalBytes = 0.0;
+     private double totalTimeMs = 0.0;
+     private int count = 0;
+ 
+     /**
+      * Defines the usage of the directive, specifying the required arguments.
+      *
+      * @return UsageDefinition object containing the directive's argument definitions.
+      */
+     @Override
+     public UsageDefinition define() {
+         UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+         builder.define("byteCol", TokenType.COLUMN_NAME);
+         builder.define("timeCol", TokenType.COLUMN_NAME);
+         builder.define("outputSizeCol", TokenType.TEXT);
+         builder.define("outputTimeCol", TokenType.TEXT);
+         return builder.build();
+     }
+ 
+     /**
+      * Initializes the directive with the provided arguments.
+      *
+      * @param args Arguments object containing the directive's parameters.
+      * @throws DirectiveParseException if there is an error parsing the arguments.
+      */
+     @Override
+     public void initialize(Arguments args) throws DirectiveParseException {
+         byteCol = ((ColumnName) args.value("byteCol")).value();
+         timeCol = ((ColumnName) args.value("timeCol")).value();
+         outputSizeCol = ((Text) args.value("outputSizeCol")).value();
+         outputTimeCol = ((Text) args.value("outputTimeCol")).value();
+     }
+ 
+     /**
+      * Executes the directive on a list of rows, aggregating statistics based on the specified columns.
+      *
+      * @param rows List of Row objects to process.
+      * @param ctx ExecutorContext providing execution context information.
+      * @return List of Row objects containing the aggregated results.
+      * @throws DirectiveExecutionException if there is an error during execution.
+      */
+     @Override
+     public List<Row> execute(List<Row> rows, ExecutorContext ctx) throws DirectiveExecutionException {
+         try {
+             for (Row row : rows) {
+                 if (row.find(byteCol) != -1 && row.find(timeCol) != -1) {
+                     String byteVal = row.getValue(byteCol).toString();
+                     String timeVal = row.getValue(timeCol).toString();
+ 
+                     // Use ByteSize and TimeDuration classes for parsing
+                     ByteSize byteSize = new ByteSize(byteVal);
+                     TimeDuration duration = new TimeDuration(timeVal);
+ 
+                     totalBytes += byteSize.getBytes();
+                     totalTimeMs += duration.getValue();
+                     count++;
+                 }
+             }
+ 
+             if (count == 0) {
+                 return new ArrayList<>();
+             }
+ 
+             List<Row> results = new ArrayList<>();
+             Row result = new Row();
+ 
+             // Convert bytes to MB and milliseconds to seconds
+             result.add(outputSizeCol, totalBytes / (1024.0 * 1024.0));
+             result.add(outputTimeCol, totalTimeMs / 1000.0);
+ 
+             results.add(result);
+             return results;
+ 
+         } catch (Exception e) {
+             throw new DirectiveExecutionException(
+                     String.format("Error aggregating stats: %s", e.getMessage())
+             );
+         }
+     }
+ 
+     /**
+      * Provides the output schema for the directive based on the input schema.
+      *
+      * @param inputSchema Schema object representing the input schema.
+      * @return Schema object representing the output schema.
+      */
+     public Schema getOutputSchema(Schema inputSchema) {
+         List<Schema.Field> fields = new ArrayList<>();
+         fields.add(Schema.Field.of(outputSizeCol, Schema.of(Schema.Type.DOUBLE)));
+         fields.add(Schema.Field.of(outputTimeCol, Schema.of(Schema.Type.DOUBLE)));
+         return Schema.recordOf("aggregate-stats", fields);
+     }
+ 
+     /**
+      * Cleans up resources and resets the directive's state.
+      */
+     @Override
+     public void destroy() {
+         // Reset all accumulated values
+         totalBytes = 0.0;
+         totalTimeMs = 0.0;
+         count = 0;
+ 
+         // Clear column references
+         byteCol = null;
+         timeCol = null;
+         outputSizeCol = null;
+         outputTimeCol = null;
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,206 @@
+/*
+*  Copyright © 2017-2019 Cask Data, Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+*  use this file except in compliance with the License. You may obtain a copy of
+*  the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+*  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+*  License for the specific language governing permissions and limitations under
+*  the License.
+*/
+
+package io.cdap.directives.aggregates;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.gson.JsonElement;
+
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.TokenType;
+
+public class AggregateStatsTest {
+
+   @Test
+   public void testAggregateStatsDirective() throws Exception {
+       // Step 1: Prepare input rows
+       List<Row> rows = new ArrayList<>();
+       rows.add(new Row().add("data_transfer_size", "10KB").add("response_time", "2s"));
+       rows.add(new Row().add("data_transfer_size", "5KB").add("response_time", "500ms"));
+
+       // Step 2: Create an instance of the directive
+       AggregateStats directive = new AggregateStats();
+
+       // Step 3: Manually mock Arguments
+       Arguments args = createMockArguments();
+
+       // Step 4: Initialize and execute the directive
+       directive.initialize(args);
+       List<Row> result = directive.execute(rows, null);
+
+       // Step 5: Validate output
+       Assert.assertEquals(1, result.size());
+
+       Row output = result.get(0);
+
+       // Size: 10KB + 5KB = 15KB = 15 * 1024 bytes = 15360 bytes
+       // MB = bytes / (1024 * 1024)
+       double expectedMB = 15360.0 / (1024 * 1024);
+       double actualMB = (Double) output.getValue("total_size_mb");
+
+       // Time: 2s + 500ms = 2500ms = 2.5s
+       double expectedSeconds = 2.5;
+       double actualSeconds = (Double) output.getValue("total_time_sec");
+
+       Assert.assertEquals(expectedMB, actualMB, 0.001);
+       Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+   }
+
+   @Test
+   public void testEmptyInputRows() throws Exception {
+       List<Row> rows = new ArrayList<>();
+
+       AggregateStats directive = new AggregateStats();
+       Arguments args = createMockArguments();
+
+       directive.initialize(args);
+       List<Row> result = directive.execute(rows, null);
+
+       Assert.assertEquals(0, result.size());
+   }
+
+   @Test
+   public void testInvalidData() throws Exception {
+       List<Row> rows = new ArrayList<>();
+       rows.add(new Row().add("data_transfer_size", "invalidKB").add("response_time", "invalidTime"));
+
+       AggregateStats directive = new AggregateStats();
+       Arguments args = createMockArguments();
+
+       directive.initialize(args);
+       try {
+           directive.execute(rows, null);
+           Assert.fail("Expected an exception for invalid data");
+       } catch (Exception e) {
+           Assert.assertTrue(e.getMessage().contains("Error aggregating stats"));
+       }
+   }
+
+   @Test
+   public void testLargeData() throws Exception {
+       List<Row> rows = new ArrayList<>();
+       rows.add(new Row().add("data_transfer_size", "1024MB").add("response_time", "1h"));
+       rows.add(new Row().add("data_transfer_size", "512MB").add("response_time", "30m"));
+
+       AggregateStats directive = new AggregateStats();
+       Arguments args = createMockArguments();
+
+       directive.initialize(args);
+       List<Row> result = directive.execute(rows, null);
+
+       Assert.assertEquals(1, result.size());
+
+       Row output = result.get(0);
+
+       double expectedMB = 1536.0; // 1024MB + 512MB
+       double actualMB = (Double) output.getValue("total_size_mb");
+
+       double expectedSeconds = 5400.0; // 1h + 30m = 5400 seconds
+       double actualSeconds = (Double) output.getValue("total_time_sec");
+
+       Assert.assertEquals(expectedMB, actualMB, 0.001);
+       Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+   }
+
+   @Test
+   public void testEdgeCases() throws Exception {
+       List<Row> rows = new ArrayList<>();
+       rows.add(new Row().add("data_transfer_size", "0KB").add("response_time", "0s"));
+
+       AggregateStats directive = new AggregateStats();
+       Arguments args = createMockArguments();
+
+       directive.initialize(args);
+       List<Row> result = directive.execute(rows, null);
+
+       Assert.assertEquals(1, result.size());
+
+       Row output = result.get(0);
+
+       double expectedMB = 0.0;
+       double actualMB = (Double) output.getValue("total_size_mb");
+
+       double expectedSeconds = 0.0;
+       double actualSeconds = (Double) output.getValue("total_time_sec");
+
+       Assert.assertEquals(expectedMB, actualMB, 0.001);
+       Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+   }
+
+   private Arguments createMockArguments() {
+       return new Arguments() {
+           @SuppressWarnings("unchecked")
+           @Override
+           public <T extends Token> T value(String name) {
+               switch (name) {
+                   case "byteCol":
+                       return (T) new ColumnName("data_transfer_size");
+                   case "timeCol":
+                       return (T) new ColumnName("response_time");
+                   case "outputSizeCol":
+                       return (T) new Text("total_size_mb");
+                   case "outputTimeCol":
+                       return (T) new Text("total_time_sec");
+               }
+               return null;
+           }
+
+           @Override
+           public int size() {
+               return 4;
+           }
+
+           @Override
+           public boolean contains(String name) {
+               return true;
+           }
+
+           @Override
+           public TokenType type(String name) {
+               return null;
+           }
+
+           @Override
+           public int line() {
+               return 1;
+           }
+
+           @Override
+           public int column() {
+               return 0;
+           }
+
+           @Override
+           public String source() {
+               return "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec";
+           }
+
+           @Override
+           public JsonElement toJson() {
+               return null;
+           }
+       };
+   }
+}


### PR DESCRIPTION
_**-> Improved directive expressiveness for better handling of data size and time-related operations.
-> Enhanced Directives.g4 grammar to recognize BYTE SIZE and TIME DURATION tokens (e.g., IOMB ,
15Øms ).
-> Introduced Bytesize.java and TimeDuration.java classes in wrangler-api to parse and normalize
unit values.
-> Implemented aggregate-stats directive in wrangler-core to compute aggregate values for size and
duration.
-> Added unit tests for token parsing, directive logic, and grammar validation in RecipeCompi1erTest ,
GrammarBasedParserTest , and directive-specific test files.
-> **Updated** README with usage documentation for ByteSize and TimeDuration in recipes.
Verified functionality via TestingRig and ensured accurate unit conversions and output aggregation.**_