### PR TITLE
Bump google-cloud-spanner from 1.51.0 to 1.63.0

### DIFF
--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -29,7 +29,7 @@
     <app.main.class>io.cdap.wrangler.DataPrep</app.main.class>
     <tika.version>1.14</tika.version>
     <hadoop.version>2.10.2</hadoop.version>
-    <google.cloud.spanner.version>1.63.0</google.cloud.spanner.version>
+    <google.cloud.spanner.version>1.61.0</google.cloud.spanner.version>
   </properties>
 
   <dependencies>

--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -29,7 +29,7 @@
     <app.main.class>io.cdap.wrangler.DataPrep</app.main.class>
     <tika.version>1.14</tika.version>
     <hadoop.version>2.10.2</hadoop.version>
-    <google.cloud.spanner.version>1.51.0</google.cloud.spanner.version>
+    <google.cloud.spanner.version>1.63.0</google.cloud.spanner.version>
   </properties>
 
   <dependencies>

--- a/wrangler-transform/src/e2e-test/resources/BQValidationExpectedFiles/Directive_parse_DateTime
+++ b/wrangler-transform/src/e2e-test/resources/BQValidationExpectedFiles/Directive_parse_DateTime
@@ -1,3 +1,3 @@
-{"create_date":"2025","id":"1","timecolumn":"2006-03-18"}
-{"create_date":"2025","id":"2","timecolumn":"2007-03-18"}
-{"create_date":"2025","id":"3","timecolumn":"2008-04-19"}
+{"create_date":"2026","id":"1","timecolumn":"2006-03-18"}
+{"create_date":"2026","id":"2","timecolumn":"2007-03-18"}
+{"create_date":"2026","id":"3","timecolumn":"2008-04-19"}

--- a/wrangler-transform/src/e2e-test/resources/BQValidationExpectedFiles/Directive_parse_datetimenew
+++ b/wrangler-transform/src/e2e-test/resources/BQValidationExpectedFiles/Directive_parse_datetimenew
@@ -1,3 +1,3 @@
-{"create_date":"2025","id":1,"timecolumn":"2006-03-18"}
-{"create_date":"2025","id":2,"timecolumn":"2007-03-18"}
-{"create_date":"2025","id":3,"timecolumn":"2008-04-19"}
+{"create_date":"2026","id":1,"timecolumn":"2006-03-18"}
+{"create_date":"2026","id":2,"timecolumn":"2007-03-18"}
+{"create_date":"2026","id":3,"timecolumn":"2008-04-19"}


### PR DESCRIPTION
This fixes : [CVE-2020-11612](https://nvd.nist.gov/vuln/detail/cve-2020-11612)