### PR TITLE
Add Support for ByteSize & TimeDuration Tokens and Aggregation Directive

### DIFF
--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * Token for representing byte sizes like "10KB", "1MB", etc.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A token representing a byte size value like "10KB", "1MB", etc.
+ */
+public class ByteSize implements Token {
+    private static final Pattern PATTERN = Pattern.compile("(?i)(\\d+(\\.\\d+)?)([KMGTPEZY]?B)");
+
+    private final String original;
+    private final long bytes;
+
+    /**
+     * Constructs a ByteSize token by parsing the given string.
+     *
+     * @param value the byte size string (e.g., "10KB", "1MB")
+     * @throws IllegalArgumentException if the format is invalid
+     */
+    public ByteSize(String value) {
+        this.original = value;
+
+        Matcher matcher = PATTERN.matcher(value.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid byte size: " + value);
+        }
+
+        double number = Double.parseDouble(matcher.group(1));
+        String unit = matcher.group(3).toUpperCase();
+
+        switch (unit) {
+            case "B":
+                bytes = (long) number;
+                break;
+            case "KB":
+                bytes = (long) (number * 1024);
+                break;
+            case "MB":
+                bytes = (long) (number * 1024 * 1024);
+                break;
+            case "GB":
+                bytes = (long) (number * 1024 * 1024 * 1024);
+                break;
+            case "TB":
+                bytes = (long) (number * 1024L * 1024 * 1024 * 1024);
+                break;
+            case "PB":
+                bytes = (long) (number * 1024L * 1024 * 1024 * 1024 * 1024);
+                break;
+            case "EB":
+                bytes = (long) (number * 1024L * 1024 * 1024 * 1024 * 1024 * 1024);
+                break;
+            case "ZB":
+                bytes = (long) (number * 1024L * 1024 * 1024 * 1024 * 1024 * 1024 * 1024);
+                break;
+            case "YB":
+                bytes = (long) (number * 1024L * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown byte unit: " + unit);
+        }
+    }
+
+    /**
+     * Returns the size in bytes.
+     *
+     * @return the size in bytes
+     */
+    public long getBytes() {
+        return bytes;
+    }
+
+    @Override
+    public Object value() {
+        return original;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.BYTE_SIZE;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(original);
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * Token for representing byte sizes like "10KB", "1MB", etc.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TimeDuration implements Token {
+    private static final Pattern PATTERN = Pattern.compile("(?i)(\\d+(\\.\\d+)?)(ns|us|ms|s|m|h|d)");
+
+    private final String original;
+    private final long millis;
+
+    public TimeDuration(String value) {
+        this.original = value;
+
+        Matcher matcher = PATTERN.matcher(value.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid time duration: " + value);
+        }
+
+        double number = Double.parseDouble(matcher.group(1));
+        String unit = matcher.group(3).toLowerCase();
+
+        switch (unit) {
+            case "ns": millis = (long) (number / 1_000_000); break;
+            case "us": millis = (long) (number / 1_000); break;
+            case "ms": millis = (long) number; break;
+            case "s":  millis = (long) (number * 1000); break;
+            case "m":  millis = (long) (number * 60 * 1000); break;
+            case "h":  millis = (long) (number * 60 * 60 * 1000); break;
+            case "d":  millis = (long) (number * 24 * 60 * 60 * 1000); break;
+            default: throw new IllegalArgumentException("Unknown time unit: " + unit);
+        }
+    }
+
+    public long getMillis() {
+        return millis;
+    }
+
+    @Override
+    public Object value() {
+        return original;
+    }
+
+    @Override
+    public TokenType type() {
+        return TokenType.TIME_DURATION;
+    }
+
+    @Override
+    public JsonElement toJson() {
+        return new JsonPrimitive(original);
+    }
+}

--- a/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-api/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -17,16 +17,15 @@
 package io.cdap.wrangler.api.parser;
 
 import io.cdap.wrangler.api.annotations.PublicEvolving;
-
 import java.io.Serializable;
 
 /**
  * The TokenType class provides the enumerated types for different types of
  * tokens that are supported by the grammar.
  *
- * Each of the enumerated types specified in this class also has associated
- * object representing it. e.g. {@code DIRECTIVE_NAME} is represented by the
- * object {@code DirectiveName}.
+ * Each of the enumerated types specified in this class also has an associated
+ * object representing it. For example, {@code DIRECTIVE_NAME} is represented by
+ * the object {@code DirectiveName}.
  *
  * @see Bool
  * @see BoolList
@@ -43,114 +42,78 @@ import java.io.Serializable;
  */
 @PublicEvolving
 public enum TokenType implements Serializable {
+
   /**
-   * Represents the enumerated type for the object {@code DirectiveName} type.
-   * This type is associated with the token that is recognized as a directive
-   * name within the recipe.
+   * Token for directive names.
    */
   DIRECTIVE_NAME,
 
   /**
-   * Represents the enumerated type for the object of {@code ColumnName} type.
-   * This type is associated with token that represents the column as defined
-   * by the grammar as :<column-name>.
+   * Token for a single column name.
    */
   COLUMN_NAME,
 
   /**
-   * Represents the enumerated type for the object of {@code Text} type.
-   * This type is associated with the token that is either enclosed within a single quote(')
-   * or a double quote (") as string.
+   * Token for text strings (quoted).
    */
   TEXT,
 
   /**
-   * Represents the enumerated type for the object of {@code Numeric} type.
-   * This type is associated with the token that is either a integer or real number.
+   * Token for numeric values.
    */
   NUMERIC,
 
   /**
-   * Represents the enumerated type for the object of {@code Bool} type.
-   * This type is associated with the token that either represents string 'true' or 'false'.
+   * Token for boolean values ("true" or "false").
    */
   BOOLEAN,
 
   /**
-   * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the rule that is a collection of {@code Boolean} values
-   * separated by comman(,). E.g.
-   * <code>
-   *   ColumnName[,ColumnName]*
-   * </code>
+   * Token for a list of column names.
    */
   COLUMN_NAME_LIST,
 
   /**
-   * Represents the enumerated type for the object of type {@code TextList} type.
-   * This type is associated with the comma separated text represented were each text
-   * is enclosed within a single quote (') or double quote (") and each text is separated
-   * by comma (,). E.g.
-   * <code>
-   *   Text[,Text]*
-   * </code>
+   * Token for a list of text values.
    */
   TEXT_LIST,
 
   /**
-   * Represents the enumerated type for the object of type {@code NumericList} type.
-   * This type is associated with the collection of {@code Numeric} values separated by
-   * comma(,). E.g.
-   * <code>
-   *   Numeric[,Numeric]*
-   * </code>
-   *
+   * Token for a list of numeric values.
    */
   NUMERIC_LIST,
 
   /**
-   * Represents the enumerated type for the object of type {@code BoolList} type.
-   * This type is associated with the collection of {@code Bool} values separated by
-   * comma(,). E.g.
-   * <code>
-   *   Boolean[,Boolean]*
-   * </code>
+   * Token for a list of boolean values.
    */
   BOOLEAN_LIST,
 
   /**
-   * Represents the enumerated type for the object of type {@code Expression} type.
-   * This type is associated with code block that either represents a condition or
-   * an expression. E.g.
-   * <code>
-   *   exp:{ <expression || condition> }
-   * </code>
+   * Token for expressions or conditions.
    */
   EXPRESSION,
 
   /**
-   * Represents the enumerated type for the object of type {@code Properties} type.
-   * This type is associated with a collection of key and value pairs all separated
-   * by a comma(,). E.g.
-   * <code>
-   *   prop:{ <key>=<value>[,<key>=<value>]*}
-   * </code>
+   * Token for key-value property pairs.
    */
   PROPERTIES,
 
   /**
-   * Represents the enumerated type for the object of type {@code Ranges} types.
-   * This type is associated with a collection of range represented in the form shown
-   * below
-   * <code>
-   *   <start>:<end>=value[,<start>:<end>=value]*
-   * </code>
+   * Token for range-value mappings.
    */
   RANGES,
 
   /**
-   * Represents the enumerated type for the object of type {@code String} with restrictions
-   * on characters that can be present in a string.
+   * Token for identifiers with restricted characters.
    */
-  IDENTIFIER
+  IDENTIFIER,
+
+  /**
+   * Token representing a byte size (e.g., "10KB", "1MB").
+   */
+  BYTE_SIZE,
+  /**
+   * Token representing a time duration (e.g., "500ms", "2h").
+   */
+  TIME_DURATION
 }

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -335,6 +335,20 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- new Plugin added -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            --add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.io=ALL-UNNAMED
+          </argLine>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>

--- a/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
+++ b/wrangler-core/src/main/antlr4/io/cdap/wrangler/parser/Directives.g4
@@ -140,7 +140,7 @@ numberRange
  ;
 
 value
- : String | Number | Column | Bool
+ : String | Number | Column | Bool | ByteSize | TimeDuration
  ;
 
 ecommand
@@ -311,3 +311,14 @@ fragment Int
 fragment Digit
  : [0-9]
  ;
+
+byteSizeArg
+ : Number ('KB' | 'MB' | 'GB' | 'TB')
+ ;
+
+timeDurationArg
+ : Number ('s' | 'm' | 'h' | 'd')
+ ;
+
+ByteSize : Number ('KB' | 'MB' | 'GB' | 'TB');
+TimeDuration : Number ('s' | 'm' | 'h' | 'd');

--- a/wrangler-core/src/main/java/io/cdap/directives/aggregates/Aggregate.java
+++ b/wrangler-core/src/main/java/io/cdap/directives/aggregates/Aggregate.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.directives.aggregates;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.wrangler.api.Arguments;
+import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveExecutionException;
+import io.cdap.wrangler.api.DirectiveParseException;
+import io.cdap.wrangler.api.EntityCountMetric;
+import io.cdap.wrangler.api.ExecutorContext;
+import io.cdap.wrangler.api.Optional;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.api.TransientStore;
+import io.cdap.wrangler.api.TransientVariableScope;
+import io.cdap.wrangler.api.annotations.Categories;
+import io.cdap.wrangler.api.parser.ColumnName;
+import io.cdap.wrangler.api.parser.Text;
+import io.cdap.wrangler.api.parser.TokenType;
+import io.cdap.wrangler.api.parser.UsageDefinition;
+
+/**
+ * A directive for aggregating byte sizes and time durations across records.
+ *
+ * This directive accepts:
+ * - Two source column names (one for byte sizes and one for time durations)
+ * - Two target column names (for total size and total/average time)
+ * - Optional output units for size and time
+ * - Optional aggregation type for time (sum or average)
+ */
+@Plugin(type = Directive.TYPE)
+@Name(Aggregate.NAME)
+@Categories(categories = {"aggregate"})
+@Description("Aggregates byte sizes and time durations across records.")
+public class Aggregate implements Directive {
+    public static final String NAME = "aggregate";
+
+    private String sizeSourceColumn;
+    private String timeSourceColumn;
+    private String sizeTargetColumn;
+    private String timeTargetColumn;
+    private String sizeUnit = "bytes";
+    private String timeUnit = "milliseconds";
+    private String timeAggregationType = "sum";
+
+    private static final String SIZE_COUNTER = "total_size";
+    private static final String TIME_COUNTER = "total_time";
+    private static final String RECORD_COUNTER = "record_count";
+
+    @Override
+    public UsageDefinition define() {
+        UsageDefinition.Builder builder = UsageDefinition.builder(NAME);
+        builder.define("size_source", TokenType.COLUMN_NAME);
+        builder.define("time_source", TokenType.COLUMN_NAME);
+        builder.define("size_target", TokenType.COLUMN_NAME);
+        builder.define("time_target", TokenType.COLUMN_NAME);
+        builder.define("size_unit", TokenType.TEXT, Optional.TRUE);
+        builder.define("time_unit", TokenType.TEXT, Optional.TRUE);
+        builder.define("time_aggregation", TokenType.TEXT, Optional.TRUE);
+        return builder.build();
+    }
+
+    @Override
+    public void initialize(Arguments args) throws DirectiveParseException {
+        this.sizeSourceColumn = ((ColumnName) args.value("size_source")).value();
+        this.timeSourceColumn = ((ColumnName) args.value("time_source")).value();
+        this.sizeTargetColumn = ((ColumnName) args.value("size_target")).value();
+        this.timeTargetColumn = ((ColumnName) args.value("time_target")).value();
+
+        if (args.contains("size_unit")) {
+            this.sizeUnit = ((Text) args.value("size_unit")).value();
+        }
+        if (args.contains("time_unit")) {
+            this.timeUnit = ((Text) args.value("time_unit")).value();
+        }
+        if (args.contains("time_aggregation")) {
+            String aggType = ((Text) args.value("time_aggregation")).value();
+            if (!aggType.equals("sum") && !aggType.equals("average")) {
+                throw new DirectiveParseException(NAME, "Time aggregation type must be either 'sum' or 'average'");
+            }
+            this.timeAggregationType = aggType;
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // no-op
+    }
+
+    @Override
+    public List<Row> execute(List<Row> rows, ExecutorContext context) throws DirectiveExecutionException {
+        // Initialize counters in transient store if not already present
+        if (context != null) {
+            TransientStore store = context.getTransientStore();
+            if (!store.getVariables().contains(SIZE_COUNTER)) {
+                store.set(TransientVariableScope.GLOBAL, SIZE_COUNTER, 0L);
+            }
+            if (!store.getVariables().contains(TIME_COUNTER)) {
+                store.set(TransientVariableScope.GLOBAL, TIME_COUNTER, 0L);
+            }
+            if (!store.getVariables().contains(RECORD_COUNTER)) {
+                store.set(TransientVariableScope.GLOBAL, RECORD_COUNTER, 0L);
+            }
+        }
+
+        // Process each row
+        for (Row row : rows) {
+            try {
+                // Get size value
+                int sizeIdx = row.find(sizeSourceColumn);
+                if (sizeIdx != -1) {
+                    Object sizeVal = row.getValue(sizeIdx);
+                    if (sizeVal instanceof Number) {
+                        long size = ((Number) sizeVal).longValue();
+                        context.getTransientStore().increment(TransientVariableScope.GLOBAL, SIZE_COUNTER, size);
+                    }
+                }
+
+                // Get time value
+                int timeIdx = row.find(timeSourceColumn);
+                if (timeIdx != -1) {
+                    Object timeVal = row.getValue(timeIdx);
+                    if (timeVal instanceof Number) {
+                        long time = ((Number) timeVal).longValue();
+                        context.getTransientStore().increment(TransientVariableScope.GLOBAL, TIME_COUNTER, time);
+                    }
+                }
+
+                // Increment record counter
+                context.getTransientStore().increment(TransientVariableScope.GLOBAL, RECORD_COUNTER, 1L);
+
+                // Add aggregated values to the row
+                TransientStore store = context.getTransientStore();
+                long totalSize = (Long) store.get(SIZE_COUNTER);
+                long totalTime = (Long) store.get(TIME_COUNTER);
+                long recordCount = (Long) store.get(RECORD_COUNTER);
+
+                // Convert size to target unit if needed
+                long convertedSize = convertSize(totalSize, sizeUnit);
+                row.addOrSet(sizeTargetColumn, convertedSize);
+
+                // Calculate time based on aggregation type
+                long timeValue;
+                if (timeAggregationType.equals("average")) {
+                    timeValue = recordCount > 0 ? totalTime / recordCount : 0;
+                } else {
+                    timeValue = totalTime;
+                }
+                // Convert time to target unit if needed
+                long convertedTime = convertTime(timeValue, timeUnit);
+                row.addOrSet(timeTargetColumn, convertedTime);
+
+            } catch (Exception e) {
+                throw new DirectiveExecutionException(NAME, e.getMessage(), e);
+            }
+        }
+        return rows;
+    }
+
+    private long convertSize(long size, String targetUnit) {
+        switch (targetUnit.toLowerCase()) {
+            case "kb":
+                return size / 1024;
+            case "mb":
+                return size / (1024 * 1024);
+            case "gb":
+                return size / (1024 * 1024 * 1024);
+            default:
+                return size; // Default to bytes
+        }
+    }
+
+    private long convertTime(long time, String targetUnit) {
+        switch (targetUnit.toLowerCase()) {
+            case "seconds":
+                return time / 1000;
+            case "minutes":
+                return time / (1000 * 60);
+            case "hours":
+                return time / (1000 * 60 * 60);
+            default:
+                return time; // Default to milliseconds
+        }
+    }
+
+    @Override
+    public List<EntityCountMetric> getCountMetrics() {
+        return ImmutableList.of();
+    }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/api/parser/ByteSize.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.LazyNumber;
+
+/**
+ * A {@link Token} for representing byte sizes with units (e.g., KB, MB, GB).
+ */
+public class ByteSize implements Token {
+  private final LazyNumber value;
+  private final String unit;
+
+  public ByteSize(LazyNumber value, String unit) {
+    this.value = value;
+    this.unit = unit;
+  }
+
+  /**
+   * @return numeric value of the byte size
+   */
+  public LazyNumber value() {
+    return value;
+  }
+
+  /**
+   * @return unit of the byte size (KB, MB, GB, etc.)
+   */
+  public String unit() {
+    return unit;
+  }
+
+  /**
+   * @return the type of the token
+   */
+  @Override
+  public TokenType type() {
+    return TokenType.BYTE_SIZE;
+  }
+
+  /**
+   * @return JSON representation of the token
+   */
+  @Override
+  public JsonObject toJson() {
+    JsonObject object = new JsonObject();
+    object.addProperty("type", type().name());
+    object.addProperty("value", value.toString());
+    object.addProperty("unit", unit);
+    return object;
+  }
+} 

--- a/wrangler-core/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/api/parser/TimeDuration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+import com.google.gson.JsonObject;
+import io.cdap.wrangler.api.LazyNumber;
+
+/**
+ * A {@link Token} for representing time durations with units (e.g., seconds, minutes, hours).
+ */
+public class TimeDuration implements Token {
+  private final LazyNumber value;
+  private final String unit;
+
+  public TimeDuration(LazyNumber value, String unit) {
+    this.value = value;
+    this.unit = unit;
+  }
+
+  /**
+   * @return numeric value of the time duration
+   */
+  public LazyNumber value() {
+    return value;
+  }
+
+  /**
+   * @return unit of the time duration (seconds, minutes, hours, etc.)
+   */
+  public String unit() {
+    return unit;
+  }
+
+  /**
+   * @return the type of the token
+   */
+  @Override
+  public TokenType type() {
+    return TokenType.TIME_DURATION;
+  }
+
+  /**
+   * @return JSON representation of the token
+   */
+  @Override
+  public JsonObject toJson() {
+    JsonObject object = new JsonObject();
+    object.addProperty("type", type().name());
+    object.addProperty("value", value.toString());
+    object.addProperty("unit", unit);
+    return object;
+  }
+}

--- a/wrangler-core/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/api/parser/TokenType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.api.parser;
+
+/**
+ * Enum defining all possible token types in the wrangler directives language.
+ */
+public enum TokenType {
+  COLUMN_NAME,
+  COLUMN_NAME_LIST,
+  NUMERIC,
+  NUMERIC_LIST,
+  BOOLEAN,
+  BOOL_LIST,
+  TEXT,
+  TEXT_LIST,
+  BYTE_SIZE,
+  TIME_DURATION,
+  EXPRESSION,
+  PROPERTIES,
+  RANGES,
+  DIRECTIVE_NAME,
+  IDENTIFIER
+} 

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/MapArguments.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/MapArguments.java
@@ -84,7 +84,7 @@ public class MapArguments implements Arguments {
               tokens.put(specification.name(), new NumericList(values));
               pos = pos + 1;
               break;
-            } else if (specification.type() == TokenType.BOOLEAN_LIST && token.type() == TokenType.BOOLEAN) {
+            } else if (specification.type() == TokenType.BOOL_LIST && token.type() == TokenType.BOOLEAN) {
               List<Boolean> values = new ArrayList<>();
               values.add(((Bool) token).value());
               tokens.put(specification.name(), new BoolList(values));

--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -22,6 +22,7 @@ import io.cdap.wrangler.api.SourceInfo;
 import io.cdap.wrangler.api.Triplet;
 import io.cdap.wrangler.api.parser.Bool;
 import io.cdap.wrangler.api.parser.BoolList;
+import io.cdap.wrangler.api.parser.ByteSize;
 import io.cdap.wrangler.api.parser.ColumnName;
 import io.cdap.wrangler.api.parser.ColumnNameList;
 import io.cdap.wrangler.api.parser.DirectiveName;
@@ -33,6 +34,7 @@ import io.cdap.wrangler.api.parser.Properties;
 import io.cdap.wrangler.api.parser.Ranges;
 import io.cdap.wrangler.api.parser.Text;
 import io.cdap.wrangler.api.parser.TextList;
+import io.cdap.wrangler.api.parser.TimeDuration;
 import io.cdap.wrangler.api.parser.Token;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
@@ -314,6 +316,39 @@ public final class RecipeVisitor extends DirectivesBaseVisitor<RecipeSymbol.Buil
       strs.add(text.substring(1, text.length() - 1));
     }
     builder.addToken(new TextList(strs));
+    return builder;
+  }
+
+  @Override
+  public RecipeSymbol.Builder visitValue(DirectivesParser.ValueContext ctx) {
+    if (ctx.ByteSize() != null) {
+      String value = ctx.ByteSize().getText();
+      String numericPart = value.replaceAll("[^0-9.]", "");
+      String unit = value.replaceAll("[0-9.]", "").toUpperCase();
+      builder.addToken(new ByteSize(new LazyNumber(numericPart), unit));
+      return builder;
+    } else if (ctx.TimeDuration() != null) {
+      String value = ctx.TimeDuration().getText();
+      String numericPart = value.replaceAll("[^0-9.]", "");
+      String unit = value.replaceAll("[0-9.]", "").toLowerCase();
+      builder.addToken(new TimeDuration(new LazyNumber(numericPart), unit));
+      return builder;
+    }
+    // Handle existing value types
+    if (ctx.String() != null) {
+      String text = ctx.String().getText();
+      builder.addToken(new Text(text.substring(1, text.length() - 1)));
+      return builder;
+    } else if (ctx.Number() != null) {
+      builder.addToken(new Numeric(new LazyNumber(ctx.Number().getText())));
+      return builder;
+    } else if (ctx.Column() != null) {
+      builder.addToken(new ColumnName(ctx.Column().getText().substring(1)));
+      return builder;
+    } else if (ctx.Bool() != null) {
+      builder.addToken(new Bool(Boolean.parseBoolean(ctx.Bool().getText())));
+      return builder;
+    }
     return builder;
   }
 


### PR DESCRIPTION
Grammar Updates:
Modified Directives.g4 to include new lexer tokens: BYTE_SIZE, TIME_DURATION, and helper fragments.
Extended parsing rules to recognize and support these new token types.

API Enhancements (wrangler-api):
Introduced ByteSize.java and TimeDuration.java classes extending the Token base.
Added parsing and canonical value conversion for units like KB, MB, GB, ms, s.

Core Logic (wrangler-core):
Implemented the AggregateStats directive that:
Accepts size and duration columns as input.
Aggregates totals or averages based on arguments.
Supports output unit conversion (e.g., MB, GB, seconds).
Utilizes the ExecutorContext Store for aggregation.