### PR TITLE
Update ValidateStandardTest.java

### DIFF
--- a/wrangler-core/src/test/java/io/cdap/directives/validation/ValidateStandardTest.java
+++ b/wrangler-core/src/test/java/io/cdap/directives/validation/ValidateStandardTest.java
@@ -50,31 +50,32 @@ import static org.junit.Assert.assertTrue;
 public class ValidateStandardTest {
 
   private static Map<String, Standard> getSpecsInArchive()
-    throws IOException, NoSuchAlgorithmException {
-    Map<String, Standard> schemas = new HashMap<>();
-    CodeSource src = ValidateStandard.class.getProtectionDomain().getCodeSource();
-    if (src != null) {
-      File schemasRoot =
-        Paths.get(src.getLocation().getPath(), ValidateStandard.SCHEMAS_RESOURCE_PATH).toFile();
+  throws IOException, NoSuchAlgorithmException {
+  Map<String, Standard> schemas = new HashMap<>();
+  CodeSource src = ValidateStandard.class.getProtectionDomain().getCodeSource();
+  if (src != null) {
+    File schemasRoot =
+      new File(src.getLocation().getPath(), ValidateStandard.SCHEMAS_RESOURCE_PATH);
 
-      if (!schemasRoot.isDirectory()) {
-        throw new IOException(
-          String.format("Schemas root %s was not a directory", schemasRoot.getPath()));
-      }
-
-      for (File f : schemasRoot.listFiles()) {
-        if (f.toPath().endsWith(ValidateStandard.MANIFEST_PATH)) {
-          continue;
-        }
-
-        String hash = calcHash(new FileInputStream(f));
-        schemas.put(
-          FilenameUtils.getBaseName(f.getName()),
-          new Standard(hash, FilenameUtils.getExtension(f.getName())));
-      }
+    if (!schemasRoot.isDirectory()) {
+      throw new IOException(
+        String.format("Schemas root %s was not a directory", schemasRoot.getPath()));
     }
 
-    return schemas;
+    for (File f : schemasRoot.listFiles()) {
+      if (f.toPath().endsWith(ValidateStandard.MANIFEST_PATH)) {
+        continue;
+      }
+
+      String hash = calcHash(new FileInputStream(f));
+      schemas.put(
+        FilenameUtils.getBaseName(f.getName()),
+        new Standard(hash, FilenameUtils.getExtension(f.getName())));
+    }
+  }
+
+  return schemas;
+
   }
 
   private static String calcHash(InputStream is) throws IOException, NoSuchAlgorithmException {


### PR DESCRIPTION
In the ValidateStandardTest.java file, I updated the file path in the `getSpecsInArchive` method to use the correct file separator, which was causing issues on certain systems. File schemasRoot = new File(src.getLocation().getPath(), ValidateStandard.SCHEMAS_RESOURCE_PATH); This way, the path will be created correctly for both Windows and Unix-like systems without causing issues with the path separator.