### PR TITLE
Enhance Wrangler with BYTE_SIZE and TIME_DURATION 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,16 @@
     <testSourceDirectory>${testSourceLocation}</testSourceDirectory>
     <pluginManagement>
       <plugins>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version> <!-- use at least 2.22.0+ -->
+          <configuration>
+            <forkCount>1</forkCount>
+            <reuseForks>true</reuseForks>
+            <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>

--- a/prompts.txt
+++ b/prompts.txt
@@ -1,0 +1,7 @@
+"Can you show an example of how to implement custom error messages in the parser for specific syntax mistakes?"
+"Help me debug this lexer rule for handling BYTE_SIZE and TIME_DURATION correctly."
+"What are some tips to ensure the robustness of the generated parser when dealing with complex nested conditions?"
+"What are the best practices for testing byte size and time duration parsing in Java, including handling different cases like '10KB', '150ms', and '2s'?"
+"How do I implement a test case to ensure the aggregate stats directive correctly calculates total byte size and time duration?"
+"Can you guide me in handling edge cases like zero values, large numbers, and inconsistent units in the new parsing logic?"
+"How should I structure my tests to ensure they cover various cases for byte size and time duration conversions and aggregations?"

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,156 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+/**
+ * Represents a ByteSize token, capable of parsing strings like "10KB", "1.5MB",
+ * and converting them into bytes.
+ */
+@PublicEvolving
+public class ByteSize implements Token {
+
+  // Multipliers for each unit
+  private static final double KILOBYTE = 1024.0;
+  private static final double MEGABYTE = KILOBYTE * 1024.0;
+  private static final double GIGABYTE = MEGABYTE * 1024.0;
+  private static final double TERABYTE = GIGABYTE * 1024.0;
+
+  // Parsed byte value stored as long
+  private final long bytesValue;
+
+  /**
+   * Constructs a ByteSize token by parsing the given size string.
+   *
+   * @param sizeString The string to parse (e.g., "10KB", "1.5MB").
+   * @throws IllegalArgumentException If the string format is invalid.
+   */
+  public ByteSize(String sizeString) {
+    this.bytesValue = parseSize(sizeString);
+  }
+
+  /**
+   * Parses a size string and converts it into bytes.
+   *
+   * @param sizeString The input string representing a byte size.
+   * @return The size in bytes.
+   */
+  private long parseSize(String sizeString) {
+    if (sizeString == null || sizeString.trim().isEmpty()) {
+      throw new IllegalArgumentException("Size string must not be null or empty.");
+    }
+
+    sizeString = sizeString.trim().toUpperCase();
+    String numericPart;
+    double multiplier;
+
+    try {
+      if (sizeString.endsWith("KB")) {
+        numericPart = sizeString.substring(0, sizeString.length() - 2);
+        multiplier = KILOBYTE;
+      } else if (sizeString.endsWith("MB")) {
+        numericPart = sizeString.substring(0, sizeString.length() - 2);
+        multiplier = MEGABYTE;
+      } else if (sizeString.endsWith("GB")) {
+        numericPart = sizeString.substring(0, sizeString.length() - 2);
+        multiplier = GIGABYTE;
+      } else if (sizeString.endsWith("TB")) {
+        numericPart = sizeString.substring(0, sizeString.length() - 2);
+        multiplier = TERABYTE;
+      } else if (sizeString.endsWith("B")) {
+        numericPart = sizeString.substring(0, sizeString.length() - 1);
+        multiplier = 1.0;
+      } else {
+        throw new IllegalArgumentException("Invalid byte size format or unsupported unit in string: " + sizeString);
+      }
+
+      if (numericPart.isEmpty()) {
+        throw new IllegalArgumentException("Missing numeric value in size string: " + sizeString);
+      }
+
+      double parsedValue = Double.parseDouble(numericPart);
+      if (parsedValue < 0) {
+        throw new IllegalArgumentException("Size value cannot be negative: " + sizeString);
+      }
+
+      return (long) (parsedValue * multiplier); // Truncate to long
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid numeric value in size string: " + sizeString, e);
+    }
+  }
+
+  /**
+   * @return Size in bytes.
+   */
+  public long getBytes() {
+    return bytesValue;
+  }
+
+  /**
+   * @return Size in kilobytes.
+   */
+  public double getKiloBytes() {
+    return bytesValue / KILOBYTE;
+  }
+
+  /**
+   * @return Size in megabytes.
+   */
+  public double getMegaBytes() {
+    return bytesValue / MEGABYTE;
+  }
+
+  /**
+   * @return Size in gigabytes.
+   */
+  public double getGigaBytes() {
+    return bytesValue / GIGABYTE;
+  }
+
+  /**
+   * @return Size in terabytes.
+   */
+  public double getTeraBytes() {
+    return bytesValue / TERABYTE;
+  }
+
+  @Override
+  public Object value() {
+    return bytesValue;
+  }
+
+  @Override
+  public TokenType type() {
+    return TokenType.BYTE_SIZE;
+  }
+
+  @Override
+  public JsonElement toJson() {
+    JsonObject object = new JsonObject();
+    object.addProperty("type", TokenType.BYTE_SIZE.name());
+    object.addProperty("value", bytesValue);
+    return object;
+  }
+
+  @Override
+  public String toString() {
+    return bytesValue + "B";
+  }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,155 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *  Copyright © 2023 Google LLC // Update copyright year/holder if needed
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.annotations.PublicEvolving;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Represents a Token for time durations, capable of parsing strings
+ * like "5ms", "2.1s", or "3h" and converting them into milliseconds.
+ */
+@PublicEvolving
+public class TimeDuration implements Token {
+
+    // Time unit conversion factors (all in terms of milliseconds)
+    private static final double MILLIS_IN_NANOSECOND = 1.0 / 1_000_000.0;
+    private static final double MILLIS_IN_MICROSECOND = 1.0 / 1_000.0;
+    private static final double MILLIS_IN_SECOND = 1_000.0;
+    private static final double MILLIS_IN_MINUTE = 60.0 * MILLIS_IN_SECOND;
+    private static final double MILLIS_IN_HOUR = 60.0 * MILLIS_IN_MINUTE;
+    private static final double MILLIS_IN_DAY = 24.0 * MILLIS_IN_HOUR;
+
+    // Final parsed duration value (in milliseconds)
+    private final double durationMillis;
+
+    /**
+     * Constructs a TimeDuration object by parsing the provided duration string.
+     *
+     * @param inputDuration A string representing duration (e.g., "5ms", "2.5h").
+     * @throws IllegalArgumentException if the string format is invalid.
+     */
+    public TimeDuration(String inputDuration) {
+        this.durationMillis = parseDuration(inputDuration);
+    }
+
+    /**
+     * Parses a duration string and converts it to milliseconds.
+     *
+     * @param durationStr Input duration string to parse.
+     * @return Duration value in milliseconds.
+     * @throws IllegalArgumentException if format or value is invalid.
+     */
+    private double parseDuration(String durationStr) {
+        if (durationStr == null || durationStr.trim().isEmpty()) {
+            throw new IllegalArgumentException("Duration string must not be null or empty.");
+        }
+
+        durationStr = durationStr.trim().toLowerCase();
+        String numericPart;
+        double conversionFactor;
+
+        try {
+            if (durationStr.endsWith("ns")) {
+                numericPart = durationStr.substring(0, durationStr.length() - 2);
+                conversionFactor = MILLIS_IN_NANOSECOND;
+            } else if (durationStr.endsWith("us")) {
+                numericPart = durationStr.substring(0, durationStr.length() - 2);
+                conversionFactor = MILLIS_IN_MICROSECOND;
+            } else if (durationStr.endsWith("ms")) {
+                numericPart = durationStr.substring(0, durationStr.length() - 2);
+                conversionFactor = 1.0;
+            } else if (durationStr.endsWith("s")) {
+                numericPart = durationStr.substring(0, durationStr.length() - 1);
+                conversionFactor = MILLIS_IN_SECOND;
+            } else if (durationStr.endsWith("min")) {
+                numericPart = durationStr.substring(0, durationStr.length() - 3);
+                conversionFactor = MILLIS_IN_MINUTE;
+            } else if (durationStr.endsWith("m")) {
+                numericPart = durationStr.substring(0, durationStr.length() - 1);
+                conversionFactor = MILLIS_IN_MINUTE;
+            } else if (durationStr.endsWith("h")) {
+                numericPart = durationStr.substring(0, durationStr.length() - 1);
+                conversionFactor = MILLIS_IN_HOUR;
+            } else if (durationStr.endsWith("d")) {
+                numericPart = durationStr.substring(0, durationStr.length() - 1);
+                conversionFactor = MILLIS_IN_DAY;
+            } else {
+                throw new IllegalArgumentException(
+                        "Invalid time duration format or unsupported unit in string: " + durationStr);
+            }
+
+            if (numericPart.isEmpty()) {
+                throw new IllegalArgumentException("Missing numeric value in duration string: " + durationStr);
+            }
+
+            double parsedNumber = Double.parseDouble(numericPart);
+            if (parsedNumber < 0) {
+                throw new IllegalArgumentException("Duration value cannot be negative: " + durationStr);
+            }
+
+            return parsedNumber * conversionFactor;
+
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid numeric value in duration string: " + durationStr, e);
+        }
+    }
+
+    /**
+     * Converts and returns the duration in the given {@link TimeUnit}.
+     *
+     * @param unit Time unit to convert to.
+     * @return Converted duration in the specified unit (rounded).
+     */
+    public long getDuration(TimeUnit unit) {
+        return unit.convert((long) this.durationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * @return Canonical duration value in milliseconds.
+     */
+    public double getValue() {
+        return durationMillis;
+    }
+
+    @Override
+    public Object value() {
+        return durationMillis;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("type", TokenType.TIME_DURATION.name());
+        object.addProperty("value", durationMillis);
+        return object;
+    }
+
+    @Override
+    public String toString() {
+        return durationMillis + "ms";
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -152,5 +152,7 @@ public enum TokenType implements Serializable {
    * Represents the enumerated type for the object of type {@code String} with restrictions
    * on characters that can be present in a string.
    */
-  IDENTIFIER
+  IDENTIFIER,
+  BYTE_SIZE,
+  TIME_DURATION
 }

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/UsageDefinition.java
@@ -23,10 +23,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This class {@link UsageDefinition} provides a way for users to registers the argument for UDDs.
+ * This class {@link UsageDefinition} provides a way for users to registers the
+ * argument for UDDs.
  *
- * {@link UsageDefinition} is a collection of {@link TokenDefinition} and the name of the directive
- * itself. Each token specification has an associated ordinal that can be used to position the argument
+ * {@link UsageDefinition} is a collection of {@link TokenDefinition} and the
+ * name of the directive
+ * itself. Each token specification has an associated ordinal that can be used
+ * to position the argument
  * within the directive.
  *
  * Following is a example of how this class can be used.
@@ -43,7 +46,8 @@ import java.util.List;
  * @see TokenDefinition
  */
 public final class UsageDefinition implements Serializable {
-  // transient so it doesn't show up when serialized using gson in service endpoint responses
+  // transient so it doesn't show up when serialized using gson in service
+  // endpoint responses
   private final transient int optionalCnt;
   private final String directive;
   private final List<TokenDefinition> tokens;
@@ -55,7 +59,8 @@ public final class UsageDefinition implements Serializable {
   }
 
   /**
-   * Returns the name of the directive for which the this <code>UsageDefinition</code>
+   * Returns the name of the directive for which the this
+   * <code>UsageDefinition</code>
    * object is created.
    *
    * @return name of the directive.
@@ -118,7 +123,7 @@ public final class UsageDefinition implements Serializable {
         } else if (token.type().equals(TokenType.IDENTIFIER) || token.type().equals(TokenType.NUMERIC)) {
           sb.append(token.name());
         } else if (token.type().equals(TokenType.BOOLEAN_LIST) || token.type().equals(TokenType.NUMERIC_LIST)
-          || token.type().equals(TokenType.TEXT_LIST)) {
+            || token.type().equals(TokenType.TEXT_LIST)) {
           sb.append(token.name()).append("[,").append(token.name()).append(" ...]*");
         } else if (token.type().equals(TokenType.EXPRESSION)) {
           sb.append("exp:{<").append(token.name()).append(">}");
@@ -126,6 +131,10 @@ public final class UsageDefinition implements Serializable {
           sb.append("prop:{key:value,[key:value]*");
         } else if (token.type().equals(TokenType.RANGES)) {
           sb.append("start:end=[bool|text|numeric][,start:end=[bool|text|numeric]*");
+        } else if (token.type().equals(TokenType.BYTE_SIZE)) {
+          sb.append(":").append(token.name());
+        } else if (token.type().equals(TokenType.TIME_DURATION)) {
+          sb.append(":").append(token.name());
         }
       }
 
@@ -143,23 +152,30 @@ public final class UsageDefinition implements Serializable {
   }
 
   /**
-   * This is a static method for creating a builder for the <code>UsageDefinition</code>
-   * object. In order to create a <code>UsageDefinition</code>, a builder has to created.
+   * This is a static method for creating a builder for the
+   * <code>UsageDefinition</code>
+   * object. In order to create a <code>UsageDefinition</code>, a builder has to
+   * created.
    *
-   * <p>This builder is provided as user API for constructing the usage specification
-   * for a directive.</p>
+   * <p>
+   * This builder is provided as user API for constructing the usage specification
+   * for a directive.
+   * </p>
    *
    * @param directive name of the directive for which the builder is created for.
-   * @return A <code>UsageDefinition.Builder</code> object that can be used to construct
-   * <code>UsageDefinition</code> object.
+   * @return A <code>UsageDefinition.Builder</code> object that can be used to
+   *         construct
+   *         <code>UsageDefinition</code> object.
    */
   public static UsageDefinition.Builder builder(String directive) {
     return new UsageDefinition.Builder(directive);
   }
 
   /**
-   * This inner builder class provides a way to create <code>UsageDefinition</code>
-   * object. It exposes different methods that allow users to configure the <code>TokenDefinition</code>
+   * This inner builder class provides a way to create
+   * <code>UsageDefinition</code>
+   * object. It exposes different methods that allow users to configure the
+   * <code>TokenDefinition</code>
    * for each token used within the usage of a directive.
    */
   public static final class Builder {
@@ -189,11 +205,12 @@ public final class UsageDefinition implements Serializable {
     }
 
     /**
-     * Allows users to define a token with a name, type of the token and additional optional
+     * Allows users to define a token with a name, type of the token and additional
+     * optional
      * for the label that is used during creation of the usage for the directive.
      *
-     * @param name of the token in the definition of a directive.
-     * @param type of the token to be extracted.
+     * @param name  of the token in the definition of a directive.
+     * @param type  of the token to be extracted.
      * @param label label that modifies the usage for this field.
      */
     public void define(String name, TokenType type, String label) {
@@ -206,9 +223,10 @@ public final class UsageDefinition implements Serializable {
      * Method allows users to specify a field as optional in combination to the
      * name of the token and the type of token.
      *
-     * @param name of the token in the definition of a directive.
-     * @param type of the token to be extracted.
-     * @param optional <code>Optional#TRUE</code> if token is optional, else <code>Optional#FALSE</code>.
+     * @param name     of the token in the definition of a directive.
+     * @param type     of the token to be extracted.
+     * @param optional <code>Optional#TRUE</code> if token is optional, else
+     *                 <code>Optional#FALSE</code>.
      */
     public void define(String name, TokenType type, boolean optional) {
       TokenDefinition spec = new TokenDefinition(name, type, null, currentOrdinal, optional);
@@ -222,10 +240,11 @@ public final class UsageDefinition implements Serializable {
      * name of the token, the type of token and also the ability to specify a label
      * for the usage.
      *
-     * @param name of the token in the definition of a directive.
-     * @param type of the token to be extracted.
-     * @param label label that modifies the usage for this field.
-     * @param optional <code>Optional#TRUE</code> if token is optional, else <code>Optional#FALSE</code>.
+     * @param name     of the token in the definition of a directive.
+     * @param type     of the token to be extracted.
+     * @param label    label that modifies the usage for this field.
+     * @param optional <code>Optional#TRUE</code> if token is optional, else
+     *                 <code>Optional#FALSE</code>.
      */
     public void define(String name, TokenType type, String label, boolean optional) {
       TokenDefinition spec = new TokenDefinition(name, type, label, currentOrdinal, optional);

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -35,17 +35,20 @@
   <dependencies>
 
     <!-- Internal -->
-
+        
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
     </dependency>
-    <dependency>
-      <groupId>io.cdap.wrangler</groupId>
-      <artifactId>wrangler-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
+   <dependency>
+  <groupId>io.cdap.wrangler</groupId>
+  <artifactId>wrangler-api</artifactId>
+  <version>${project.version}</version>
+  <scope>compile</scope>
+</dependency>
+
+
     <dependency>
       <groupId>io.cdap.wrangler</groupId>
       <artifactId>wrangler-proto</artifactId>
@@ -98,6 +101,12 @@
       <artifactId>powermock-module-junit4</artifactId>
       <version>2.0.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+        <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
@@ -320,6 +329,17 @@
       </resource>
     </resources>
     <plugins>
+     <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version> <!-- use at least 2.22.0+ -->
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>true</reuseForks>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+    
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -64,6 +64,8 @@ directive
     | stringList
     | numberRanges
     | properties
+    | byteSizeArg
+    | timeDurationArg
   )*?
   ;
 
@@ -114,6 +116,10 @@ codeblock
 identifier
  : Identifier
  ;
+
+ byteSizeArg : BYTE_SIZE ;
+
+ timeDurationArg : TIME_DURATION ;
 
 properties
  : 'prop' ':' OBrace (propertyList)+  CBrace
@@ -311,3 +317,25 @@ fragment Int
 fragment Digit
  : [0-9]
  ;
+
+
+BYTE_SIZE
+    : DecimalNumber BYTE_UNIT
+    ;
+
+TIME_DURATION
+    : DecimalNumber TIME_UNIT
+    ;
+
+
+fragment DecimalNumber
+    : Digit+ ('.' Digit+)?   // matches 123, 1.5, 0.25, etc.
+    ;
+
+fragment BYTE_UNIT 
+    : ([kK]|[mM]|[gG]|[tT])? [bB]   // e.g., KB, kb, Mb, GB
+    ;
+
+fragment TIME_UNIT 
+    :([nNmM])+ [sS]?           // e.g., ms, MS, h, H, ns
+    ;

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/AggregateStats.java
@@ -1,0 +1,180 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.aggregates;
+
+import io.cdap.cdap.api.annotation.Name;
+
+import io.cdap.cdap.api.annotation.Plugin;
+
+import io.cdap.cdap.api.data.schema.Schema;
+
+import io.cdap.wrangler.api.Arguments;
+
+import io.cdap.wrangler.api.Directive;
+
+import io.cdap.wrangler.api.DirectiveExecutionException;
+
+import io.cdap.wrangler.api.DirectiveParseException;
+
+import io.cdap.wrangler.api.ExecutorContext;
+
+import io.cdap.wrangler.api.Row;
+
+import io.cdap.wrangler.api.annotations.Categories;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+
+import io.cdap.wrangler.api.parser.ColumnName;
+
+import io.cdap.wrangler.api.parser.Text;
+
+import io.cdap.wrangler.api.parser.TimeDuration;
+
+import io.cdap.wrangler.api.parser.TokenType;
+
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+import java.util.ArrayList;
+
+import java.util.List;
+/**
+ * Directive to aggregate statistics over a dataset. It computes
+ * total bytes and total time, then outputs the summary in MB and seconds.
+ */
+@Plugin(type = Directive.TYPE)
+@Name(AggregateStats.NAME)
+@Categories(categories = { "data-aggregation" })
+public class AggregateStats implements Directive {
+
+    public static final String NAME = "aggregate-stats";
+
+    // Input column names
+    private String inputByteColumn;
+    private String inputTimeColumn;
+
+    // Output column names
+    private String resultByteColumn;
+    private String resultTimeColumn;
+
+    // Aggregated values
+    private double accumulatedBytes = 0.0;
+    private double accumulatedTimeMs = 0.0;
+    private int processedRowCount = 0;
+
+    /**
+     * Defines the parameters required to use this directive.
+     *
+     * @return UsageDefinition instance outlining directive inputs.
+     */
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+        builder.define("byteCol", TokenType.COLUMN_NAME);
+        builder.define("timeCol", TokenType.COLUMN_NAME);
+        builder.define("outputSizeCol", TokenType.TEXT);
+        builder.define("outputTimeCol", TokenType.TEXT);
+        return builder.build();
+    }
+
+    /**
+     * Initializes the directive with user-provided arguments.
+     *
+     * @param args The input arguments.
+     * @throws DirectiveParseException if parsing fails.
+     */
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        inputByteColumn = ((ColumnName) args.value("byteCol")).value();
+        inputTimeColumn = ((ColumnName) args.value("timeCol")).value();
+        resultByteColumn = ((Text) args.value("outputSizeCol")).value();
+        resultTimeColumn = ((Text) args.value("outputTimeCol")).value();
+    }
+
+    /**
+     * Executes aggregation logic over input rows.
+     *
+     * @param rows List of input rows.
+     * @param ctx  Execution context.
+     * @return List containing a single row with aggregated metrics.
+     * @throws DirectiveExecutionException if any error occurs during execution.
+     */
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext ctx) throws DirectiveExecutionException {
+        try {
+            for (Row row : rows) {
+                if (row.find(inputByteColumn) != -1 && row.find(inputTimeColumn) != -1) {
+                    String byteValue = row.getValue(inputByteColumn).toString();
+                    String timeValue = row.getValue(inputTimeColumn).toString();
+
+                    // Parse input values
+                    ByteSize byteSize = new ByteSize(byteValue);
+                    TimeDuration duration = new TimeDuration(timeValue);
+
+                    accumulatedBytes += byteSize.getBytes();
+                    accumulatedTimeMs += duration.getValue();
+                    processedRowCount++;
+                }
+            }
+
+            if (processedRowCount == 0) {
+                return new ArrayList<>();
+            }
+
+            // Prepare output
+            List<Row> results = new ArrayList<>();
+            Row resultRow = new Row();
+
+            resultRow.add(resultByteColumn, accumulatedBytes / (1024.0 * 1024.0));  // Convert bytes to MB
+            resultRow.add(resultTimeColumn, accumulatedTimeMs / 1000.0);            // Convert ms to seconds
+
+            results.add(resultRow);
+            return results;
+
+        } catch (Exception e) {
+            throw new DirectiveExecutionException(
+                String.format("Error aggregating stats: %s", e.getMessage())
+            );
+        }
+    }
+
+    /**
+     * Defines the output schema for the transformed dataset.
+     *
+     * @param inputSchema The schema of incoming data.
+     * @return Schema of the resulting data.
+     */
+    public Schema getOutputSchema(Schema inputSchema) {
+        List<Schema.Field> fields = new ArrayList<>();
+        fields.add(Schema.Field.of(resultByteColumn, Schema.of(Schema.Type.DOUBLE)));
+        fields.add(Schema.Field.of(resultTimeColumn, Schema.of(Schema.Type.DOUBLE)));
+        return Schema.recordOf("aggregate-stats", fields);
+    }
+
+    /**
+     * Cleans up and resets the internal state of the directive.
+     */
+    @Override
+    public void destroy() {
+        accumulatedBytes = 0.0;
+        accumulatedTimeMs = 0.0;
+        processedRowCount = 0;
+
+        inputByteColumn = null;
+        inputTimeColumn = null;
+        resultByteColumn = null;
+        resultTimeColumn = null;
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,6 +22,7 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
+import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -33,6 +34,7 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
+import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
@@ -49,19 +51,31 @@ import java.util.Map;
  * used during traversal of the AST tree. The <code>ParserTree#Walker</code>
  * invokes appropriate methods as call backs with information about the node.
  *
- * <p>In order to understand what's being invoked, please look at the grammar file
- * <tt>Directive.g4</tt></p>.
+ * <p>
+ * In order to understand what's being invoked, please look at the grammar file
+ * <tt>Directive.g4</tt>
+ * </p>
+ * .
  *
- * <p>This class exposes a <code>getTokenGroups</code> method for retrieving the
- * <code>RecipeSymbol</code> after visiting. The <code>RecipeSymbol</code> represents
- * all the <code>TokenGroup</code> for all directives in a recipe. Each directive
- * will create a <code>TokenGroup</code></p>
+ * <p>
+ * This class exposes a <code>getTokenGroups</code> method for retrieving the
+ * <code>RecipeSymbol</code> after visiting. The <code>RecipeSymbol</code>
+ * represents
+ * all the <code>TokenGroup</code> for all directives in a recipe. Each
+ * directive
+ * will create a <code>TokenGroup</code>
+ * </p>
  *
- * <p> As the <code>ParseTree</code> is walking through the call graph, it generates
- * one <code>TokenGroup</code> for each directive in the recipe. Each <code>TokenGroup</code>
- * contains parsed <code>Tokens</code> for that directive along with more information like
- * <code>SourceInfo</code>. A collection of <code>TokenGroup</code> consistutes a <code>RecipeSymbol</code>
- * that is returned by this function.</p>
+ * <p>
+ * As the <code>ParseTree</code> is walking through the call graph, it generates
+ * one <code>TokenGroup</code> for each directive in the recipe. Each
+ * <code>TokenGroup</code>
+ * contains parsed <code>Tokens</code> for that directive along with more
+ * information like
+ * <code>SourceInfo</code>. A collection of <code>TokenGroup</code> consistutes
+ * a <code>RecipeSymbol</code>
+ * that is returned by this function.
+ * </p>
  */
 public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Builder> {
   private RecipeSymbol.Builder builder = new RecipeSymbol.Builder();
@@ -78,8 +92,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Recipe is made up of Directives and Directives is made up of each individual
-   * Directive. This method is invoked on every visit to a new directive in the recipe.
+   * A Recipe is made up of Directives and Directives is made up of each
+   * individual
+   * Directive. This method is invoked on every visit to a new directive in the
+   * recipe.
    */
   @Override
   public RecipeSymbol.Builder visitDirective(DirectivesParser.DirectiveContext ctx) {
@@ -88,7 +104,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can include identifiers, this method extracts that token that is being
+   * A Directive can include identifiers, this method extracts that token that is
+   * being
    * identified as token of type <code>Identifier</code>.
    */
   @Override
@@ -98,8 +115,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can include properties (which are a collection of key and value pairs),
-   * this method extracts that token that is being identified as token of type <code>Properties</code>.
+   * A Directive can include properties (which are a collection of key and value
+   * pairs),
+   * this method extracts that token that is being identified as token of type
+   * <code>Properties</code>.
    */
   @Override
   public RecipeSymbol.Builder visitPropertyList(DirectivesParser.PropertyListContext ctx) {
@@ -123,11 +142,15 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Pragma is an instruction to the compiler to dynamically load the directives being specified
+   * A Pragma is an instruction to the compiler to dynamically load the directives
+   * being specified
    * from the <code>DirectiveRegistry</code>. These do not affect the data flow.
    *
-   * <p>E.g. <code>#pragma load-directives test1, test2, test3;</code> will collect the tokens
-   * test1, test2 and test3 as dynamically loadable directives. <p>
+   * <p>
+   * E.g. <code>#pragma load-directives test1, test2, test3;</code> will collect
+   * the tokens
+   * test1, test2 and test3 as dynamically loadable directives.
+   * <p>
    */
   @Override
   public RecipeSymbol.Builder visitPragmaLoadDirective(DirectivesParser.PragmaLoadDirectiveContext ctx) {
@@ -139,7 +162,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Pragma version is a informational directive to notify compiler about the grammar that is should
+   * A Pragma version is a informational directive to notify compiler about the
+   * grammar that is should
    * be using to parse the directives below.
    */
   @Override
@@ -149,8 +173,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can include number ranges like start:end=value[,start:end=value]*. This
-   * visitor method allows you to collect all the number ranges and create a token type
+   * A Directive can include number ranges like
+   * start:end=value[,start:end=value]*. This
+   * visitor method allows you to collect all the number ranges and create a token
+   * type
    * <code>Ranges</code>.
    */
   @Override
@@ -163,11 +189,9 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
       if (text.startsWith("'") && text.endsWith("'")) {
         text = text.substring(1, text.length() - 1);
       }
-      Triplet<Numeric, Numeric, String> val =
-        new Triplet<>(new Numeric(new LazyNumber(numbers.get(0).getText())),
-                      new Numeric(new LazyNumber(numbers.get(1).getText())),
-                      text
-        );
+      Triplet<Numeric, Numeric, String> val = new Triplet<>(new Numeric(new LazyNumber(numbers.get(0).getText())),
+          new Numeric(new LazyNumber(numbers.get(1).getText())),
+          text);
       output.add(val);
     }
     builder.addToken(new Ranges(output));
@@ -185,8 +209,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can consist of column specifiers. These are columns that the directive
-   * would operate on. When a token of type column is visited, it would generate a token
+   * A Directive can consist of column specifiers. These are columns that the
+   * directive
+   * would operate on. When a token of type column is visited, it would generate a
+   * token
    * type of type <code>ColumnName</code>.
    */
   @Override
@@ -196,8 +222,10 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * A Directive can consist of text field. These type of fields are enclosed within
-   * a single-quote or a double-quote. This visitor method extracts the string value
+   * A Directive can consist of text field. These type of fields are enclosed
+   * within
+   * a single-quote or a double-quote. This visitor method extracts the string
+   * value
    * within the quotes and creates a token type <code>Text</code>.
    */
   @Override
@@ -232,7 +260,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   /**
    * A Directive can include a expression or a condition to be evaluated. When
    * such a token type is found, the visitor extracts the expression and generates
-   * a token type <code>Expression</code> to be added to the <code>TokenGroup</code>
+   * a token type <code>Expression</code> to be added to the
+   * <code>TokenGroup</code>
    */
   @Override
   public RecipeSymbol.Builder visitCondition(DirectivesParser.ConditionContext ctx) {
@@ -248,7 +277,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
 
   /**
    * A Directive has name and in the parsing context it's called a command.
-   * This visitor methods extracts the command and creates a toke type <code>DirectiveName</code>
+   * This visitor methods extracts the command and creates a toke type
+   * <code>DirectiveName</code>
    */
   @Override
   public RecipeSymbol.Builder visitCommand(DirectivesParser.CommandContext ctx) {
@@ -257,7 +287,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of columns specified. It creates a token
+   * This visitor methods extracts the list of columns specified. It creates a
+   * token
    * type <code>ColumnNameList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -272,7 +303,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of numeric specified. It creates a token
+   * This visitor methods extracts the list of numeric specified. It creates a
+   * token
    * type <code>NumericList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -287,7 +319,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of booleans specified. It creates a token
+   * This visitor methods extracts the list of booleans specified. It creates a
+   * token
    * type <code>BoolList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -302,7 +335,8 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
   }
 
   /**
-   * This visitor methods extracts the list of strings specified. It creates a token
+   * This visitor methods extracts the list of strings specified. It creates a
+   * token
    * type <code>StringList</code> to be added to <code>TokenGroup</code>.
    */
   @Override
@@ -314,6 +348,31 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
       strs.add(text.substring(1, text.length() - 1));
     }
     builder.addToken(new TextList(strs));
+    return builder;
+  }
+
+  // Parse the byte size argument (e.g., "10MB") and convert it into a ByteSize
+  // token.
+  // Add the ByteSize token to the directive builder for further processing.
+
+  @Override
+  public RecipeSymbol.Builder visitByteSizeArg(DirectivesParser.ByteSizeArgContext ctx) {
+    String byteSizeValue = ctx.BYTE_SIZE().getText(); // e.g., 10MB
+    ByteSize byteSize = new ByteSize(byteSizeValue);
+    builder.addToken(byteSize);
+    return builder;
+  }
+
+  // Parse the time duration argument (e.g., "5s", "1h") and create a TimeDuration
+  // token.
+  // Add the TimeDuration token to the directive builder for use in directive
+  // execution.
+
+  @Override
+  public RecipeSymbol.Builder visitTimeDurationArg(DirectivesParser.TimeDurationArgContext ctx) {
+    String token = ctx.TIME_DURATION().getText(); // More explicit
+    TimeDuration timeDuration = new TimeDuration(token);
+    builder.addToken(timeDuration);
     return builder;
   }
 

--- a/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/aggregates/AggregateStatsTest.java
@@ -1,0 +1,189 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.directives.aggregates;
+
+import com.google.gson.JsonElement;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.Token;
+import io.cdap.wrangler.api.parser.TokenType;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AggregateStatsTest {
+
+    @Test
+    public void testAggregateStatsDirective() throws Exception {
+        // Prepare sample input rows with size in KB and response time in seconds/milliseconds
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "12KB").add("response_time", "1.2s"));
+        rows.add(new Row().add("data_transfer_size", "8KB").add("response_time", "800ms"));
+
+        // Instantiate the directive
+        AggregateStats directive = new AggregateStats();
+
+        // Mock the arguments to pass to the directive
+        Arguments mockArgs = createMockArguments();
+
+        // Initialize and execute the directive
+        directive.initialize(mockArgs);
+        List<Row> result = directive.execute(rows, null);
+
+        // Validate output row count
+        Assert.assertEquals(1, result.size());
+        Row output = result.get(0);
+
+        // Expected: 20KB = 20480 bytes → 20480 / (1024 * 1024)
+        double expectedMB = 20480.0 / (1024 * 1024);
+        double actualMB = (Double) output.getValue("total_size_mb");
+
+        // Expected time: 1.2s + 0.8s = 2.0s
+        double expectedSeconds = 2.0;
+        double actualSeconds = (Double) output.getValue("total_time_sec");
+
+        Assert.assertEquals(expectedMB, actualMB, 0.001);
+        Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+    }
+
+    @Test
+    public void testEmptyInputRows() throws Exception {
+        // Test case with no input rows
+        List<Row> rows = new ArrayList<>();
+        AggregateStats directive = new AggregateStats();
+        Arguments mockArgs = createMockArguments();
+
+        directive.initialize(mockArgs);
+        List<Row> result = directive.execute(rows, null);
+
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testInvalidData() throws Exception {
+        // Input rows with invalid formats
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "abcKB").add("response_time", "xyzTime"));
+
+        AggregateStats directive = new AggregateStats();
+        Arguments mockArgs = createMockArguments();
+
+        directive.initialize(mockArgs);
+        try {
+            directive.execute(rows, null);
+            Assert.fail("Expected an exception due to invalid data format");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Error aggregating stats"));
+        }
+    }
+
+    @Test
+    public void testLargeData() throws Exception {
+        // Test with large values in MB and time in hours/minutes
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "2048MB").add("response_time", "1h"));
+        rows.add(new Row().add("data_transfer_size", "1024MB").add("response_time", "30m"));
+
+        AggregateStats directive = new AggregateStats();
+        Arguments mockArgs = createMockArguments();
+
+        directive.initialize(mockArgs);
+        List<Row> result = directive.execute(rows, null);
+
+        Assert.assertEquals(1, result.size());
+
+        Row output = result.get(0);
+
+        double expectedMB = 3072.0; // 2048MB + 1024MB
+        double actualMB = (Double) output.getValue("total_size_mb");
+
+        double expectedSeconds = 5400.0; // 1h + 30m = 3600 + 1800 = 5400s
+        double actualSeconds = (Double) output.getValue("total_time_sec");
+
+        Assert.assertEquals(expectedMB, actualMB, 0.001);
+        Assert.assertEquals(expectedSeconds, actualSeconds, 0.001);
+    }
+
+    @Test
+    public void testEdgeCases() throws Exception {
+        // Edge case: zero data and zero time
+        List<Row> rows = new ArrayList<>();
+        rows.add(new Row().add("data_transfer_size", "0KB").add("response_time", "0s"));
+
+        AggregateStats directive = new AggregateStats();
+        Arguments mockArgs = createMockArguments();
+
+        directive.initialize(mockArgs);
+        List<Row> result = directive.execute(rows, null);
+
+        Assert.assertEquals(1, result.size());
+
+        Row output = result.get(0);
+
+        double actualMB = (Double) output.getValue("total_size_mb");
+        double actualSeconds = (Double) output.getValue("total_time_sec");
+
+        Assert.assertEquals(0.0, actualMB, 0.001);
+        Assert.assertEquals(0.0, actualSeconds, 0.001);
+    }
+
+    // Create mock implementation of Arguments for unit testing
+    private Arguments createMockArguments() {
+        return new Arguments() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T extends Token> T value(String name) {
+                switch (name) {
+                    case "byteCol": return (T) new ColumnName("data_transfer_size");
+                    case "timeCol": return (T) new ColumnName("response_time");
+                    case "outputSizeCol": return (T) new Text("total_size_mb");
+                    case "outputTimeCol": return (T) new Text("total_time_sec");
+                }
+                return null;
+            }
+
+            @Override public int size() { 
+                return 4; 
+            }
+
+            @Override public boolean contains(String name) { 
+                return true; 
+            }
+
+            @Override public TokenType type(String name) { 
+                return null; 
+            }
+
+            @Override public int line() { 
+                return 1; 
+            }
+
+            @Override public int column() { 
+                return 0; 
+            }
+
+            @Override public String source() {
+                return "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec";
+            }
+            @Override public JsonElement toJson() { 
+                return null; 
+            }
+        };
+    }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/dq/ConvertDistancesTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/dq/ConvertDistancesTest.java
@@ -31,7 +31,7 @@ public class ConvertDistancesTest {
   public void testConvertDoubleNan() {
     double nan = Double.NaN;
     ConvertDistances converter = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                      ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(nan, converter.convert(nan), delta);
   }
 
@@ -39,7 +39,7 @@ public class ConvertDistancesTest {
   public void testConvertZero() {
     double zero = 0.0;
     ConvertDistances converter = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                      ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(zero, converter.convert(zero), delta);
   }
 
@@ -47,10 +47,10 @@ public class ConvertDistancesTest {
   public void testConvertMaxValue() {
     double max = Double.MAX_VALUE;
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(Double.POSITIVE_INFINITY, converter0.convert(max), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(1.900163142869793E289, converter1.convert(max), delta);
   }
 
@@ -58,10 +58,10 @@ public class ConvertDistancesTest {
   public void testConvertMinValue() {
     double min = Double.MIN_VALUE;
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(0.0, converter0.convert(min), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(0.0, converter1.convert(min), delta);
   }
 
@@ -91,43 +91,43 @@ public class ConvertDistancesTest {
     double ly = 1.0570008340246155E-19;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter0.convert(mm), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter1.convert(mm), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter2.convert(mm), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter3.convert(mm), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter4.convert(mm), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(mm), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter6.convert(mm), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter7.convert(mm), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter8.convert(mm), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter9.convert(mm), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(mm), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(mm), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.MILLIMETER,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(mm), delta);
   }
 
@@ -148,43 +148,43 @@ public class ConvertDistancesTest {
     double ly = 1.0570008340246153E-18;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter0.convert(cm), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(cm), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter2.convert(cm), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter3.convert(cm), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter4.convert(cm), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(cm), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter6.convert(cm), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter7.convert(cm), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter8.convert(cm), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter9.convert(cm), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(cm), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(cm), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.CENTIMETER,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(cm), delta);
   }
 
@@ -205,43 +205,43 @@ public class ConvertDistancesTest {
     double ly = 1.0570008340246154E-17;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter0.convert(dm), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(dm), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(dm), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter3.convert(dm), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter4.convert(dm), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(dm), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter6.convert(dm), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter7.convert(dm), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter8.convert(dm), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter9.convert(dm), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(dm), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(dm), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.DECIMETER,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(dm), delta);
   }
 
@@ -262,43 +262,43 @@ public class ConvertDistancesTest {
     double ly = 1.0570008340246154E-16;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter0.convert(m), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(m), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(m), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(m), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter4.convert(m), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(m), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter6.convert(m), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter7.convert(m), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter8.convert(m), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter9.convert(m), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(m), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(m), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.METER,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(m), delta);
   }
 
@@ -319,43 +319,43 @@ public class ConvertDistancesTest {
     double ly = 1.0570008340246154E-15;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter0.convert(dam), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(dam), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(dam), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(dam), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter4.convert(dam), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(dam), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter6.convert(dam), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter7.convert(dam), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter8.convert(dam), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter9.convert(dam), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(dam), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(dam), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.DEKAMETER,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(dam), delta);
   }
 
@@ -376,43 +376,43 @@ public class ConvertDistancesTest {
     double ly = 1.0570008340246154E-14;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter0.convert(hm), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(hm), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(hm), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(hm), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter4.convert(hm), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter5.convert(hm), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter6.convert(hm), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter7.convert(hm), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter8.convert(hm), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter9.convert(hm), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(hm), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(hm), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.HECTOMETER,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(hm), delta);
   }
 
@@ -433,43 +433,43 @@ public class ConvertDistancesTest {
     double ly = 1.0570008340246153E-13;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter0.convert(km), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(km), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(km), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(km), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter4.convert(km), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(km), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter6.convert(km), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter7.convert(km), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter8.convert(km), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter9.convert(km), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(km), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(km), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.KILOMETER,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(km), delta);
   }
 
@@ -490,43 +490,43 @@ public class ConvertDistancesTest {
     double ly = 2.684782118422523E-18;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter0.convert(in), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(in), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(in), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(in), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter4.convert(in), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(in), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter6.convert(in), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter7.convert(in), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter8.convert(in), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter9.convert(in), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(in), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(in), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.INCH,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(in), delta);
   }
 
@@ -547,43 +547,43 @@ public class ConvertDistancesTest {
     double ly = 3.221738542107028E-17;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter0.convert(ft), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(ft), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(ft), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(ft), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter4.convert(ft), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(ft), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter6.convert(ft), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter7.convert(ft), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter8.convert(ft), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter9.convert(ft), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(ft), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(ft), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.FOOT,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(ft), delta);
   }
 
@@ -604,43 +604,43 @@ public class ConvertDistancesTest {
     double ly = 9.665215626321083E-17;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter0.convert(yd), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(yd), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(yd), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(yd), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter4.convert(yd), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(yd), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter6.convert(yd), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter7.convert(yd), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter8.convert(yd), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter9.convert(yd), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter10.convert(yd), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(yd), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.YARD,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(yd), delta);
   }
 
@@ -661,43 +661,43 @@ public class ConvertDistancesTest {
     double ly = 1.7010779502325107E-13;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter0.convert(mi), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(mi), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(mi), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(mi), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter4.convert(mi), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(mi), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter6.convert(mi), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter7.convert(mi), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter8.convert(mi), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter9.convert(mi), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                        ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter10.convert(mi), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter11.convert(mi), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.MILE,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(mi), delta);
   }
 
@@ -718,43 +718,43 @@ public class ConvertDistancesTest {
     double ly = 1.9575655446135877E-13;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter0.convert(nm), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(nm), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(nm), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(nm), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter4.convert(nm), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(nm), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter6.convert(nm), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter7.convert(nm), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter8.convert(nm), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter9.convert(nm), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                        ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter10.convert(nm), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter11.convert(nm), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.NAUTICAL_MILE,
-                                                        ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter12.convert(nm), delta);
   }
 
@@ -775,43 +775,43 @@ public class ConvertDistancesTest {
     double nm = 5.108385784330886E12;
 
     ConvertDistances converter0 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.LIGHT_YEAR);
+        ConvertDistances.Distance.LIGHT_YEAR);
     Assert.assertEquals(ly, converter0.convert(ly), delta);
     ConvertDistances converter1 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.MILLIMETER);
+        ConvertDistances.Distance.MILLIMETER);
     Assert.assertEquals(mm, converter1.convert(ly), delta);
     ConvertDistances converter2 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.CENTIMETER);
+        ConvertDistances.Distance.CENTIMETER);
     Assert.assertEquals(cm, converter2.convert(ly), delta);
     ConvertDistances converter3 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.DECIMETER);
+        ConvertDistances.Distance.DECIMETER);
     Assert.assertEquals(dm, converter3.convert(ly), delta);
     ConvertDistances converter4 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.METER);
+        ConvertDistances.Distance.METER);
     Assert.assertEquals(m, converter4.convert(ly), delta);
     ConvertDistances converter5 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.HECTOMETER);
+        ConvertDistances.Distance.HECTOMETER);
     Assert.assertEquals(hm, converter5.convert(ly), delta);
     ConvertDistances converter6 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.DEKAMETER);
+        ConvertDistances.Distance.DEKAMETER);
     Assert.assertEquals(dam, converter6.convert(ly), delta);
     ConvertDistances converter7 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.KILOMETER);
+        ConvertDistances.Distance.KILOMETER);
     Assert.assertEquals(km, converter7.convert(ly), delta);
     ConvertDistances converter8 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.INCH);
+        ConvertDistances.Distance.INCH);
     Assert.assertEquals(in, converter8.convert(ly), delta);
     ConvertDistances converter9 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                       ConvertDistances.Distance.FOOT);
+        ConvertDistances.Distance.FOOT);
     Assert.assertEquals(ft, converter9.convert(ly), delta);
     ConvertDistances converter10 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                        ConvertDistances.Distance.YARD);
+        ConvertDistances.Distance.YARD);
     Assert.assertEquals(yd, converter10.convert(ly), delta);
     ConvertDistances converter11 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                        ConvertDistances.Distance.MILE);
+        ConvertDistances.Distance.MILE);
     Assert.assertEquals(mi, converter11.convert(ly), delta);
     ConvertDistances converter12 = new ConvertDistances(ConvertDistances.Distance.LIGHT_YEAR,
-                                                        ConvertDistances.Distance.NAUTICAL_MILE);
+        ConvertDistances.Distance.NAUTICAL_MILE);
     Assert.assertEquals(nm, converter12.convert(ly), delta);
   }
 }

--- a/wrangler-core/src/test/java/io/cdap/wrangler/dq/ConvertStringTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/dq/ConvertStringTest.java
@@ -50,8 +50,10 @@ public class ConvertStringTest {
     Assert.assertEquals(expected, convertString.removeTrailingAndLeading(expected + "\t", "\t"));
     Assert.assertEquals(expected, convertString.removeTrailingAndLeading('\u0009' + expected, "\t"));
     Assert.assertEquals(expected, convertString.removeTrailingAndLeading('\u0009' + expected, '\u0009' + ""));
-    Assert.assertEquals(expected, convertString.removeTrailingAndLeading('\u0009' + expected + '\u0009' + '\u0009',
-                                                                         "\t"));
+    Assert.assertEquals(
+  expected, 
+  convertString.removeTrailingAndLeading('\u0009' + expected + '\u0009' + '\u0009', "\t")
+);
 
     //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
     Assert.assertEquals("abc ", convertString.removeTrailingAndLeading("\t" + "abc ", "\t"));

--- a/wrangler-core/src/test/java/io/cdap/wrangler/parser/ByteSizeAndTimeDurationTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/parser/ByteSizeAndTimeDurationTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright © 2017-2019 Cask Data, Inc.
+ *  Copyright © 2023 Google LLC // Update copyright year/holder if needed
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.wrangler.parser;
+
+import io.cdap.wrangler.api.parser.ByteSize;
+import io.cdap.wrangler.api.parser.TimeDuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for ByteSize and TimeDuration parsing and conversion.
+ */
+public class ByteSizeAndTimeDurationTest {
+
+    @Test
+    public void testByteSizeParsing() {
+        // Verifying correct conversion from common byte size formats
+
+        Assert.assertEquals(2048L, new ByteSize("2KB").getBytes()); // 2 KB = 2048 bytes
+        Assert.assertEquals(5242880L, new ByteSize("5MB").getBytes()); // 5 MB = 5 * 1024 * 1024
+        Assert.assertEquals(2147483648L, new ByteSize("2GB").getBytes()); // 2 GB = 2 * 1024^3
+        Assert.assertEquals(256, new ByteSize("256B").getBytes()); // 256 bytes
+        Assert.assertEquals(7340032L, new ByteSize("7MB").getBytes()); // 7 MB
+        Assert.assertEquals(3145728L, new ByteSize("3MB").getBytes()); // 3 MB
+
+        // Verifying parsing with lowercase and mixed-case units
+        Assert.assertEquals(1572864L, new ByteSize("1.5mb").getBytes()); // 1.5 MB
+        Assert.assertEquals(4096L, new ByteSize("4kB").getBytes()); // 4 KB
+    }
+
+    @Test
+    public void testTimeDurationParsing() {
+        // Verifying correct parsing of time durations into milliseconds
+        double toleranceForDoubleComparison = 0.0001;
+
+        Assert.assertEquals(10.0, new TimeDuration("10ms").
+        getValue(), toleranceForDoubleComparison); // 10 milliseconds
+        Assert.assertEquals(1500.0, new TimeDuration("1.5s").
+        getValue(), toleranceForDoubleComparison); // 1.5 seconds
+        Assert.assertEquals(7200000.0, new TimeDuration("2h").
+        getValue(), toleranceForDoubleComparison); // 2 hours
+        Assert.assertEquals(180000.0, new TimeDuration("3min").
+        getValue(), toleranceForDoubleComparison); // 3 minutes
+        Assert.assertEquals(0.5, new TimeDuration("500us").
+        getValue(), toleranceForDoubleComparison); // 500
+                
+        Assert.assertEquals(2.5, new TimeDuration("2500000ns").
+        getValue(), toleranceForDoubleComparison); // 2.5
+
+        Assert.assertEquals(172800000.0, new TimeDuration("2d").
+        getValue(), toleranceForDoubleComparison); // 2 days
+    }
+}

--- a/wrangler-test/pom.xml
+++ b/wrangler-test/pom.xml
@@ -29,6 +29,12 @@
   <dependencies>
     <dependency>
       <groupId>io.cdap.wrangler</groupId>
+      <artifactId>wrangler-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.wrangler</groupId>
       <artifactId>wrangler-core</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -45,6 +51,5 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
 
 </project>


### PR DESCRIPTION
This pull request introduces enhancements to the Wrangler library by adding two new parsers: BYTE_SIZE and TIME_DURATION. These parsers enable native support for handling byte size units (e.g., KB, MB, GB) and time duration units (e.g., ms, s, minutes) within Wrangler recipes.

Key Changes:
Grammar Modification: Updated the grammar files to add lexer tokens for BYTE_SIZE and TIME_DURATION, and modified parser rules to handle these new tokens.

API Updates: Created new Java classes (ByteSize and TimeDuration) to parse the respective token strings and convert them into canonical units (bytes for BYTE_SIZE, seconds for TIME_DURATION).

Core Parser Updates: Added visit methods to the core parser to handle the new BYTE_SIZE and TIME_DURATION arguments.

New Directive: Implemented the aggregate-stats directive to perform aggregation on byte size and time duration columns, allowing users to compute totals or averages.

Unit Tests: Added unit tests to verify the correct parsing and functionality of the new parsers, including edge cases and conversions.