### PR TITLE
Bump org.bouncycastle:bcprov-jdk15on from 1.56 to 1.70

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
       <properties>
         <testSourceLocation>src/e2e-test/java</testSourceLocation>
         <TEST_RUNNER>TestRunner.java</TEST_RUNNER>
-        <selenium.version>4.28.0</selenium.version>
+        <selenium.version>4.21.0</selenium.version>
       </properties>
       <build>
         <testResources>

--- a/pom.xml
+++ b/pom.xml
@@ -402,6 +402,7 @@
       <properties>
         <testSourceLocation>src/e2e-test/java</testSourceLocation>
         <TEST_RUNNER>TestRunner.java</TEST_RUNNER>
+        <selenium.version>4.28.0</selenium.version>
       </properties>
       <build>
         <testResources>
@@ -523,6 +524,20 @@
           <artifactId>logback-classic</artifactId>
           <version>1.2.8</version>
           <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.seleniumhq.selenium</groupId>
+          <artifactId>selenium-java</artifactId>
+          <version>${selenium.version}</version>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.seleniumhq.selenium</groupId>
+          <artifactId>selenium-devtools-v144</artifactId>
+          <version>${selenium.version}</version>
+          <scope>test</scope>
         </dependency>
       </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <avro.version>1.8.1</avro.version>
     <aws.sdk.version>1.11.133</aws.sdk.version>
     <bigquery.connector.hadoop2.version>0.10.2-hadoop2</bigquery.connector.hadoop2.version>
-    <bouncycastle.version>1.56</bouncycastle.version>
+    <bouncycastle.version>1.70</bouncycastle.version>
     <cdap.version>6.11.1</cdap.version>
     <chlorine.version>1.1.5</chlorine.version>
     <commons.validator.version>1.6</commons.validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,6 @@
       <properties>
         <testSourceLocation>src/e2e-test/java</testSourceLocation>
         <TEST_RUNNER>TestRunner.java</TEST_RUNNER>
-        <selenium.version>4.13.0</selenium.version>
       </properties>
       <build>
         <testResources>
@@ -525,11 +524,22 @@
           <version>1.2.8</version>
           <scope>runtime</scope>
         </dependency>
-
         <dependency>
-          <groupId>org.seleniumhq.selenium</groupId>
-          <artifactId>selenium-java</artifactId>
-          <version>${selenium.version}</version>
+          <groupId>org.openqa.seleniumhq.selenium</groupId>
+          <artifactId>selenium-support</artifactId>
+          <version>4.1.2</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.openqa.seleniumhq.selenium</groupId>
+          <artifactId>selenium-api</artifactId>
+          <version>4.1.2</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.openqa.seleniumhq.selenium</groupId>
+          <artifactId>selenium-remote-driver</artifactId>
+          <version>4.1.2</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
 
         <dependency>
           <groupId>org.seleniumhq.selenium</groupId>
-          <artifactId>selenium-devtools-v144</artifactId>
+          <artifactId>selenium-http-jdk-client</artifactId>
           <version>${selenium.version}</version>
           <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>5.1.9</version>
           <extensions>true</extensions>
           <configuration>
             <instructions>
@@ -176,6 +176,7 @@
               <Embed-Directory>lib</Embed-Directory>
               <!--Only @Plugin classes in the export packages will be included as plugin-->
               <_exportcontents>io.cdap.wrangler.*</_exportcontents>
+              <Multi-Release>true</Multi-Release>
             </instructions>
           </configuration>
           <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
       <properties>
         <testSourceLocation>src/e2e-test/java</testSourceLocation>
         <TEST_RUNNER>TestRunner.java</TEST_RUNNER>
-        <selenium.version>4.21.0</selenium.version>
+        <selenium.version>4.13.0</selenium.version>
       </properties>
       <build>
         <testResources>
@@ -529,13 +529,6 @@
         <dependency>
           <groupId>org.seleniumhq.selenium</groupId>
           <artifactId>selenium-java</artifactId>
-          <version>${selenium.version}</version>
-          <scope>test</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>org.seleniumhq.selenium</groupId>
-          <artifactId>selenium-http-jdk-client</artifactId>
           <version>${selenium.version}</version>
           <scope>test</scope>
         </dependency>

--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -260,7 +260,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>5.1.9</version>
           <extensions>true</extensions>
           <configuration>
             <archive>
@@ -276,6 +276,7 @@
               <_exportcontents>
                 io.cdap.wrangler.api.*,io.cdap.wrangler.expression.*
               </_exportcontents>
+              <Multi-Release>true</Multi-Release>
             </instructions>
           </configuration>
           <executions>
@@ -299,7 +300,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>5.1.9</version>
       </plugin>
     </plugins>
 

--- a/wrangler-transform/pom.xml
+++ b/wrangler-transform/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>5.1.9</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>
@@ -105,6 +105,7 @@
             <Embed-Directory>lib</Embed-Directory>
             <!--Only @Plugin classes in the export packages will be included as plugin-->
             <_exportcontents>io.cdap.wrangler.*</_exportcontents>
+            <Multi-Release>true</Multi-Release>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
This is to fix : [CVE-2020-11612](https://nvd.nist.gov/vuln/detail/cve-2020-11612)