### PR TITLE
[CDAP-21204] Fix wrangler expression classpath issue for remote task execution for UDD

### DIFF
--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -272,8 +272,10 @@
               <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
               <Embed-Transitive>true</Embed-Transitive>
               <Embed-Directory>lib</Embed-Directory>
-              <!-- So that user plugins can depend on Directive.java and other classes, for user-defined directives -->
-              <_exportcontents>io.cdap.wrangler.api.*</_exportcontents>
+              <!-- So that user plugins can depend on Directive.java, EL.java and other classes, for user-defined directives -->
+              <_exportcontents>
+                io.cdap.wrangler.api.*,io.cdap.wrangler.expression.*
+              </_exportcontents>
             </instructions>
           </configuration>
           <executions>


### PR DESCRIPTION
When using [EL class](https://github.com/data-integrations/wrangler/blob/develop/wrangler-core/src/main/java/io/cdap/wrangler/expression/EL.java#L70) in UDD, it fails with `java.lang.NoClassDefFoundError: io/cdap/wrangler/expression/ELException `. This is because wrangler-core is not present in classpath.


Testing:
Created a UDD which uses EL class. Able to successfully execute it.  
<img width="1456" height="702" alt="Screenshot 2025-08-08 at 12 14 22 PM" src="https://github.com/user-attachments/assets/1640f6f4-6a9b-435c-823e-e998c5862628" />
