### PR TITLE
Create ByteSize.java

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/ByteSize.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/ByteSize.java
@@ -1,0 +1,30 @@
+package io.cdap.wrangler.api.parser;
+
+public class ByteSize extends Token {
+  private final long bytes;
+
+  public ByteSize(String value) {
+    super(Type.BYTE_SIZE, value);
+    this.bytes = parseToBytes(value.trim().toUpperCase());
+  }
+
+  private long parseToBytes(String value) {
+    if (value.endsWith("KB")) {
+      return (long) (Double.parseDouble(value.replace("KB", "")) * 1024);
+    } else if (value.endsWith("MB")) {
+      return (long) (Double.parseDouble(value.replace("MB", "")) * 1024 * 1024);
+    } else if (value.endsWith("GB")) {
+      return (long) (Double.parseDouble(value.replace("GB", "")) * 1024 * 1024 * 1024);
+    } else if (value.endsWith("TB")) {
+      return (long) (Double.parseDouble(value.replace("TB", "")) * 1024L * 1024 * 1024 * 1024);
+    } else if (value.endsWith("B")) {
+      return (long) Double.parseDouble(value.replace("B", ""));
+    } else {
+      throw new IllegalArgumentException("Unknown byte unit: " + value);
+    }
+  }
+
+  public long getBytes() {
+    return bytes;
+  }
+}


### PR DESCRIPTION
These classes are wrappers around the raw string (e.g., "2s") and give you canonical values:

ByteSize.getBytes() → returns size in bytes.

TimeDuration.getNanoseconds() → returns time in nanos.

This allows:

Easy math/aggregation

Clean, reusable code

Type-safe directive execution