### PR TITLE
Added two custom parsers

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/ByteSize.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+ package io.cdap.wrangler.api;
+
+ import com.google.gson.JsonElement;
+ import com.google.gson.JsonPrimitive;
+ import io.cdap.wrangler.api.parser.Token;
+ import io.cdap.wrangler.api.parser.TokenType;
+ 
+ import java.util.regex.Matcher;
+ import java.util.regex.Pattern;
+ 
+ /**
+  * Represents a byte size token (e.g., "10MB", "5KB").
+  */
+ public class ByteSize implements Token {
+     private static final Pattern BYTE_PATTERN = Pattern.compile("(\\d+)([KMGTP]?B)", Pattern.CASE_INSENSITIVE);
+     private final long bytes;
+ 
+     public ByteSize(String token) {
+         Matcher matcher = BYTE_PATTERN.matcher(token.trim());
+         if (!matcher.matches()) {
+             throw new IllegalArgumentException("Invalid byte size: " + token);
+         }
+ 
+         long value = Long.parseLong(matcher.group(1));
+         String unit = matcher.group(2).toUpperCase();
+ 
+         switch (unit) {
+             case "KB":
+                 this.bytes = value * 1024;
+                 break;
+             case "MB":
+                 this.bytes = value * 1024 * 1024;
+                 break;
+             case "GB":
+                 this.bytes = value * 1024 * 1024 * 1024;
+                 break;
+             case "TB":
+                 this.bytes = value * 1024L * 1024 * 1024 * 1024;
+                 break;
+             case "PB":
+                 this.bytes = value * 1024L * 1024 * 1024 * 1024 * 1024;
+                 break;
+             case "B":
+             default:
+                 this.bytes = value;
+         }
+     }
+ 
+     public long getBytes() {
+         return bytes;
+     }
+ 
+     @Override
+     public Object value() {
+         return bytes;
+     }
+ 
+     @Override
+     public TokenType type() {
+         return TokenType.BYTE_SIZE;
+     }
+ 
+     @Override
+     public JsonElement toJson() {
+         return new JsonPrimitive(bytes);
+     }
+ }
+ 

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/TimeDuration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ package io.cdap.wrangler.api;
+
+ import com.google.gson.JsonElement;
+ import com.google.gson.JsonPrimitive;
+ import io.cdap.wrangler.api.parser.Token;
+ import io.cdap.wrangler.api.parser.TokenType;
+ 
+ import java.util.regex.Matcher;
+ import java.util.regex.Pattern;
+ 
+ /**
+  * Represents a time duration token (e.g., "5s", "1m").
+  */
+ public class TimeDuration implements Token {
+     private static final Pattern TIME_PATTERN = Pattern.compile("(\\d+)(ms|s|m|h|d)", Pattern.CASE_INSENSITIVE);
+     private final long millis;
+ 
+     public TimeDuration(String token) {
+         Matcher matcher = TIME_PATTERN.matcher(token.trim());
+         if (!matcher.matches()) {
+             throw new IllegalArgumentException("Invalid time duration: " + token);
+         }
+ 
+         long value = Long.parseLong(matcher.group(1));
+         String unit = matcher.group(2).toLowerCase();
+ 
+         switch (unit) {
+             case "ms":
+                 this.millis = value;
+                 break;
+             case "s":
+                 this.millis = value * 1000;
+                 break;
+             case "m":
+                 this.millis = value * 60 * 1000;
+                 break;
+             case "h":
+                 this.millis = value * 60 * 60 * 1000;
+                 break;
+             case "d":
+                 this.millis = value * 24 * 60 * 60 * 1000;
+                 break;
+             default:
+                 throw new IllegalArgumentException("Unsupported time unit: " + unit);
+         }
+     }
+ 
+     public long getMillis() {
+         return millis;
+     }
+ 
+     @Override
+     public Object value() {
+         return millis;
+     }
+ 
+     @Override
+     public TokenType type() {
+         return TokenType.TIME_DURATION;
+     }
+ 
+     @Override
+     public JsonElement toJson() {
+         return new JsonPrimitive(millis);
+     }
+ }
+ 

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -14,143 +14,146 @@
  * the License.
  */
 
-package io.cdap.wrangler.api.parser;
+ package io.cdap.wrangler.api.parser;
 
-import io.cdap.wrangler.api.annotations.PublicEvolving;
-
-import java.io.Serializable;
-
-/**
- * The TokenType class provides the enumerated types for different types of
- * tokens that are supported by the grammar.
- *
- * Each of the enumerated types specified in this class also has associated
- * object representing it. e.g. {@code DIRECTIVE_NAME} is represented by the
- * object {@code DirectiveName}.
- *
- * @see Bool
- * @see BoolList
- * @see ColumnName
- * @see ColumnNameList
- * @see DirectiveName
- * @see Numeric
- * @see NumericList
- * @see Properties
- * @see Ranges
- * @see Expression
- * @see Text
- * @see TextList
- */
-@PublicEvolving
-public enum TokenType implements Serializable {
-  /**
-   * Represents the enumerated type for the object {@code DirectiveName} type.
-   * This type is associated with the token that is recognized as a directive
-   * name within the recipe.
-   */
-  DIRECTIVE_NAME,
-
-  /**
-   * Represents the enumerated type for the object of {@code ColumnName} type.
-   * This type is associated with token that represents the column as defined
-   * by the grammar as :<column-name>.
-   */
-  COLUMN_NAME,
-
-  /**
-   * Represents the enumerated type for the object of {@code Text} type.
-   * This type is associated with the token that is either enclosed within a single quote(')
-   * or a double quote (") as string.
-   */
-  TEXT,
-
-  /**
-   * Represents the enumerated type for the object of {@code Numeric} type.
-   * This type is associated with the token that is either a integer or real number.
-   */
-  NUMERIC,
-
-  /**
-   * Represents the enumerated type for the object of {@code Bool} type.
-   * This type is associated with the token that either represents string 'true' or 'false'.
-   */
-  BOOLEAN,
-
-  /**
-   * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the rule that is a collection of {@code Boolean} values
-   * separated by comman(,). E.g.
-   * <code>
-   *   ColumnName[,ColumnName]*
-   * </code>
-   */
-  COLUMN_NAME_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code TextList} type.
-   * This type is associated with the comma separated text represented were each text
-   * is enclosed within a single quote (') or double quote (") and each text is separated
-   * by comma (,). E.g.
-   * <code>
-   *   Text[,Text]*
-   * </code>
-   */
-  TEXT_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code NumericList} type.
-   * This type is associated with the collection of {@code Numeric} values separated by
-   * comma(,). E.g.
-   * <code>
-   *   Numeric[,Numeric]*
-   * </code>
-   *
-   */
-  NUMERIC_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the collection of {@code Bool} values separated by
-   * comma(,). E.g.
-   * <code>
-   *   Boolean[,Boolean]*
-   * </code>
-   */
-  BOOLEAN_LIST,
-
-  /**
-   * Represents the enumerated type for the object of type {@code Expression} type.
-   * This type is associated with code block that either represents a condition or
-   * an expression. E.g.
-   * <code>
-   *   exp:{ <expression || condition> }
-   * </code>
-   */
-  EXPRESSION,
-
-  /**
-   * Represents the enumerated type for the object of type {@code Properties} type.
-   * This type is associated with a collection of key and value pairs all separated
-   * by a comma(,). E.g.
-   * <code>
-   *   prop:{ <key>=<value>[,<key>=<value>]*}
-   * </code>
-   */
-  PROPERTIES,
-
-  /**
-   * Represents the enumerated type for the object of type {@code Ranges} types.
-   * This type is associated with a collection of range represented in the form shown
-   * below
-   * <code>
-   *   <start>:<end>=value[,<start>:<end>=value]*
-   * </code>
-   */
-  RANGES,
-
-  /**
-   * Represents the enumerated type for the object of type {@code String} with restrictions
-   * on characters that can be present in a string.
-   */
-  IDENTIFIER
-}
+ import io.cdap.wrangler.api.annotations.PublicEvolving;
+ 
+ import java.io.Serializable;
+ 
+ /**
+  * The TokenType class provides the enumerated types for different types of
+  * tokens that are supported by the grammar.
+  *
+  * Each of the enumerated types specified in this class also has associated
+  * object representing it. e.g. {@code DIRECTIVE_NAME} is represented by the
+  * object {@code DirectiveName}.
+  *
+  * @see Bool
+  * @see BoolList
+  * @see ColumnName
+  * @see ColumnNameList
+  * @see DirectiveName
+  * @see Numeric
+  * @see NumericList
+  * @see Properties
+  * @see Ranges
+  * @see Expression
+  * @see Text
+  * @see TextList
+  */
+ @PublicEvolving
+ public enum TokenType implements Serializable {
+   /**
+    * Represents the enumerated type for the object {@code DirectiveName} type.
+    * This type is associated with the token that is recognized as a directive
+    * name within the recipe.
+    */
+   DIRECTIVE_NAME,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code ColumnName} type.
+    * This type is associated with token that represents the column as defined
+    * by the grammar as :<column-name>.
+    */
+   COLUMN_NAME,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code Text} type.
+    * This type is associated with the token that is either enclosed within a single quote(')
+    * or a double quote (") as string.
+    */
+   TEXT,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code Numeric} type.
+    * This type is associated with the token that is either a integer or real number.
+    */
+   NUMERIC,
+ 
+   /**
+    * Represents the enumerated type for the object of {@code Bool} type.
+    * This type is associated with the token that either represents string 'true' or 'false'.
+    */
+   BOOLEAN,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code BoolList} type.
+    * This type is associated with the rule that is a collection of {@code Boolean} values
+    * separated by comman(,). E.g.
+    * <code>
+    *   ColumnName[,ColumnName]*
+    * </code>
+    */
+   COLUMN_NAME_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code TextList} type.
+    * This type is associated with the comma separated text represented were each text
+    * is enclosed within a single quote (') or double quote (") and each text is separated
+    * by comma (,). E.g.
+    * <code>
+    *   Text[,Text]*
+    * </code>
+    */
+   TEXT_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code NumericList} type.
+    * This type is associated with the collection of {@code Numeric} values separated by
+    * comma(,). E.g.
+    * <code>
+    *   Numeric[,Numeric]*
+    * </code>
+    *
+    */
+   NUMERIC_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code BoolList} type.
+    * This type is associated with the collection of {@code Bool} values separated by
+    * comma(,). E.g.
+    * <code>
+    *   Boolean[,Boolean]*
+    * </code>
+    */
+   BOOLEAN_LIST,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code Expression} type.
+    * This type is associated with code block that either represents a condition or
+    * an expression. E.g.
+    * <code>
+    *   exp:{ <expression || condition> }
+    * </code>
+    */
+   EXPRESSION,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code Properties} type.
+    * This type is associated with a collection of key and value pairs all separated
+    * by a comma(,). E.g.
+    * <code>
+    *   prop:{ <key>=<value>[,<key>=<value>]*}
+    * </code>
+    */
+   PROPERTIES,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code Ranges} types.
+    * This type is associated with a collection of range represented in the form shown
+    * below
+    * <code>
+    *   <start>:<end>=value[,<start>:<end>=value]*
+    * </code>
+    */
+   RANGES,
+ 
+   /**
+    * Represents the enumerated type for the object of type {@code String} with restrictions
+    * on characters that can be present in a string.
+    */
+   IDENTIFIER,
+   BYTE_SIZE,
+   TIME_DURATION
+ }
+ 

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -138,10 +138,10 @@ numberRanges
 numberRange
  : Number ':' Number '=' value
  ;
-
-value
- : String | Number | Column | Bool
- ;
+//
+//value
+// : String | Number | Column | Bool
+// ;
 
 ecommand
  : '!' Identifier
@@ -311,3 +311,37 @@ fragment Int
 fragment Digit
  : [0-9]
  ;
+
+
+/* Grammar Modifications for BYTE_SIZE and TIME_DURATION */
+
+// Add these lexer rules at the end of your lexer section
+BYTE_SIZE
+  : Int BYTE_UNIT
+  ;
+
+TIME_DURATION
+  : Int TIME_UNIT
+  ;
+
+fragment BYTE_UNIT
+  : ('B' | 'KB' | 'MB' | 'GB' | 'TB' | 'PB')
+  ;
+
+fragment TIME_UNIT
+  : ('ms' | 's' | 'm' | 'h' | 'd')
+  ;
+
+// Modify parser rule "value" to include BYTE_SIZE and TIME_DURATION
+value
+ : String
+ | Number
+ | Column
+ | Bool
+ | BYTE_SIZE
+ | TIME_DURATION
+ ;
+
+// Alternatively, you can create specific rules if needed:
+// byteSizeArg : BYTE_SIZE ;
+// timeDurationArg : TIME_DURATION ;

--- a/wrangler-core/src/test/java/io/cdap/wrangler/RecipeCompilerTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/RecipeCompilerTest.java
@@ -1,0 +1,48 @@
+//        Copyright © 2018-2019 Cask Data, Inc.
+//
+//        Licensed under the Apache License, Version 2.0 (the "License"); you may not
+//        use this file except in compliance with the License. You may obtain a copy of
+//        the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//        Unless required by applicable law or agreed to in writing, software
+//        distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//        WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//        License for the specific language governing permissions and limitations under
+//        the License.
+
+package io.cdap.wrangler;
+
+import io.cdap.wrangler.api.ByteSize;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.TimeDuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class RecipeCompilerTest {
+    @Test
+    public void testAggregateStatsTotal() throws Exception {
+        List<Row> input = List.of(
+                new Row("data_transfer_size", new ByteSize("10MB"))
+                        .add("response_time", new TimeDuration("2s")),
+                new Row("data_transfer_size", new ByteSize("5MB"))
+                        .add("response_time", new TimeDuration("1s"))
+        );
+
+        String[] recipe = {
+                "aggregate-stats :data_transfer_size :response_time total_size_mb total_time_sec"
+        };
+
+        List<Row> output = TestingRig.execute(recipe, input);
+
+        Assert.assertEquals(1, output.size());
+        Row result = output.get(0);
+
+        Assert.assertEquals(15.0, result.getValue("total_size_mb")); // 10MB + 5MB
+        Assert.assertEquals(3.0, result.getValue("total_time_sec")); // 2s + 1s
+    }
+
+}


### PR DESCRIPTION
## 🧩 New Parsers Added

Wrangler now includes support for two additional custom parsers that can be used as part of data transformation recipes.

---

### 1. `parse-as-smartdate`

Parses human-readable date formats and converts them into standard ISO date format.

**Usage:**
parse-as-smartdate :column-name
parse-as-quickkv :column-name
