### PR TITLE
Enhanced Wrangler with Byte Size and Time Duration Units Parsers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.13.0</version>
+          <version>3.0.0-M5</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
@@ -301,6 +301,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.14.1</version>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -556,6 +560,25 @@
           <artifactId>logback-classic</artifactId>
           <version>1.2.8</version>
           <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>io.cdap.wrangler</groupId>
+          <artifactId>wrangler-api</artifactId>
+          <version>6.9.1</version>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>io.cdap.wrangler</groupId>
+          <artifactId>wrangler-core</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>io.cdap</groupId>
+          <artifactId>cdap-api</artifactId>
+          <version>${cdap.version}</version>
         </dependency>
       </dependencies>
 

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+ 
+/**
+ * Represents a token that holds byte size values like "10KB", "1.5MB", etc.
+ * This class extends the Token base class.
+ */
+public class ByteSize implements Token {
+    // Stores the parsed value in bytes (canonical unit)
+    private long bytes;
+    private final String originalValue;
+ 
+    /**
+     * Constructor to initialize the ByteSize token with a value. ("10KB","1.5MB")
+     */
+    public ByteSize(String value) {
+        this.bytes = parseBytes(value); // Convert string to bytes
+        this.originalValue = value;
+    }
+ 
+    private long parseBytes(String value) {
+        value = value.toUpperCase();
+        if (value.endsWith("KB")) {
+            // Convert kilobytes to bytes
+            return (long) (Double.parseDouble(value.replace("KB", "")) * 1024);
+        }   else if (value.endsWith("MB")) {
+            // Convert megabytes to bytes
+            return (long) (Double.parseDouble(value.replace("MB", "")) * 1024 * 1024);
+        }   else if (value.endsWith("GB")) {
+            // Convert gigabytes to bytes
+            return (long) (Double.parseDouble(value.replace("GB", "")) * 1024 * 1024 * 1024);
+        }   else if (value.endsWith("TB")) {
+            // Convert terabytes to bytes
+            return (long) (Double.parseDouble(value.replace("TB", "")) * 1024L * 1024L * 1024L * 1024L);
+        }   else if (value.endsWith("B")) {
+            // Bytes are already in the base unit
+            return (long) Double.parseDouble(value.replace("B", ""));
+        }   else {
+            throw new IllegalArgumentException("Invalid byte size format: " + value);
+        }
+    }
+    
+    public long getBytes() {
+        return bytes;
+    }
+    
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(originalValue); 
+    }
+    
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+    
+    /**
+        * Returns a string representation of the ByteSize token.
+    */
+    @Override
+    public String value() {
+        return "ByteSize{" + "value='" + originalValue + '\'' + '}';
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+ 
+/**
+ * Represents a token that holds time duration values like "150ms", "2.5s", etc.
+ * This class extends the Token base class.
+ */
+public class TimeDuration implements Token {
+ 
+    // Stores the parsed value in milliseconds (canonical unit)
+    private long milliseconds;
+    private final String originalValue;
+ 
+    /**
+     * Constructor to initialize the TimeDuration token with a value. ("150ms","2.5s")
+     */
+    public TimeDuration(String value) {
+        this.milliseconds = parseDuration(value); // Parse and convert to milliseconds
+        this.originalValue = value;
+    }
+ 
+    /**
+     * Parses the time duration string and converts it into milliseconds.
+     */
+    private long parseDuration(String value) {
+        value = value.toLowerCase();
+        if (value.endsWith("ns")) {
+            // Convert nanoseconds to milliseconds
+            return Long.parseLong(value.replace("ns", "")) / 1000000;
+        }   else if (value.endsWith("us")) {
+            // Convert microseconds to milliseconds
+            return Long.parseLong(value.replace("us", "")) / 1000;
+        }   else if (value.endsWith("ms")) {
+            // Already in milliseconds
+            return Long.parseLong(value.replace("ms", ""));
+        }   else if (value.endsWith("s")) {
+            // Convert seconds to milliseconds
+            return (long) (Double.parseDouble(value.replace("s", "")) * 1000);
+        }   else if (value.endsWith("m")) {
+            // Convert minutes to milliseconds
+            return (long) (Double.parseDouble(value.replace("m", "")) * 60 * 1000);
+        }   else if (value.endsWith("h")) {
+            // Convert hours to milliseconds
+            return (long) (Double.parseDouble(value.replace("h", "")) * 60 * 60 * 1000);
+        }   else {
+            throw new IllegalArgumentException("Invalid time duration format: " + value);
+        }
+    }
+    
+    // Canonical unit method
+    public long getMilliseconds() {
+        return milliseconds;
+    }
+    
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(originalValue); 
+    }
+    
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+    
+    /**
+     * Returns a string representation of the TimeDuration token.
+     */
+    @Override
+    public String value() {
+        return "TimeDuration{" + "value='" + originalValue + '\'' + '}';
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,28 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+
+  /**
+   * Represents the enumerated type for tokens of type {@code BYTE_SIZE}.
+   * This type is used to represent storage sizes like:
+   * <code>
+   *   10KB, 1.5MB, 3GB, 512B
+   * </code>
+   * It supports suffixes like B, KB, MB, GB, and TB and converts the values into bytes.
+   */
+  BYTE_SIZE,
+
+  /**
+   * Represents the enumerated type for tokens of type {@code TIME_DURATION}.
+   * This type is used to express durations like:
+   * <code>
+   *   150ms, 2.5s, 3m, 1h
+   * </code>
+   * It supports time units such as ns (nanoseconds), us (microseconds), ms (milliseconds),
+   * s (seconds), m (minutes), and h (hours), and internally converts all values to milliseconds.
+   */
+  TIME_DURATION,
+
+  LITERAL
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -126,6 +126,10 @@ public final class UsageDefinition implements Serializable {
           sb.append("prop:{key:value,[key:value]*");
         } else if (token.type().equals(TokenType.RANGES)) {
           sb.append("start:end=[bool|text|numeric][,start:end=[bool|text|numeric]*");
+        } else if (token.type().equals(TokenType.BYTE_SIZE)) {
+          sb.append(":").append(token.name());
+        } else if (token.type().equals(TokenType.TIME_DURATION)) {
+          sb.append(":").append(token.name());
         }
       }
 
@@ -182,10 +186,11 @@ public final class UsageDefinition implements Serializable {
      * @param name of the token in the definition of a directive.
      * @param type of the token to be extracted.
      */
-    public void define(String name, TokenType type) {
+    public Builder define(String name, TokenType type) {
       TokenDefinition spec = new TokenDefinition(name, type, null, currentOrdinal, Optional.FALSE);
       currentOrdinal++;
       tokens.add(spec);
+      return this;
     }
 
     /**
@@ -196,10 +201,11 @@ public final class UsageDefinition implements Serializable {
      * @param type of the token to be extracted.
      * @param label label that modifies the usage for this field.
      */
-    public void define(String name, TokenType type, String label) {
+    public Builder define(String name, TokenType type, String label) {
       TokenDefinition spec = new TokenDefinition(name, type, label, currentOrdinal, Optional.FALSE);
       currentOrdinal++;
       tokens.add(spec);
+      return this;
     }
 
     /**
@@ -210,11 +216,12 @@ public final class UsageDefinition implements Serializable {
      * @param type of the token to be extracted.
      * @param optional <code>Optional#TRUE</code> if token is optional, else <code>Optional#FALSE</code>.
      */
-    public void define(String name, TokenType type, boolean optional) {
+    public Builder define(String name, TokenType type, boolean optional) {
       TokenDefinition spec = new TokenDefinition(name, type, null, currentOrdinal, optional);
       optionalCnt = optional ? optionalCnt + 1 : optionalCnt;
       currentOrdinal++;
       tokens.add(spec);
+      return this;
     }
 
     /**
@@ -227,11 +234,12 @@ public final class UsageDefinition implements Serializable {
      * @param label label that modifies the usage for this field.
      * @param optional <code>Optional#TRUE</code> if token is optional, else <code>Optional#FALSE</code>.
      */
-    public void define(String name, TokenType type, String label, boolean optional) {
+    public Builder define(String name, TokenType type, String label, boolean optional) {
       TokenDefinition spec = new TokenDefinition(name, type, label, currentOrdinal, optional);
       optionalCnt = optional ? optionalCnt + 1 : optionalCnt;
       currentOrdinal++;
       tokens.add(spec);
+      return this;
     }
 
     /**

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -105,6 +105,13 @@
       <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+
 
     <!-- External -->
 

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | BYTE_SIZE | TIME_DURATION
  ;
 
 ecommand
@@ -194,6 +194,16 @@ stringList
 identifierList
  : Identifier (',' Identifier)*
  ;
+
+// BYTE SIZE Token - matches values like 10KB , 1.5MB
+BYTE_SIZE
+: [0-9]+('.'[0-9]+)? BYTE_UNIT;
+fragment BYTE_UNIT: ('B' | 'KB' | 'MB' | 'GB' | 'TB');
+
+// TIME DURATION Token - matches values like 150ms,2.5s 
+TIME_DURATION
+: [0-9]+('.'[0-9]+)? TIME_UNIT;
+fragment TIME_UNIT: ('ns' | 'us'| 'ms'| 's'| 'm' | 'h');
 
 
 /*

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateSizeTime.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateSizeTime.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ package io.cdap.directives.aggregates;
+
+ import io.cdap.cdap.api.annotation.Description;
+ import io.cdap.cdap.api.annotation.Name;
+  import io.cdap.cdap.api.annotation.Plugin;
+ import io.cdap.wrangler.api.Arguments;
+ import io.cdap.wrangler.api.Directive;
+ import io.cdap.wrangler.api.ExecutorContext;
+ import io.cdap.wrangler.api.Row;
+ import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TokenType;
+ import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+ 
+ /**
+ * A directive that aggregates byte sizes and time durations from input rows into total or average values.
+ *
+ * <p>This directive operates on two input columns:
+ * - One column containing byte sizes (e.g., "10MB", "1GB").
+ * - Another column containing time durations (e.g., "500ms", "2s").
+ *
+ * <p>The directive supports both total and average aggregation types and allows specifying output units
+ * for size (e.g., MB, GB) and time (e.g., seconds, minutes).
+ *
+ * <p>Example usage in a Wrangler recipe:
+ * <pre>
+ * {@code
+ * aggregate-size-time :data_size :response_time total_size_mb total_time_sec 'MB' 'seconds' 'total';
+ * }
+ * </pre>
+ *
+ * @see Directive
+ */
+
+ @Plugin
+ @Name("aggregateSizeTime")
+ @Description("Aggregates byte size and time duration columns, returning total/average values.")
+ @Categories(categories = { "aggregate" })
+ public class AggregateSizeTime implements Directive {
+ 
+   private String sizeColumn;
+   private String timeColumn;
+   private String targetSizeColumn;
+   private String targetTimeColumn;
+   private String outputSizeUnit;
+   private String outputTimeUnit;
+   private String aggregationType;
+   private long totalSize;
+   private long totalDuration;
+   private int validRowCount;
+   private Row resultRow;
+
+   @Override
+   public UsageDefinition define() {
+    return UsageDefinition.builder("aggregate-stats")
+        .define("sizeColumn", TokenType.COLUMN_NAME)
+        .define("timeColumn", TokenType.COLUMN_NAME)
+        .define("outputSizeColumn", TokenType.COLUMN_NAME)
+        .define("outputTimeColumn", TokenType.COLUMN_NAME)
+        .define("outputSizeUnit", TokenType.TEXT, true)
+        .define("outputTimeUnit", TokenType.TEXT, true)
+        .define("aggregationType", TokenType.TEXT, true)
+        .build();
+    }
+ 
+   @Override
+   public void initialize(Arguments args) {
+     totalSize = 0;
+     totalDuration = 0;
+     validRowCount = 0;
+     resultRow = new Row();
+
+    // Correctly handle ColumnName tokens
+    this.sizeColumn = ((ColumnName) args.value("sizeColumn")).value();
+    this.timeColumn = ((ColumnName) args.value("timeColumn")).value();
+    this.targetSizeColumn = ((ColumnName) args.value("outputSizeColumn")).value();
+    this.targetTimeColumn = ((ColumnName) args.value("outputTimeColumn")).value();
+
+    // Handle optional TEXT tokens with defaults
+    this.outputSizeUnit = args.contains("outputSizeUnit") ? 
+        ((Text) args.value("outputSizeUnit")).value().toLowerCase() : "MB";
+    
+    this.outputTimeUnit = args.contains("outputTimeUnit") ? 
+        ((Text) args.value("outputTimeUnit")).value().toLowerCase() : "SECONDS";
+    
+    this.aggregationType = args.contains("aggregationType") ? 
+        ((Text) args.value("aggregationType")).value().toLowerCase() : "total";
+    }
+ 
+   @Override
+   public List<Row> execute(List<Row> rows, ExecutorContext context) {
+   
+     System.out.println("first time calling execute: totalSize: " + totalSize);
+
+     for (Row row : rows) {
+       Object sizeObj = row.getValue(sizeColumn);
+       Object timeObj = row.getValue(timeColumn);
+ 
+       System.out.println("Row: " + row);  
+       System.out.println("sizeObj: " + sizeObj + ", timeObj: " + timeObj);
+       System.out.println("orig totalSize: " + totalSize);
+       System.out.println("orig totalDuration: " + totalDuration);
+
+       boolean validRow = false;
+ 
+       // Handle size value
+       //if (sizeObj instanceof String) {
+          try {
+              totalSize += convertToBytes((String) sizeObj);  // Convert size to bytes and add to total
+              System.out.println("new totalSize: " + totalSize);
+              validRow = true;
+          } catch (Exception e) {
+              // If invalid, print the error and skip the size value
+              System.out.println("Error in converting size: " + e.getMessage());
+          }
+       //}
+ 
+       // Handle time value
+       if (timeObj instanceof Number) {
+         totalDuration += ((Number) timeObj).longValue();
+         System.out.println("new totalDuration: " + totalDuration);
+         validRow = true;
+       } else if (timeObj instanceof String) {
+         try {
+           totalDuration += convertToNanos((String) timeObj);
+           System.out.println("new totalDuration: " + totalDuration);
+           validRow = true;
+         } catch (Exception e) {
+           // Skip invalid strings
+         }
+       }
+ 
+       if (validRow) {
+         validRowCount++;
+       }
+     }
+ 
+     if ("average".equalsIgnoreCase(aggregationType) && validRowCount > 0) {
+       totalSize = totalSize / validRowCount;
+       totalDuration = totalDuration / validRowCount;
+     }
+ 
+     double finalSize = convertSize(totalSize, outputSizeUnit);
+     double finalTime = convertTime(totalDuration, outputTimeUnit);
+ 
+    //Row resultRow = new Row();
+    if (resultRow.find(targetSizeColumn) != -1) {
+      resultRow.remove(resultRow.find(targetSizeColumn));
+      resultRow.remove(resultRow.find(targetTimeColumn));
+    }
+    resultRow.add(targetSizeColumn, finalSize);
+    resultRow.add(targetTimeColumn, finalTime);
+     
+    List<Row> resultList = new ArrayList<>();
+    resultList.add(resultRow);
+    return resultList;
+
+   }
+ 
+   private double convertSize(long bytes, String unit) {
+     switch (unit.toUpperCase()) {
+       case "KB":
+         return bytes / 1024.0;
+       case "MB":
+         return bytes / (1024.0 * 1024);
+       case "GB":
+         return bytes / (1024.0 * 1024 * 1024);
+       default:
+         return (double) bytes;
+     }
+   }
+ 
+   private double convertTime(long nanos, String unit) {
+    switch (unit.toLowerCase()) {
+      case "s":
+      case "sec":
+      case "second":
+      case "seconds":
+        return nanos / 1_000_000_000.0;
+      case "ms":
+      case "millisecond":
+      case "milliseconds":
+        return nanos / 1_000_000.0;
+      case "min":
+      case "minute":
+      case "minutes":
+        return nanos / 60_000_000_000.0;
+      default:
+        return (double) nanos;
+    }
+   }
+ 
+   private long convertToBytes(String input) {
+    input = input.trim().toLowerCase();
+    System.out.println("Inside convertToBytes, input = " + input);
+
+    if (input.matches(".*\\d.*")) {  // has digits
+      if (input.endsWith("kb")) {
+        return (long) (Double.parseDouble(input.replaceAll("[^0-9.]", "")) * 1024);
+      }
+      if (input.endsWith("mb")) {
+        return (long) (Double.parseDouble(input.replaceAll("[^0-9.]", "")) * 1024 * 1024);
+      }
+      if (input.endsWith("gb")) {
+        return (long) (Double.parseDouble(input.replaceAll("[^0-9.]", "")) * 1024 * 1024 * 1024);
+      }
+    }
+  
+    // Fallback: try to parse raw number
+    return Long.parseLong(input.replaceAll("[^0-9]", ""));
+  }
+  
+ 
+   private long convertToNanos(String input) {
+     input = input.toLowerCase().trim();
+     if (input.endsWith("ms")) {
+       return (long) (Double.parseDouble(input.replace("ms", "")) * 1_000_000);
+     }
+     if (input.endsWith("s")) {
+       return (long) (Double.parseDouble(input.replace("s", "")) * 1_000_000_000);
+     }
+     if (input.endsWith("min")) {
+       return (long) (Double.parseDouble(input.replace("min", "")) * 60_000_000_000L);
+     }
+     return Long.parseLong(input);
+   }
+ 
+   @Override
+   public void destroy() {
+     // No-op for now
+   }
+ }

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/SetTransientVariable.java
@@ -83,9 +83,14 @@ public class SetTransientVariable implements Directive {
 
   @Override
   public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
+  
+    long totalSize = 0;
+    System.out.println("first time calling execute: : " + totalSize);
+
     for (Row row : rows) {
       // Move the fields from the row into the context.
       ELContext ctx = new ELContext(context, el, row);
+      System.out.println("  executing row: " + totalSize);
 
       // Execution of the script / expression based on the row data
       // mapped into context.

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,6 +22,7 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
+import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -33,6 +34,7 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
+import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
@@ -64,6 +66,7 @@ import java.util.Map;
  * that is returned by this function.</p>
  */
 public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Builder> {
+  private final ThreadLocal<RecipeSymbol.Builder> current = new ThreadLocal<>();
   private RecipeSymbol.Builder builder = new RecipeSymbol.Builder();
 
   /**
@@ -316,6 +319,33 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
     builder.addToken(new TextList(strs));
     return builder;
   }
+
+  /**
+ * This visitor method inspects the type of token matched by the value rule and creates the appropriate
+ * token object (e.g., <code>ByteSize</code>, <code>TimeDuration</code>, etc.) 
+ * to be added to the <code>TokenGroup</code>.
+ */
+@Override
+public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
+  Token token;
+
+  if (ctx.BYTE_SIZE() != null) {
+    token = new ByteSize(ctx.BYTE_SIZE().getText());
+  } else if (ctx.TIME_DURATION() != null) {
+    token = new TimeDuration(ctx.TIME_DURATION().getText());
+  } else if (ctx.String() != null) {
+    String value = ctx.String().getText();
+    token = new Text(value.substring(1, value.length() - 1));
+  } else if (ctx.Bool() != null) {
+    token = new Bool(Boolean.valueOf(ctx.Bool().getText()));
+  } else if (ctx.Number() != null) {
+    token = new Numeric(new LazyNumber(ctx.Number().getText()));
+  } else {
+    throw new IllegalArgumentException("Unknown value type in visitValue: " + ctx.getText());
+  }
+  builder.addToken(token);
+  return builder;
+}
 
   private SourceInfo getOriginalSource(ParserRuleContext ctx) {
     int a = ctx.getStart().getStartIndex();

--- a/wrangler-core/src/main/resources/META-INF/services/io.cdap.wrangler.api.Directive
+++ b/wrangler-core/src/main/resources/META-INF/services/io.cdap.wrangler.api.Directive
@@ -1,0 +1,1 @@
+io.cdap.directives.aggregates.AggregateSizeTime

--- a/wrangler-core/src/main/resources/schemas/manifest.json
+++ b/wrangler-core/src/main/resources/schemas/manifest.json
@@ -1,8 +1,8 @@
 {
   "standards": {
     "hl7-fhir-r4": {
-      "format": "json",
-      "hash": "2721123ac666b321ce9833627c8bb712c62b36d326934767fc6c9aea701ce549"
+      "hash": "5d4d99755becc037880850debc447a1c9a5cfdba3d6f0512d470817433bd486d",
+      "format": "json"
     }
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateSizeTimeTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateSizeTimeTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.etl.api.Lookup;
+import io.cdap.cdap.etl.api.StageMetrics;
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.TransientStore;
+import io.cdap.wrangler.api.TransientVariableScope;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.proto.Contexts;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+public class AggregateSizeTimeTest {
+    @Test
+    public void testAggregation() throws Exception {
+        List<Row> rows = Arrays.asList(
+            new Row().add("data_size", "2mb").add("response_time", "1500ms"),
+            new Row().add("data_size", "1mb").add("response_time", "500ms")
+        );
+
+
+        String[] recipe = { 
+            "aggregateSizeTime :data_size :response_time :total_size_mb :total_time_sec 'MB' 'seconds' 'total';"
+        };
+        
+        final Map<String, Object> s = new HashMap<>();
+        rows = TestingRig.execute(recipe, rows, new ExecutorContext() {
+      @Override
+      public Environment getEnvironment() {
+        return Environment.TESTING;
+      }
+
+      @Override
+      public String getNamespace() {
+        return Contexts.SYSTEM;
+      }
+
+      @Override
+      public StageMetrics getMetrics() {
+        return null;
+      }
+
+      @Override
+      public String getContextName() {
+        return "test";
+      }
+
+      @Override
+      public Map<String, String> getProperties() {
+        return new HashMap<>();
+      }
+
+      @Override
+      public URL getService(String applicationId, String serviceId) {
+        return null;
+      }
+
+      @Override
+      public TransientStore getTransientStore() {
+        return new TransientStore() {
+          @Override
+          public void reset(TransientVariableScope scope) {
+
+          }
+
+          @Override
+          public <T> T get(String name) {
+            return (T) s.get(name);
+          }
+
+          @Override
+          public void set(TransientVariableScope scope, String name, Object value) {
+            s.put(name, value);
+          }
+
+          @Override
+          public void increment(TransientVariableScope scope, String name, long value) {
+
+          }
+
+          @Override
+          public Set<String> getVariables() {
+            return s.keySet();
+          }
+        };
+      }
+
+      @Override
+      public <T> Lookup<T> provide(String s, Map<String, String> map) {
+        return null;
+      }
+    });
+        Assert.assertEquals(3.0, rows.get(0).getValue("total_size_mb")); // 3MB
+        Assert.assertEquals(2.0, rows.get(0).getValue("total_time_sec")); // 2000ms = 2s
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateSizeTimeTest1.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateSizeTimeTest1.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.etl.api.Lookup;
+import io.cdap.cdap.etl.api.StageMetrics;
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.TransientStore;
+import io.cdap.wrangler.api.TransientVariableScope;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.proto.Contexts;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+public class AggregateSizeTimeTest1 {
+    @Test
+    public void testAggregation() throws Exception {
+        List<Row> rows = Arrays.asList(
+            new Row().add("data_size", "2000000B").add("response_time", "15000ms"),
+            new Row().add("data_size", "4mb").add("response_time", "500s")
+        );
+
+
+        String[] recipe = { 
+            "aggregateSizeTime :data_size :response_time :total_size_mb :total_time_sec 'MB' 'seconds' 'total';"
+        };
+        
+        final Map<String, Object> s = new HashMap<>();
+        rows = TestingRig.execute(recipe, rows, new ExecutorContext() {
+      @Override
+      public Environment getEnvironment() {
+        return Environment.TESTING;
+      }
+
+      @Override
+      public String getNamespace() {
+        return Contexts.SYSTEM;
+      }
+
+      @Override
+      public StageMetrics getMetrics() {
+        return null;
+      }
+
+      @Override
+      public String getContextName() {
+        return "test";
+      }
+
+      @Override
+      public Map<String, String> getProperties() {
+        return new HashMap<>();
+      }
+
+      @Override
+      public URL getService(String applicationId, String serviceId) {
+        return null;
+      }
+
+      @Override
+      public TransientStore getTransientStore() {
+        return new TransientStore() {
+          @Override
+          public void reset(TransientVariableScope scope) {
+
+          }
+
+          @Override
+          public <T> T get(String name) {
+            return (T) s.get(name);
+          }
+
+          @Override
+          public void set(TransientVariableScope scope, String name, Object value) {
+            s.put(name, value);
+          }
+
+          @Override
+          public void increment(TransientVariableScope scope, String name, long value) {
+
+          }
+
+          @Override
+          public Set<String> getVariables() {
+            return s.keySet();
+          }
+        };
+      }
+
+      @Override
+      public <T> Lookup<T> provide(String s, Map<String, String> map) {
+        return null;
+      }
+    });
+        Assert.assertEquals(5.9073486328125, rows.get(0).getValue("total_size_mb")); // 5.9073486328125 MB
+        Assert.assertEquals(515.0, rows.get(0).getValue("total_time_sec")); // 515s
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateSizeTimeTest2.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateSizeTimeTest2.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.etl.api.Lookup;
+import io.cdap.cdap.etl.api.StageMetrics;
+import io.cdap.wrangler.TestingRig;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.TransientStore;
+import io.cdap.wrangler.api.TransientVariableScope;
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import io.cdap.wrangler.proto.Contexts;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+public class AggregateSizeTimeTest2 {
+    @Test
+    public void testAggregation() throws Exception {
+        List<Row> rows = Arrays.asList(
+            new Row().add("data_size", "4000KB").add("response_time", "1500s"),
+            new Row().add("data_size", "700KB").add("response_time", "5min")
+        );
+
+
+        String[] recipe = { 
+            "aggregateSizeTime :data_size :response_time :total_size_mb :total_time_sec 'MB' 'seconds' 'total';"
+        };
+        
+        final Map<String, Object> s = new HashMap<>();
+        rows = TestingRig.execute(recipe, rows, new ExecutorContext() {
+      @Override
+      public Environment getEnvironment() {
+        return Environment.TESTING;
+      }
+
+      @Override
+      public String getNamespace() {
+        return Contexts.SYSTEM;
+      }
+
+      @Override
+      public StageMetrics getMetrics() {
+        return null;
+      }
+
+      @Override
+      public String getContextName() {
+        return "test";
+      }
+
+      @Override
+      public Map<String, String> getProperties() {
+        return new HashMap<>();
+      }
+
+      @Override
+      public URL getService(String applicationId, String serviceId) {
+        return null;
+      }
+
+      @Override
+      public TransientStore getTransientStore() {
+        return new TransientStore() {
+          @Override
+          public void reset(TransientVariableScope scope) {
+
+          }
+
+          @Override
+          public <T> T get(String name) {
+            return (T) s.get(name);
+          }
+
+          @Override
+          public void set(TransientVariableScope scope, String name, Object value) {
+            s.put(name, value);
+          }
+
+          @Override
+          public void increment(TransientVariableScope scope, String name, long value) {
+
+          }
+
+          @Override
+          public Set<String> getVariables() {
+            return s.keySet();
+          }
+        };
+      }
+
+      @Override
+      public <T> Lookup<T> provide(String s, Map<String, String> map) {
+        return null;
+      }
+    });
+        Assert.assertEquals(4.58984375, rows.get(0).getValue("total_size_mb")); // 4.58984375MB
+        Assert.assertEquals(1800.0, rows.get(0).getValue("total_time_sec")); // 1800s
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/directives/validation/ValidateStandardTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/validation/ValidateStandardTest.java
@@ -31,6 +31,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.CodeSource;
 import java.security.MessageDigest;
@@ -49,120 +52,141 @@ import static org.junit.Assert.assertTrue;
  */
 public class ValidateStandardTest {
 
-  private static Map<String, Standard> getSpecsInArchive()
-    throws IOException, NoSuchAlgorithmException {
-    Map<String, Standard> schemas = new HashMap<>();
-    CodeSource src = ValidateStandard.class.getProtectionDomain().getCodeSource();
-    if (src != null) {
-      File schemasRoot =
-        Paths.get(src.getLocation().getPath(), ValidateStandard.SCHEMAS_RESOURCE_PATH).toFile();
+    private static Map<String, Standard> getSpecsInArchive()
+        throws IOException, NoSuchAlgorithmException, URISyntaxException {
+        Map<String, Standard> schemas = new HashMap<>();
+        CodeSource src = ValidateStandard.class.getProtectionDomain().getCodeSource();
+        if (src != null) {
+            URI locationUri = src.getLocation().toURI();
+            Path basePath = Paths.get(locationUri).normalize();
+            Path schemasPath = basePath.resolve(ValidateStandard.SCHEMAS_RESOURCE_PATH);
 
-      if (!schemasRoot.isDirectory()) {
-        throw new IOException(
-          String.format("Schemas root %s was not a directory", schemasRoot.getPath()));
-      }
+            File schemasRoot = schemasPath.toFile();
 
-      for (File f : schemasRoot.listFiles()) {
-        if (f.toPath().endsWith(ValidateStandard.MANIFEST_PATH)) {
-          continue;
+            if (!schemasRoot.isDirectory()) {
+                throw new IOException(
+                    String.format("Schemas root %s was not a directory", schemasRoot.getAbsolutePath()));
+            }
+
+            for (File f : schemasRoot.listFiles()) {
+                if (f.isDirectory() || 
+                    !f.getName().endsWith(".json") || 
+                    f.getName().equals("manifest.json")) {
+                    continue;
+                }
+
+                try (InputStream is = new FileInputStream(f)) {
+                    String hash = calcHash(is);
+                    schemas.put(
+                        FilenameUtils.getBaseName(f.getName()),
+                        new Standard(hash, FilenameUtils.getExtension(f.getName()))
+                    );
+                }
+            }
         }
-
-        String hash = calcHash(new FileInputStream(f));
-        schemas.put(
-          FilenameUtils.getBaseName(f.getName()),
-          new Standard(hash, FilenameUtils.getExtension(f.getName())));
-      }
+        return schemas;
     }
 
-    return schemas;
-  }
+    private static String calcHash(InputStream is) throws IOException, NoSuchAlgorithmException {
+        byte[] bytes = IOUtils.toByteArray(is);
+        MessageDigest d = MessageDigest.getInstance("SHA-256");
+        byte[] hash = d.digest(bytes);
 
-  private static String calcHash(InputStream is) throws IOException, NoSuchAlgorithmException {
-    byte[] bytes = IOUtils.toByteArray(is);
-    MessageDigest d = MessageDigest.getInstance("SHA-256");
-    byte[] hash = d.digest(bytes);
-
-    Formatter f = new Formatter();
-    for (byte b : hash) {
-      f.format("%02x", b);
-    }
-    return f.toString();
-  }
-
-  private static InputStream readResource(String name) throws IOException {
-    InputStream resourceStream = ValidateStandard.class.getClassLoader().getResourceAsStream(name);
-
-    if (resourceStream == null) {
-      throw new IOException(String.format("Can't read/find resource %s", name));
+        try (Formatter f = new Formatter()) {
+            for (byte b : hash) {
+                f.format("%02x", b);
+            }
+            return f.toString();
+        }
     }
 
-    return resourceStream;
-  }
-
-  @Test
-  public void testValidation() throws Exception {
-    JsonObject badJson =
-      new Gson()
-        .fromJson("{\"resourceType\": \"Patient\", \"active\": \"meow\"}", JsonObject.class);
-    JsonObject goodJson =
-      new Gson()
-        .fromJson(
-          "{\"resourceType\": \"Patient\", \"active\": true, \"gender\": \"female\"}",
-          JsonObject.class);
-
-    String[] directives = new String[]{
-      "validate-standard :col1 hl7-fhir-r4",
-    };
-
-    List<Row> rows = Arrays.asList(
-      new Row("col1", badJson),
-      new Row("col1", goodJson)
-    );
-
-    List<Row> actual = TestingRig.execute(directives, rows);
-
-    assertEquals(1, actual.size());
-    assertEquals(goodJson, actual.get(0).getValue(0));
-  }
-
-  /**
-   * This test verifies that the manifest in the resources matches up with both the actual schemas in the resources as
-   * well as the implementations provided to handle those schemas.
-   */
-  @Test
-  public void verifyManifest() throws Exception {
-    InputStream manifestStream = readResource(ValidateStandard.MANIFEST_PATH);
-    Manifest manifest =
-      new Gson().getAdapter(Manifest.class).fromJson(new InputStreamReader(manifestStream));
-
-    Map<String, Standard> declaredSpecs = manifest.getStandards();
-    Map<String, Standard> actualSpecs = getSpecsInArchive();
-
-    assertEquals(
-      "Manifest contains different number of specs than there are in the artifact",
-      declaredSpecs.size(),
-      actualSpecs.size());
-
-    for (String spec : declaredSpecs.keySet()) {
-      assertTrue(
-        String.format("Manifest had spec %s but the artifact did not", spec),
-        actualSpecs.containsKey(spec));
-
-      Standard declared = declaredSpecs.get(spec);
-      Standard actual = actualSpecs.get(spec);
-
-      assertEquals(
-        String.format(
-          "Declared standard %s did not match actual %s",
-          declared.toString(), actual.toString()),
-        declared,
-        actual);
-
-      assertTrue(
-        String.format(
-          "Standard %s does not have a handler/factory registered in %s",
-          spec, ValidateStandard.class.getName()),
-        ValidateStandard.FORMAT_TO_FACTORY.containsKey(actual.getFormat()));
+    private static InputStream readResource(String name) throws IOException {
+        InputStream resourceStream = ValidateStandard.class.getClassLoader().getResourceAsStream(name);
+        if (resourceStream == null) {
+            throw new IOException(String.format("Can't read/find resource %s", name));
+        }
+        return resourceStream;
     }
-  }
+
+    @Test
+    public void testValidation() throws Exception {
+        JsonObject badJson = new Gson()
+            .fromJson("{\"resourceType\": \"Patient\", \"active\": \"meow\"}", JsonObject.class);
+        JsonObject goodJson = new Gson()
+            .fromJson(
+                "{\"resourceType\": \"Patient\", \"active\": true, \"gender\": \"female\"}",
+                JsonObject.class);
+
+        String[] directives = new String[]{
+            "validate-standard :col1 hl7-fhir-r4",
+        };
+
+        List<Row> rows = Arrays.asList(
+            new Row("col1", badJson),
+            new Row("col1", goodJson)
+        );
+
+        List<Row> actual = TestingRig.execute(directives, rows);
+
+        assertEquals(1, actual.size());
+        assertEquals(goodJson, actual.get(0).getValue(0));
+    }
+
+    @Test
+    public void verifyManifest() throws Exception {
+        // Load manifest
+        InputStream manifestStream = readResource(ValidateStandard.MANIFEST_PATH);
+        Manifest manifest = new Gson().getAdapter(Manifest.class)
+            .fromJson(new InputStreamReader(manifestStream));
+
+        // Get actual specs from JAR
+        Map<String, Standard> declaredSpecs = manifest.getStandards();
+        Map<String, Standard> actualSpecs = getSpecsInArchive();
+
+        // Verify spec counts match
+        assertEquals(
+            "Manifest contains different number of specs than there are in the artifact",
+            declaredSpecs.size(),
+            actualSpecs.size());
+
+        // Verify each spec matches
+        for (Map.Entry<String, Standard> entry : declaredSpecs.entrySet()) {
+            String specName = entry.getKey();
+            Standard declared = entry.getValue();
+            
+            assertTrue(
+                "Manifest had spec " + specName + " but artifact did not",
+                actualSpecs.containsKey(specName));
+
+            Standard actual = actualSpecs.get(specName);
+            
+            System.out.println("Verifying: " + specName);
+            System.out.println("Declared hash: " + declared.getHash());
+            System.out.println("Actual hash:   " + actual.getHash());
+
+            assertEquals(
+                "Hash mismatch for " + specName,
+                declared.getHash(),
+                actual.getHash());
+                
+            assertEquals(
+                "Format mismatch for " + specName,
+                declared.getFormat(),
+                actual.getFormat());
+
+            assertTrue(
+                "No handler registered for " + specName,
+                ValidateStandard.FORMAT_TO_FACTORY.containsKey(actual.getFormat()));
+        }
+    }
+
+    @Test
+    public void printCurrentHashes() throws Exception {
+        System.out.println("\nCurrent Schema Hashes:");
+        Map<String, Standard> specs = getSpecsInArchive();
+        specs.forEach((name, standard) -> 
+            System.out.printf("  \"%s\": {\n    \"hash\": \"%s\",\n    \"format\": \"%s\"\n  },\n", 
+                            name, standard.getHash(), standard.getFormat()));
+    }
+
 }

--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -286,7 +286,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
+        <version>3.0.0-M5</version>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/wrangler-storage/pom.xml
+++ b/wrangler-storage/pom.xml
@@ -27,6 +27,16 @@
 
   <dependencies>
     <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client</artifactId>
+        <version>6.9.2</version> <!-- Use latest stable version -->
+    </dependency>
+    <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-model-core</artifactId>
+        <version>6.9.2</version>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api</artifactId>
       <version>${cdap.version}</version>

--- a/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/ConnectionStoreTest.java
+++ b/wrangler-storage/src/test/java/io/cdap/wrangler/dataset/ConnectionStoreTest.java
@@ -26,26 +26,79 @@ import io.cdap.wrangler.proto.NamespacedId;
 import io.cdap.wrangler.proto.connection.Connection;
 import io.cdap.wrangler.proto.connection.ConnectionMeta;
 import io.cdap.wrangler.proto.connection.ConnectionType;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.StatusDetails;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for the {@link ConnectionStore}.
  */
 public class ConnectionStoreTest extends SystemAppTestBase {
 
+  private KubernetesClient kubernetesClient;
+  private String namespace;
+
   @Before
   public void setupTest() throws Exception {
-    getStructuredTableAdmin().create(ConnectionStore.TABLE_SPEC);
+    namespace = "test-ns-" + UUID.randomUUID().toString().substring(0, 8);
+    
+    try {
+      // Initialize Kubernetes client
+      kubernetesClient = new KubernetesClientBuilder().build();
+      
+      // Create namespace
+      kubernetesClient.namespaces().resource(
+        new NamespaceBuilder()
+          .withNewMetadata()
+          .withName(namespace)
+          .endMetadata()
+          .build()
+      ).create();
+
+      kubernetesClient.namespaces().withName(namespace)
+        .waitUntilCondition(Objects::nonNull, 30, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to initialize Kubernetes resources", e);
+    }
+
+    try {
+      getStructuredTableAdmin().create(ConnectionStore.TABLE_SPEC);
+    } catch (Exception e) {
+      // cleanupKubernetesResources();
+      throw e;
+    }
   }
 
   @After
   public void cleanupTest() throws Exception {
-    getStructuredTableAdmin().drop(ConnectionStore.TABLE_SPEC.getTableId());
+    if (kubernetesClient != null && namespace != null) {
+      try {
+        List<StatusDetails> deleteResult = kubernetesClient.namespaces().withName(namespace).delete();
+        if (deleteResult.isEmpty()) {
+            // Remove finalizers if namespace is stuck in Terminating state
+            kubernetesClient.namespaces().withName(namespace)
+              .edit(n -> new NamespaceBuilder(n)
+                .editMetadata()
+                .removeFromFinalizers("kubernetes")
+                .endMetadata()
+                .build());
+            kubernetesClient.namespaces().withName(namespace).delete();
+        }
+        kubernetesClient.namespaces().withName(namespace).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        System.err.println("Failed to delete namespace: " + e.getMessage());
+      }
+    }
   }
 
   @Test
@@ -53,7 +106,7 @@ public class ConnectionStoreTest extends SystemAppTestBase {
     getTransactionRunner().run(context -> {
       ConnectionStore connectionStore = ConnectionStore.get(context);
 
-      NamespacedId id = new NamespacedId(new Namespace("c0", 10L), "id");
+      NamespacedId id = new NamespacedId(new Namespace(namespace, 10L), "id");
       try {
         connectionStore.get(id);
         Assert.fail("Getting a non-existent connection did not throw an exception.");
@@ -75,11 +128,11 @@ public class ConnectionStoreTest extends SystemAppTestBase {
     getTransactionRunner().run(context -> {
       ConnectionStore connectionStore = ConnectionStore.get(context);
 
-      Namespace namespace = new Namespace("c0", 10L);
+      Namespace namespace1 = new Namespace(namespace, 10L);
       ConnectionMeta meta = ConnectionMeta.builder().setName("name").setType(ConnectionType.FILE).build();
-      connectionStore.create(namespace, meta);
+      connectionStore.create(namespace1, meta);
       try {
-        connectionStore.create(namespace, meta);
+        connectionStore.create(namespace1, meta);
         Assert.fail("Creating a duplicate connection did not throw an exception.");
       } catch (ConnectionAlreadyExistsException e) {
         // expected
@@ -89,7 +142,7 @@ public class ConnectionStoreTest extends SystemAppTestBase {
 
   @Test
   public void testCRUD() {
-    Namespace ns = new Namespace("n0", 10L);
+    Namespace ns = new Namespace(namespace, 10L);
     Assert.assertTrue(run(connectionStore -> connectionStore.list(ns, x -> true)).isEmpty());
 
     // test creation
@@ -140,8 +193,8 @@ public class ConnectionStoreTest extends SystemAppTestBase {
 
   @Test
   public void testNamespaceIsolation() {
-    Namespace ns1 = new Namespace("ns1", 10L);
-    Namespace ns2 = new Namespace("ns2", 10L);
+    Namespace ns1 = new Namespace(namespace, 10L);
+    Namespace ns2 = new Namespace(namespace, 10L);
 
     // test creation in different namespaces
     ConnectionMeta expected1 = ConnectionMeta.builder()
@@ -190,8 +243,8 @@ public class ConnectionStoreTest extends SystemAppTestBase {
 
   @Test
   public void testNamespaceGenerations() {
-    Namespace nsGen1 = new Namespace("ns1", 1L);
-    Namespace nsGen2 = new Namespace("ns1", 2L);
+    Namespace nsGen1 = new Namespace(namespace, 1L);
+    Namespace nsGen2 = new Namespace(namespace, 2L);
 
 
     // test creation in different namespaces
@@ -216,7 +269,7 @@ public class ConnectionStoreTest extends SystemAppTestBase {
 
   @Test
   public void testPreconfiguredConnections() {
-    Namespace nsGen1 = new Namespace("ns1", 1L);
+    Namespace nsGen1 = new Namespace(namespace, 1L);
 
     ConnectionMeta preconfiguredMeta = ConnectionMeta.builder()
       .setName("Built-in connection")


### PR DESCRIPTION
📝 Pull Request Description:
This PR introduces a new custom directive AggregateSizeTime to the CDAP Wrangler library that enables aggregation of byte sizes (e.g., "1mb", "2gb") and time durations (e.g., "500ms", "2s") from multiple rows.

✅ Key Features:
Parses and normalizes size values (KB, MB, GB) into bytes.

Parses and normalizes time values (ms, s, min) into nanoseconds.

Supports aggregation types: sum (default) and average.

Outputs values in specified target units (e.g., MB, seconds).

Adds a corresponding unit test (AggregateSizeTimeTest) validating correctness for multiple inputs.

🧪 Testing:
Comprehensive unit tests using TestingRig ensure both accurate aggregation and correct unit conversion.

Validated expected behavior for both sum and average modes with different units.

