### PR TITLE
deps: Upgrade Avro to 1.11.4, org.json to 20231013, and Commons-Lang3 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <antlr4.version>4.7</antlr4.version>
     <antlr4-maven-plugin.version>4.7</antlr4-maven-plugin.version>
-    <avro.version>1.8.1</avro.version>
+    <avro.version>1.11.4</avro.version>
     <aws.sdk.version>1.12.701</aws.sdk.version>
     <bigquery.connector.hadoop2.version>0.10.2-hadoop2</bigquery.connector.hadoop2.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>
@@ -79,7 +79,7 @@
     <commons-csv.version>1.4</commons-csv.version>
     <commons-jexl.version>3.0</commons-jexl.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-lang3.version>3.5</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <geogson.version>1.1.97</geogson.version>
     <google.cloud.bigquery.version>1.110.1</google.cloud.bigquery.version>
@@ -107,7 +107,7 @@
     <log4j.version>2.17.2</log4j.version>
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
     <poi.version>5.2.5</poi.version>
-    <protobuf.version>3.11.3</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <reflections.version>0.9.9</reflections.version>
     <simmetrics.version>4.1.1</simmetrics.version>
     <simplemagic.version>1.11</simplemagic.version>
@@ -515,7 +515,7 @@
           <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
+            <version>31.1-jre</version>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/wrangler-core/pom.xml
+++ b/wrangler-core/pom.xml
@@ -184,7 +184,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20180813</version>
+      <version>20231013</version>
     </dependency>
     <dependency>
       <groupId>org.unix4j</groupId>


### PR DESCRIPTION
## Vulnerability Remediation Summary
Automated dependency version upgrades for Cloud Data Fusion container image vulnerability remediation.

### Before vs. After [[1;34mINFO[m] Scanning for projects...
[[1;33mWARNING[m] 
[[1;33mWARNING[m] Some problems were encountered while building the effective model for io.cdap.cdap:cdap-runtime-ext-remote-hadoop:jar:1.1.0
[[1;33mWARNING[m] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 71, column 15
[[1;33mWARNING[m] 
[[1;33mWARNING[m] It is highly recommended to fix these problems because they threaten the stability of your build.
[[1;33mWARNING[m] 
[[1;33mWARNING[m] For this reason, future Maven versions might no longer support building such malformed projects.
[[1;33mWARNING[m] 
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m------------< [0;36mio.cdap.cdap:cdap-runtime-ext-remote-hadoop[0;1m >-------------[m
[[1;34mINFO[m] [1mBuilding CDAP Remote Hadoop Runtime Extension 1.1.0[m
[[1;34mINFO[m]   from pom.xml
[[1;34mINFO[m] [1m--------------------------------[ jar ]---------------------------------[m
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://oss.sonatype.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml
[[1;33mWARNING[m] Could not transfer metadata io.cdap.cdap:cdap-error-api:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[[1;33mWARNING[m] io.cdap.cdap:cdap-error-api:6.11.0-SNAPSHOT/maven-metadata.xml failed to transfer from https://oss.sonatype.org/content/repositories/snapshots/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced. Original error: Could not transfer metadata io.cdap.cdap:cdap-error-api:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[90mDownloading from [0msonatype[90m: https://oss.sonatype.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml
[[1;33mWARNING[m] Could not transfer metadata io.cdap.cdap:cdap-api-common:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[[1;33mWARNING[m] io.cdap.cdap:cdap-api-common:6.11.0-SNAPSHOT/maven-metadata.xml failed to transfer from https://oss.sonatype.org/content/repositories/snapshots/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced. Original error: Could not transfer metadata io.cdap.cdap:cdap-api-common:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml
Progress (1): 2.0 kB
                    
Downloaded[90m from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml[90m (2.0 kB at 2.0 kB/s)[0m
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/cdap-error-api-6.12.0-20260701.114307-317.pom
Progress (1): 1.2 kB
                    
Downloaded[90m from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/cdap-error-api-6.12.0-20260701.114307-317.pom[90m (1.2 kB at 2.1 kB/s)[0m
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml
Progress (1): 1.6 kB
                    
Downloaded[90m from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml[90m (1.6 kB at 3.0 kB/s)[0m
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/cdap-api-common-6.12.0-20260701.120019-7.pom
Progress (1): 1.5 kB
                    
Downloaded[90m from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/cdap-api-common-6.12.0-20260701.120019-7.pom[90m (1.5 kB at 2.8 kB/s)[0m
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m--- [0;32mdependency:3.7.0:tree[m [1m(default-cli)[m @ [36mcdap-runtime-ext-remote-hadoop[0;1m ---[m
[[1;34mINFO[m] io.cdap.cdap:cdap-runtime-ext-remote-hadoop:jar:1.1.0
[[1;34mINFO[m] +- io.cdap.cdap:cdap-runtime-spi:jar:6.12.0-SNAPSHOT:provided
[[1;34mINFO[m] |  +- com.google.code.findbugs:jsr305:jar:2.0.1:compile
[[1;34mINFO[m] |  +- io.cdap.twill:twill-api:jar:1.4.0:provided
[[1;34mINFO[m] |  |  +- io.cdap.twill:twill-common:jar:1.4.0:provided
[[1;34mINFO[m] |  |  \- io.cdap.twill:twill-discovery-api:jar:1.4.0:provided
[[1;34mINFO[m] |  +- io.cdap.cdap:cdap-error-api:jar:6.12.0-SNAPSHOT:provided
[[1;34mINFO[m] |  \- io.cdap.cdap:cdap-api-common:jar:6.12.0-SNAPSHOT:provided
[[1;34mINFO[m] +- org.slf4j:slf4j-api:jar:1.7.5:provided
[[1;34mINFO[m] +- com.google.guava:guava:jar:33.5.0-jre:compile
[[1;34mINFO[m] |  +- com.google.guava:failureaccess:jar:1.0.3:compile
[[1;34mINFO[m] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[[1;34mINFO[m] |  +- org.jspecify:jspecify:jar:1.0.0:compile
[[1;34mINFO[m] |  +- com.google.errorprone:error_prone_annotations:jar:2.41.0:compile
[[1;34mINFO[m] |  \- com.google.j2objc:j2objc-annotations:jar:3.1:compile
[[1;34mINFO[m] +- com.google.cloud:google-cloud-dataproc:jar:4.85.0:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-api:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-stub:jar:1.76.3:compile
[[1;34mINFO[m] |  +- org.codehaus.mojo:animal-sniffer-annotations:jar:1.24:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-protobuf:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-protobuf-lite:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- com.google.api:api-common:jar:2.59.0:compile
[[1;34mINFO[m] |  +- com.google.auto.value:auto-value-annotations:jar:1.11.0:compile
[[1;34mINFO[m] |  +- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[[1;34mINFO[m] |  +- com.google.protobuf:protobuf-java:jar:4.33.2:compile
[[1;34mINFO[m] |  +- com.google.api.grpc:proto-google-common-protos:jar:2.67.0:compile
[[1;34mINFO[m] |  +- com.google.api.grpc:proto-google-cloud-dataproc-v1:jar:4.85.0:compile
[[1;34mINFO[m] |  +- com.google.api.grpc:proto-google-iam-v1:jar:1.62.0:compile
[[1;34mINFO[m] |  +- com.google.api:gax:jar:2.76.0:compile
[[1;34mINFO[m] |  +- com.google.auth:google-auth-library-credentials:jar:1.43.0:compile
[[1;34mINFO[m] |  +- com.google.protobuf:protobuf-java-util:jar:4.33.2:compile
[[1;34mINFO[m] |  +- io.opencensus:opencensus-api:jar:0.31.1:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-context:jar:1.76.3:compile
[[1;34mINFO[m] |  +- com.google.auth:google-auth-library-oauth2-http:jar:1.43.0:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-inprocess:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-core:jar:1.76.3:compile
[[1;34mINFO[m] |  +- com.google.android:annotations:jar:4.1.1.4:runtime
[[1;34mINFO[m] |  +- io.grpc:grpc-alts:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-grpclb:jar:1.76.3:compile
[[1;34mINFO[m] |  +- org.conscrypt:conscrypt-openjdk-uber:jar:2.5.2:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-auth:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-netty-shaded:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-util:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- io.perfmark:perfmark-api:jar:0.27.0:runtime
[[1;34mINFO[m] |  +- io.grpc:grpc-googleapis:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- io.grpc:grpc-xds:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- io.grpc:grpc-services:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- com.google.re2j:re2j:jar:1.8:runtime
[[1;34mINFO[m] |  +- com.google.api:gax-httpjson:jar:2.76.0:compile
[[1;34mINFO[m] |  +- com.google.code.gson:gson:jar:2.12.1:compile
[[1;34mINFO[m] |  +- com.google.http-client:google-http-client:jar:2.1.0:compile
[[1;34mINFO[m] |  +- org.apache.httpcomponents:httpclient:jar:4.5.14:compile
[[1;34mINFO[m] |  +- commons-codec:commons-codec:jar:1.18.0:compile
[[1;34mINFO[m] |  +- org.apache.httpcomponents:httpcore:jar:4.4.16:compile
[[1;34mINFO[m] |  +- io.opencensus:opencensus-contrib-http-util:jar:0.31.1:compile
[[1;34mINFO[m] |  +- com.google.http-client:google-http-client-gson:jar:2.1.0:compile
[[1;34mINFO[m] |  \- org.threeten:threetenbp:jar:1.7.0:compile
[[1;34mINFO[m] +- com.google.apis:google-api-services-compute:jar:v1-rev235-1.25.0:compile
[[1;34mINFO[m] |  \- com.google.api-client:google-api-client:jar:1.25.0:compile
[[1;34mINFO[m] |     +- com.google.oauth-client:google-oauth-client:jar:1.25.0:compile
[[1;34mINFO[m] |     \- com.google.http-client:google-http-client-jackson2:jar:1.25.0:compile
[[1;34mINFO[m] |        \- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
[[1;34mINFO[m] \- com.google.api:gax-grpc:jar:2.76.0:compile
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] [1;32mBUILD SUCCESS[m
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] Total time:  01:05 min
[[1;34mINFO[m] Finished at: 2026-07-01T14:46:45Z
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m Comparison

#### Before ():


#### After (Feature Branch):


- Local build ([[1;34mINFO[m] Scanning for projects...
[[1;33mWARNING[m] 
[[1;33mWARNING[m] Some problems were encountered while building the effective model for io.cdap.cdap:cdap-runtime-ext-remote-hadoop:jar:1.1.0
[[1;33mWARNING[m] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 71, column 15
[[1;33mWARNING[m] 
[[1;33mWARNING[m] It is highly recommended to fix these problems because they threaten the stability of your build.
[[1;33mWARNING[m] 
[[1;33mWARNING[m] For this reason, future Maven versions might no longer support building such malformed projects.
[[1;33mWARNING[m] 
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m------------< [0;36mio.cdap.cdap:cdap-runtime-ext-remote-hadoop[0;1m >-------------[m
[[1;34mINFO[m] [1mBuilding CDAP Remote Hadoop Runtime Extension 1.1.0[m
[[1;34mINFO[m]   from pom.xml
[[1;34mINFO[m] [1m--------------------------------[ jar ]---------------------------------[m
[90mDownloading from [0msonatype[90m: https://oss.sonatype.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://oss.sonatype.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml
[[1;33mWARNING[m] Could not transfer metadata io.cdap.cdap:cdap-api-common:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[[1;33mWARNING[m] io.cdap.cdap:cdap-api-common:6.11.0-SNAPSHOT/maven-metadata.xml failed to transfer from https://oss.sonatype.org/content/repositories/snapshots/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced. Original error: Could not transfer metadata io.cdap.cdap:cdap-api-common:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml
Progress (1): 2.0 kB
                    
Downloaded[90m from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml[90m (2.0 kB at 2.3 kB/s)[0m
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml
Progress (1): 1.6 kB
                    
Downloaded[90m from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml[90m (1.6 kB at 3.2 kB/s)[0m
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/cdap-error-api-6.12.0-20260701.114307-317.jar
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/cdap-api-common-6.12.0-20260701.120019-7.jar
Progress (1): 3.8 kB
                    
Downloaded[90m from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/cdap-error-api-6.12.0-20260701.114307-317.jar[90m (3.8 kB at 7.4 kB/s)[0m
Progress (1): 4.1/87 kB
Progress (1): 7.7/87 kB
Progress (1): 12/87 kB 
Progress (1): 16/87 kB
Progress (1): 20/87 kB
Progress (1): 24/87 kB
Progress (1): 28/87 kB
Progress (1): 32/87 kB
Progress (1): 36/87 kB
Progress (1): 40/87 kB
Progress (1): 45/87 kB
Progress (1): 49/87 kB
Progress (1): 53/87 kB
Progress (1): 57/87 kB
Progress (1): 61/87 kB
Progress (1): 65/87 kB
Progress (1): 69/87 kB
Progress (1): 73/87 kB
Progress (1): 77/87 kB
Progress (1): 81/87 kB
Progress (1): 86/87 kB
Progress (1): 87 kB   
                   
Downloaded[90m from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/cdap-api-common-6.12.0-20260701.120019-7.jar[90m (87 kB at 71 kB/s)[0m
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m--- [0;32mclean:3.2.0:clean[m [1m(default-clean)[m @ [36mcdap-runtime-ext-remote-hadoop[0;1m ---[m
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m--- [0;32mapache-rat:0.13:check[m [1m(rat-check)[m @ [36mcdap-runtime-ext-remote-hadoop[0;1m ---[m
[[1;34mINFO[m] Enabled default license matchers.
[[1;34mINFO[m] Will parse SCM ignores for exclusions...
[[1;34mINFO[m] Finished adding exclusions from SCM ignore files.
[[1;34mINFO[m] 62 implicit excludes (use -debug for more details).
[[1;34mINFO[m] 26 explicit excludes (use -debug for more details).
[[1;34mINFO[m] 850275 resources included (use -debug for more details)
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] [1;31mBUILD FAILURE[m
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] Total time:  21:19 min
[[1;34mINFO[m] Finished at: 2026-07-01T15:08:07Z
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;31mERROR[m] Failed to execute goal [32morg.apache.rat:apache-rat-plugin:0.13:check[m [1m(rat-check)[m on project [36mcdap-runtime-ext-remote-hadoop[m: [1;31mCannot read header[m: .config/google-chrome/Profile 1/Sync Data/LevelDB/000990.log (No such file or directory) -> [1m[Help 1][m
[[1;31mERROR[m] 
[[1;31mERROR[m] To see the full stack trace of the errors, re-run Maven with the [1m-e[m switch.
[[1;31mERROR[m] Re-run Maven using the [1m-X[m switch to enable full debug logging.
[[1;31mERROR[m] 
[[1;31mERROR[m] For more information about the errors and possible solutions, please read the following articles:
[[1;31mERROR[m] [1m[Help 1][m http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException): **BUILD SUCCESS**
- Remote CI build status: **BUILD SUCCESS**