### PR TITLE
Upgrade avro to 1.11.3 to fix CVE-2023-39410

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <antlr4.version>4.7</antlr4.version>
     <antlr4-maven-plugin.version>4.7</antlr4-maven-plugin.version>
-    <avro.version>1.8.1</avro.version>
+    <avro.version>1.11.3</avro.version>
     <aws.sdk.version>1.12.701</aws.sdk.version>
     <bigquery.connector.hadoop2.version>0.10.2-hadoop2</bigquery.connector.hadoop2.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>

--- a/wrangler-service/src/test/java/io/cdap/wrangler/service/kafka/KafkaServiceTest.java
+++ b/wrangler-service/src/test/java/io/cdap/wrangler/service/kafka/KafkaServiceTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.wrangler.service.kafka;
 
-import avro.shaded.com.google.common.collect.Lists;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -26,6 +25,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -48,7 +48,7 @@ public class KafkaServiceTest {
     props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
     Map<String, List<PartitionInfo>> stringListMap = consumer.listTopics();
-    consumer.subscribe(Lists.newArrayList("test"));
+    consumer.subscribe(Collections.singletonList("test"));
     try {
       while (true) {
         ConsumerRecords<String, String> records = consumer.poll(1000);


### PR DESCRIPTION
This PR upgrades avro to 1.11.3 to remediate CVE-2023-39410.