### PR TITLE
Bump google-cloud-spanner from 1.51.0 to 1.61.0

### DIFF
--- a/wrangler-service/pom.xml
+++ b/wrangler-service/pom.xml
@@ -29,7 +29,7 @@
     <app.main.class>io.cdap.wrangler.DataPrep</app.main.class>
     <tika.version>1.14</tika.version>
     <hadoop.version>2.10.2</hadoop.version>
-    <google.cloud.spanner.version>1.51.0</google.cloud.spanner.version>
+    <google.cloud.spanner.version>1.61.0</google.cloud.spanner.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Fixes security vulnerability : [CVE-2020-11612](https://nvd.nist.gov/vuln/detail/cve-2020-11612)

### Before:
```
[INFO] --- dependency:3.7.0:tree (default-cli) @ wrangler-service ---
[INFO] io.cdap.wrangler:wrangler-service:jar:4.12.0-SNAPSHOT
[INFO] \- com.google.cloud:google-cloud-spanner:jar:1.51.0:compile
[INFO]    \- io.grpc:grpc-netty-shaded:jar:1.27.2:compile
```

### After:
```
[INFO] --- dependency:3.7.0:tree (default-cli) @ wrangler-service ---
[INFO] io.cdap.wrangler:wrangler-service:jar:4.12.0-SNAPSHOT
[INFO] \- com.google.cloud:google-cloud-spanner:jar:1.61.0:compile
[INFO]    \- io.grpc:grpc-netty-shaded:jar:1.31.1:compile
```

### Testing:

Tested `Add connection` and navigate database using Wrangler UI
<img width="890" height="1586" alt="image" src="https://github.com/user-attachments/assets/d6d436fe-e94b-41c1-a35e-6d939fec6f24" />

<img width="3428" height="620" alt="image" src="https://github.com/user-attachments/assets/8060352d-5718-4dda-8ac5-9930b5791158" />

<img width="2960" height="1790" alt="image" src="https://github.com/user-attachments/assets/e58ebe71-9cae-44d2-82b9-67fe7a1cec20" />

Followed : https://cdap.atlassian.net/wiki/spaces/DOCS/pages/477692449/Wrangler+Service

