### PR TITLE
Fix: Enforce wrangler directive config in wrangler service and pipeline transform

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/wrangler/clients/DataPrepServiceClient.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/clients/DataPrepServiceClient.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.clients;
+
+import com.github.rholder.retry.Attempt;
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.RetryListener;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.etl.api.StageContext;
+import io.cdap.wrangler.api.DirectiveConfig;
+import io.cdap.wrangler.proto.ServiceResponse;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Client for interacting with the system-level DataPrep service.
+ * Supports configurable connection/read timeouts via pipeline runtime arguments
+ * and implements exponential backoff retry logic for resilience against
+ * transient network failures.
+ */
+public class DataPrepServiceClient {
+  private static final Logger LOG = LoggerFactory.getLogger(DataPrepServiceClient.class);
+  private static final Gson GSON = new Gson();
+
+  private static final String SYSTEM_NAMESPACE = "system";
+  private static final String APPLICATION_NAME = "dataprep";
+  private static final String SERVICE_NAME = "service";
+  private static final String CONFIG_ENDPOINT = "config";
+
+  public static final String CONNECT_TIMEOUT_PROP = "wrangler.service.connect.timeout.ms";
+  public static final String READ_TIMEOUT_PROP = "wrangler.service.read.timeout.ms";
+
+  // Matches cdap-default.xml http.client.connection.timeout.ms and
+  // http.client.read.timeout.ms
+  private static final int DEFAULT_CONNECT_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(15);
+  private static final int DEFAULT_READ_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(60);
+
+  private static final Retryer<DirectiveConfig> DIRECTIVE_CONFIG_RETRYER = RetryerBuilder.<DirectiveConfig>newBuilder()
+      .retryIfExceptionOfType(IOException.class)
+      .withWaitStrategy(WaitStrategies.exponentialWait(1, 10, TimeUnit.SECONDS))
+      .withStopStrategy(StopStrategies.stopAfterDelay(5, TimeUnit.MINUTES))
+      .withRetryListener(new RetryListener() {
+        @Override
+        public <V> void onRetry(Attempt<V> attempt) {
+          if (attempt.hasException()) {
+            Throwable cause = attempt.getExceptionCause();
+            if (cause != null) {
+              LOG.warn("Attempt {} to fetch directive config from DataPrep service failed: {}. Retrying...",
+                  attempt.getAttemptNumber(), cause.getMessage());
+            }
+          }
+        }
+      })
+      .build();
+
+  /**
+   * Fetches directive config from the system-level DataPrep service with
+   * exponential backoff retry.
+   *
+   * @param context the stage context
+   * @return the fetched DirectiveConfig
+   */
+  public DirectiveConfig fetchDirectiveConfig(StageContext context) {
+    try {
+      Preconditions.checkArgument(context != null, "StageContext cannot be null.");
+      return DIRECTIVE_CONFIG_RETRYER.call(() -> getDirectiveConfig(context));
+    } catch (ExecutionException | RetryException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private DirectiveConfig getDirectiveConfig(StageContext context) throws IOException, RestClientException {
+    HttpURLConnection connection = null;
+    try {
+      LOG.debug("Fetching directive config from DataPrep service.");
+      connection = createConnection(context);
+      int responseCode = connection.getResponseCode();
+      if (responseCode != HttpURLConnection.HTTP_OK) {
+        handleErrorResponse(connection, responseCode);
+      }
+
+      try (InputStream is = connection.getInputStream()) {
+        String responseBody = IOUtils.toString(is, StandardCharsets.UTF_8);
+        LOG.debug("Received HTTP response from GET /config: {}", responseBody);
+        if (Strings.isNullOrEmpty(responseBody)) {
+          throw new IOException("Received null or empty response body from DataPrep service.");
+        }
+        ServiceResponse<DirectiveConfig> response = GSON.fromJson(responseBody,
+            new TypeToken<ServiceResponse<DirectiveConfig>>() {
+            }.getType());
+        if (response.getValues() != null && !response.getValues().isEmpty()) {
+          DirectiveConfig config = response.getValues().iterator().next();
+          return config;
+        }
+        throw new IOException("Received null or malformed directive configuration from DataPrep service.");
+      }
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
+    }
+  }
+
+  private HttpURLConnection createConnection(StageContext context) throws IOException {
+    HttpURLConnection connection = Objects.requireNonNull(
+        context.openConnection(SYSTEM_NAMESPACE, APPLICATION_NAME, SERVICE_NAME, CONFIG_ENDPOINT),
+        "Failed to establish connection to DataPrep service: openConnection returned null.");
+    connection.setRequestMethod("GET");
+    int connectTimeout = tryParseTimeout(context, CONNECT_TIMEOUT_PROP, DEFAULT_CONNECT_TIMEOUT_MS);
+    int readTimeout = tryParseTimeout(context, READ_TIMEOUT_PROP, DEFAULT_READ_TIMEOUT_MS);
+    connection.setConnectTimeout(connectTimeout);
+    connection.setReadTimeout(readTimeout);
+    connection.setRequestProperty("Accept", "application/json");
+    return connection;
+  }
+
+  private void handleErrorResponse(HttpURLConnection connection, int responseCode)
+      throws IOException, RestClientException {
+    LOG.debug("HTTP GET /config response code: {}", responseCode);
+    String errorMessage = "";
+    try (InputStream es = connection.getErrorStream()) {
+      if (es != null) {
+        errorMessage = IOUtils.toString(es, StandardCharsets.UTF_8);
+      }
+    }
+    throw new RestClientException(responseCode, errorMessage);
+  }
+
+  private int tryParseTimeout(StageContext context, String propKey, int defaultTimeoutMs) {
+    String value = context.getArguments().get(propKey);
+    if (Strings.isNullOrEmpty(value)) {
+      return defaultTimeoutMs;
+    }
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      LOG.warn("Invalid runtime argument for {}: '{}'. Using default timeout {} ms.",
+          propKey, value, defaultTimeoutMs, e);
+      return defaultTimeoutMs;
+    }
+  }
+}

--- a/wrangler-core/src/test/java/io/cdap/wrangler/clients/DataPrepServiceClientTest.java
+++ b/wrangler-core/src/test/java/io/cdap/wrangler/clients/DataPrepServiceClientTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.wrangler.clients;
+
+import com.google.common.base.Throwables;
+import io.cdap.cdap.etl.api.Arguments;
+import io.cdap.cdap.etl.api.StageContext;
+import io.cdap.wrangler.api.DirectiveConfig;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DataPrepServiceClientTest {
+
+  private static final String DEFAULT_RESPONSE =
+      "{\"message\":\"Success\",\"count\":1,\"values\":[{}]}";
+
+  private DataPrepServiceClient client;
+
+  @Before
+  public void setUp() {
+    client = new DataPrepServiceClient();
+  }
+
+  private StageContext createMockStageContext(Map<String, String> argsMap, HttpURLConnection connection)
+      throws IOException {
+    Arguments arguments = Mockito.mock(Arguments.class);
+    Mockito.when(arguments.get(Mockito.anyString())).thenAnswer(invocation -> {
+      String key = invocation.getArgument(0);
+      return argsMap.get(key);
+    });
+
+    StageContext context = Mockito.mock(StageContext.class);
+    Mockito.when(context.getArguments()).thenReturn(arguments);
+    Mockito.when(context.openConnection(
+        Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        .thenReturn(connection);
+    return context;
+  }
+
+  private HttpURLConnection createMockConnection(int status, String responseBody) throws IOException {
+    HttpURLConnection connection = Mockito.mock(HttpURLConnection.class);
+    Mockito.when(connection.getResponseCode()).thenReturn(status);
+    if (responseBody != null) {
+      Mockito.when(connection.getInputStream())
+          .thenReturn(new ByteArrayInputStream(responseBody.getBytes(StandardCharsets.UTF_8)));
+      Mockito.when(connection.getErrorStream())
+          .thenReturn(new ByteArrayInputStream(responseBody.getBytes(StandardCharsets.UTF_8)));
+    }
+    return connection;
+  }
+
+  @Test
+  public void testNullContextThrowsException() {
+    try {
+      client.fetchDirectiveConfig(null);
+      Assert.fail("Expected IllegalArgumentException when context is null");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("StageContext cannot be null.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testNullOpenConnectionThrowsException() throws Exception {
+    StageContext context = createMockStageContext(Collections.emptyMap(), null);
+    try {
+      client.fetchDirectiveConfig(context);
+      Assert.fail("Expected exception when openConnection returns null");
+    } catch (RuntimeException e) {
+      Throwable rootCause = Throwables.getRootCause(e);
+      Assert.assertTrue(rootCause instanceof NullPointerException);
+      Assert.assertTrue(rootCause.getMessage().contains("openConnection returned null"));
+    }
+  }
+
+  @Test
+  public void testTimeoutConfiguration() throws Exception {
+    // 1. Verify custom timeouts when configured arguments are provided
+    Map<String, String> customArgs = new HashMap<>();
+    customArgs.put(DataPrepServiceClient.CONNECT_TIMEOUT_PROP, "25000");
+    customArgs.put(DataPrepServiceClient.READ_TIMEOUT_PROP, "90000");
+    HttpURLConnection mockConnectionCustom =
+        createMockConnection(HttpURLConnection.HTTP_OK, DEFAULT_RESPONSE);
+    client.fetchDirectiveConfig(createMockStageContext(customArgs, mockConnectionCustom));
+    Mockito.verify(mockConnectionCustom).setConnectTimeout(25000);
+    Mockito.verify(mockConnectionCustom).setReadTimeout(90000);
+    Mockito.verify(mockConnectionCustom).disconnect();
+
+    // 2. Verify fallback to default timeouts (invalid connect timeout, empty read timeout)
+    Map<String, String> fallbackArgs = Collections.singletonMap(
+        DataPrepServiceClient.CONNECT_TIMEOUT_PROP, "invalid_number");
+    HttpURLConnection mockConnectionFallback =
+        createMockConnection(HttpURLConnection.HTTP_OK, DEFAULT_RESPONSE);
+    client.fetchDirectiveConfig(createMockStageContext(fallbackArgs, mockConnectionFallback));
+    Mockito.verify(mockConnectionFallback).setConnectTimeout(15000);
+    Mockito.verify(mockConnectionFallback).setReadTimeout(60000);
+    Mockito.verify(mockConnectionFallback).disconnect();
+  }
+
+  @Test
+  public void testFetchDirectiveConfigParsesServiceResponse() throws Exception {
+    String responseJson = "{\"message\":\"Success\",\"count\":1,\"values\":" +
+      "[{\"exclusions\":[\"parse-as-json\",\"set-type\"],\"aliases\":{\"alias1\":\"actual1\"}}]," +
+      "\"truncated\":\"false\"}";
+    HttpURLConnection mockConnection = createMockConnection(HttpURLConnection.HTTP_OK, responseJson);
+    StageContext context = createMockStageContext(Collections.emptyMap(), mockConnection);
+
+    DirectiveConfig config = client.fetchDirectiveConfig(context);
+
+    Assert.assertNotNull(config);
+    Assert.assertTrue(config.isExcluded("parse-as-json"));
+    Assert.assertTrue(config.isExcluded("set-type"));
+    Assert.assertFalse(config.isExcluded("keep"));
+    Assert.assertTrue(config.hasAlias("alias1"));
+    Assert.assertEquals("actual1", config.getAliasName("alias1"));
+    Mockito.verify(mockConnection).disconnect();
+  }
+
+  @Test
+  public void testInternalErrorResponseThrowsRestClientExceptionWithoutRetry() throws Exception {
+    String errorJson = "{\"message\":\"Internal Server Error\",\"status\":500}";
+    HttpURLConnection mockConnection = createMockConnection(HttpURLConnection.HTTP_INTERNAL_ERROR, errorJson);
+    StageContext context = createMockStageContext(Collections.emptyMap(), mockConnection);
+
+    try {
+      client.fetchDirectiveConfig(context);
+      Assert.fail("Expected RestClientException when service returns HTTP 500");
+    } catch (RuntimeException e) {
+      Throwable rootCause = Throwables.getRootCause(e);
+      Assert.assertTrue(rootCause instanceof RestClientException);
+      RestClientException restException = (RestClientException) rootCause;
+      Assert.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, restException.getStatus());
+      Assert.assertEquals(errorJson, restException.getMessage());
+    }
+
+    // RestClientException should NOT trigger retry; only 1 openConnection call expected
+    Mockito.verify(context, Mockito.times(1)).openConnection(
+        Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    Mockito.verify(mockConnection).disconnect();
+  }
+
+  @Test
+  public void testErrorResponseWithoutErrorStream() throws Exception {
+    HttpURLConnection mockConnection = Mockito.mock(HttpURLConnection.class);
+    Mockito.when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_NOT_FOUND);
+    Mockito.when(mockConnection.getErrorStream()).thenReturn(null);
+    StageContext context = createMockStageContext(Collections.emptyMap(), mockConnection);
+
+    try {
+      client.fetchDirectiveConfig(context);
+      Assert.fail("Expected RestClientException when service returns HTTP 404");
+    } catch (RuntimeException e) {
+      Throwable rootCause = Throwables.getRootCause(e);
+      Assert.assertTrue(rootCause instanceof RestClientException);
+      RestClientException restException = (RestClientException) rootCause;
+      Assert.assertEquals(HttpURLConnection.HTTP_NOT_FOUND, restException.getStatus());
+      Assert.assertEquals("", restException.getMessage());
+    }
+    Mockito.verify(mockConnection).disconnect();
+  }
+
+  @Test
+  public void testRetryOnTransientIOExceptionSucceeds() throws Exception {
+    HttpURLConnection mockConnection = createMockConnection(HttpURLConnection.HTTP_OK, DEFAULT_RESPONSE);
+
+    Arguments arguments = Mockito.mock(Arguments.class);
+    Mockito.when(arguments.get(Mockito.anyString())).thenReturn(null);
+
+    StageContext context = Mockito.mock(StageContext.class);
+    Mockito.when(context.getArguments()).thenReturn(arguments);
+    Mockito.when(context.openConnection("system", "dataprep", "service", "config"))
+        .thenThrow(new IOException("Transient connection failure"))
+        .thenReturn(mockConnection);
+
+    DirectiveConfig config = client.fetchDirectiveConfig(context);
+
+    Assert.assertNotNull(config);
+    Mockito.verify(context, Mockito.times(2)).openConnection(
+        "system", "dataprep", "service", "config");
+    Mockito.verify(mockConnection).disconnect();
+  }
+
+  @Test
+  public void testConnectionHeadersAndMethod() throws Exception {
+    HttpURLConnection mockConnection = createMockConnection(HttpURLConnection.HTTP_OK, DEFAULT_RESPONSE);
+    StageContext context = createMockStageContext(Collections.emptyMap(), mockConnection);
+
+    client.fetchDirectiveConfig(context);
+
+    Mockito.verify(context).openConnection("system", "dataprep", "service", "config");
+    Mockito.verify(mockConnection).setRequestMethod("GET");
+    Mockito.verify(mockConnection).setRequestProperty("Accept", "application/json");
+    Mockito.verify(mockConnection).disconnect();
+  }
+}

--- a/wrangler-docs/exclusion-and-aliasing.md
+++ b/wrangler-docs/exclusion-and-aliasing.md
@@ -28,8 +28,7 @@ Aliasing allows one to create a new name for a root directive.
 
 ## Scope
 
-Both Exclusion and Aliasing are namespace wide - meaning they are applicable
-only within the namespace were the configuration has been applied.
+Currently, Exclusion and Aliasing configuration is supported only in the `system` namespace. Directive exclusions and aliases must be configured by administrators on the `system` namespace endpoint and apply system-wide.
 
 ## Configuration
 
@@ -69,23 +68,22 @@ Is map of aliased directive and the actual directive name to which it's aliased.
 ## Applying Configuration
 
 A service endpoint exists to apply the configuration. In order to apply
-the configuration, use following REST call.
+the configuration, use the following REST call against the `system` namespace:
 
 ```
 curl -s -X POST @<path-to-json>/<filename.json> \
- "http://<hostname>:11015/v3/namespaces/<namepsace>/apps/dataprep/services/service/methods/config"
+ "http://<hostname>:11015/v3/namespaces/system/apps/dataprep/services/service/methods/config"
 ```
 
-And example would be
+An example would be:
 
 ```
 curl -s -X POST --data-binary @/tmp/wrangler-config.json \
- http://localhost:11015/v3/namespaces/default/apps/dataprep/services/service/methods/config \
+ http://localhost:11015/v3/namespaces/system/apps/dataprep/services/service/methods/config \
   | python -mjson.tool
 {
     "message": "Successfully updated configuration.",
     "status": 200
 }
 ```
-
 

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/AbstractDirectiveHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/AbstractDirectiveHandler.java
@@ -34,6 +34,7 @@ import io.cdap.wrangler.api.RecipeException;
 import io.cdap.wrangler.api.RecipeParser;
 import io.cdap.wrangler.api.Row;
 import io.cdap.wrangler.api.TransientStore;
+import io.cdap.wrangler.dataset.workspace.ConfigStore;
 import io.cdap.wrangler.executor.RecipePipelineExecutor;
 import io.cdap.wrangler.parser.ConfigDirectiveContext;
 import io.cdap.wrangler.parser.GrammarBasedParser;
@@ -89,10 +90,12 @@ public class AbstractDirectiveHandler extends AbstractWranglerHandler {
 
   protected DirectiveRegistry composite;
   protected boolean schemaManagementEnabled;
+  protected ConfigStore configStore;
 
   @Override
   public void initialize(SystemHttpServiceContext context) throws Exception {
     super.initialize(context);
+    configStore = new ConfigStore(context);
     composite = new CompositeDirectiveRegistry(
       SystemDirectiveRegistry.INSTANCE,
       new UserDirectiveRegistry(context)
@@ -118,7 +121,7 @@ public class AbstractDirectiveHandler extends AbstractWranglerHandler {
       String namespace,
       List<String> directives,
       List<Row> sample,
-      GrammarWalker.Visitor<E> grammarVisitor) throws DirectiveParseException, E, RecipeException {
+      GrammarWalker.Visitor<E> grammarVisitor) throws DirectiveParseException, E, RecipeException, IOException {
 
     if (directives.isEmpty()) {
       return sample;
@@ -128,15 +131,16 @@ public class AbstractDirectiveHandler extends AbstractWranglerHandler {
     String recipe = migrator.migrate();
 
     // Parse and call grammar visitor
+    DirectiveConfig config = getDirectiveConfig();
     try {
-      GrammarWalker walker = new GrammarWalker(new RecipeCompiler(), new ConfigDirectiveContext(DirectiveConfig.EMPTY));
+      GrammarWalker walker = new GrammarWalker(new RecipeCompiler(), new ConfigDirectiveContext(config));
       walker.walk(recipe, grammarVisitor);
     } catch (CompileException e) {
       throw new BadRequestException(e.getMessage(), e);
     }
 
     RecipeParser parser = new GrammarBasedParser(namespace, recipe, composite,
-                                                 new ConfigDirectiveContext(DirectiveConfig.EMPTY));
+                                                 new ConfigDirectiveContext(config));
     try (RecipePipelineExecutor executor = new RecipePipelineExecutor(parser,
                                                                       new ServicePipelineContext(
                                                                         namespace, ExecutorContext.Environment.SERVICE,
@@ -280,5 +284,9 @@ public class AbstractDirectiveHandler extends AbstractWranglerHandler {
     // for backward compatibility, make the characters except the first one to lower case
     type = type.substring(0, 1).toUpperCase() + type.substring(1).toLowerCase();
     return type;
+  }
+
+  protected DirectiveConfig getDirectiveConfig() throws IOException {
+    return configStore.getConfig();
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/DirectivesHandler.java
@@ -868,10 +868,7 @@ public class DirectivesHandler extends AbstractDirectiveHandler {
     respond(request, responder, namespace, ns -> {
       // CDAP-15397 - reload must be called before it can be safely used
       composite.reload(namespace);
-      DirectiveConfig config = TransactionRunners.run(getContext(), context -> {
-        ConfigStore store = ConfigStore.get(context);
-        return store.getConfig();
-      });
+      DirectiveConfig config = configStore.getConfig();
       Map<String, List<String>> aliases = config.getReverseAlias();
       List<DirectiveUsage> values = new ArrayList<>();
 
@@ -1000,10 +997,7 @@ public class DirectivesHandler extends AbstractDirectiveHandler {
       if (config == null) {
         throw new BadRequestException("Config is empty. Please check if the request is sent as HTTP POST body.");
       }
-      TransactionRunners.run(getContext(), context -> {
-        ConfigStore configStore = ConfigStore.get(context);
-        configStore.updateConfig(config);
-      });
+      configStore.updateConfig(config);
       return new ServiceResponse<Void>("Successfully updated configuration.");
     });
   }
@@ -1018,10 +1012,7 @@ public class DirectivesHandler extends AbstractDirectiveHandler {
   @Path("config")
   @TransactionPolicy(value = TransactionControl.EXPLICIT)
   public void getConfig(HttpServiceRequest request, HttpServiceResponder responder) {
-    respond(request, responder, () -> TransactionRunners.run(getContext(), context -> {
-      ConfigStore configStore = ConfigStore.get(context);
-      return new ServiceResponse<>(configStore.getConfig());
-    }));
+    respond(request, responder, () -> new ServiceResponse<>(configStore.getConfig()));
   }
 
   /**

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RemoteDirectiveRequest.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RemoteDirectiveRequest.java
@@ -15,7 +15,9 @@
  */
 package io.cdap.wrangler.service.directive;
 
+import com.google.common.base.Preconditions;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.wrangler.api.DirectiveConfig;
 import io.cdap.wrangler.parser.DirectiveClass;
 
 import java.util.HashMap;
@@ -31,14 +33,17 @@ public class RemoteDirectiveRequest {
   private final String pluginNameSpace;
   private final byte[] data;
   private final Schema inputSchema;
+  private final DirectiveConfig directiveConfig;
 
   RemoteDirectiveRequest(String recipe, Map<String, DirectiveClass> systemDirectives,
-                         String pluginNameSpace, byte[] data, Schema inputSchema) {
+                         String pluginNameSpace, byte[] data, Schema inputSchema, DirectiveConfig directiveConfig) {
     this.recipe = recipe;
     this.systemDirectives = new HashMap<>(systemDirectives);
     this.pluginNameSpace = pluginNameSpace;
     this.data = data;
     this.inputSchema = inputSchema;
+    this.directiveConfig = Preconditions.checkNotNull(directiveConfig,
+                                                      "DirectiveConfig is missing or null in RemoteDirectiveRequest.");
   }
 
   public String getRecipe() {
@@ -59,5 +64,9 @@ public class RemoteDirectiveRequest {
 
   public Schema getInputSchema() {
     return inputSchema;
+  }
+
+  public DirectiveConfig getDirectiveConfig() {
+    return directiveConfig;
   }
 }

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RemoteExecutionTask.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/RemoteExecutionTask.java
@@ -82,7 +82,8 @@ public class RemoteExecutionTask implements RunnableTask {
     // Collect directives.
     try (UserDirectiveRegistry userDirectiveRegistry = new UserDirectiveRegistry(systemAppContext)) {
       List<Directive> directives = new ArrayList<>();
-      GrammarWalker walker = new GrammarWalker(new RecipeCompiler(), new ConfigDirectiveContext(DirectiveConfig.EMPTY));
+      DirectiveConfig config = directiveRequest.getDirectiveConfig();
+      GrammarWalker walker = new GrammarWalker(new RecipeCompiler(), new ConfigDirectiveContext(config));
       walker.walk(directiveRequest.getRecipe(), (command, tokenGroup) -> {
         DirectiveInfo info;
         DirectiveClass directiveClass = systemDirectives.get(command);

--- a/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceHandler.java
+++ b/wrangler-service/src/main/java/io/cdap/wrangler/service/directive/WorkspaceHandler.java
@@ -92,6 +92,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -469,10 +470,12 @@ public class WorkspaceHandler extends AbstractDirectiveHandler {
 
       // check if the rows are empty before going to create a record schema, it will result in a 400 if empty fields
       // are passed to a record type schema
+      DirectiveConfig directiveConfig = getDirectiveConfig();
       Map<String, String> properties = ImmutableMap.of("directives", String.join("\n", directives),
                                                        "field", "*",
                                                        "precondition", "false",
-                                                       "workspaceId", workspaceId);
+                                                       "workspaceId", workspaceId,
+                                                       "directiveConfig", GSON.toJson(directiveConfig));
 
       Set<StageSpec> srcSpecs = getSourceSpecs(detail, directives);
 
@@ -630,7 +633,7 @@ public class WorkspaceHandler extends AbstractDirectiveHandler {
    */
   private <E extends Exception> List<Row> executeLocally(String namespace, List<String> directives,
                                    WorkspaceDetail detail, GrammarWalker.Visitor<E> grammarVisitor)
-    throws DirectiveLoadException, DirectiveParseException, E, RecipeException {
+    throws DirectiveLoadException, DirectiveParseException, E, RecipeException, IOException {
 
     // load the udd
     composite.reload(namespace);
@@ -656,7 +659,8 @@ public class WorkspaceHandler extends AbstractDirectiveHandler {
     Map<String, DirectiveClass> systemDirectives = new HashMap<>();
 
     // Gather system directives and call additional visitor.
-    GrammarWalker walker = new GrammarWalker(new RecipeCompiler(), new ConfigDirectiveContext(DirectiveConfig.EMPTY));
+    DirectiveConfig config = getDirectiveConfig();
+    GrammarWalker walker = new GrammarWalker(new RecipeCompiler(), new ConfigDirectiveContext(config));
     AtomicBoolean hasDirectives = new AtomicBoolean();
     walker.walk(recipe, (command, tokenGroup) -> {
       DirectiveInfo info = SystemDirectiveRegistry.INSTANCE.get(command);
@@ -674,7 +678,8 @@ public class WorkspaceHandler extends AbstractDirectiveHandler {
 
     RemoteDirectiveRequest directiveRequest = new RemoteDirectiveRequest(recipe, systemDirectives,
                                                                          namespace, detail.getSampleAsBytes(),
-                                                                         TRANSIENT_STORE.get(INPUT_SCHEMA));
+                                                                         TRANSIENT_STORE.get(INPUT_SCHEMA),
+                                                                         config);
     RunnableTaskRequest runnableTaskRequest = RunnableTaskRequest.getBuilder(RemoteExecutionTask.class.getName())
       .withParam(GSON.toJson(directiveRequest))
       .withNamespace(namespace)

--- a/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/ConfigStore.java
+++ b/wrangler-storage/src/main/java/io/cdap/wrangler/dataset/workspace/ConfigStore.java
@@ -19,13 +19,13 @@ package io.cdap.wrangler.dataset.workspace;
 import com.google.gson.Gson;
 import io.cdap.cdap.spi.data.StructuredRow;
 import io.cdap.cdap.spi.data.StructuredTable;
-import io.cdap.cdap.spi.data.StructuredTableContext;
-import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.FieldType;
 import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.wrangler.api.DirectiveConfig;
 
 import java.io.IOException;
@@ -54,32 +54,28 @@ public class ConfigStore {
     .withFields(new FieldType(KEY_COL, FieldType.Type.STRING), new FieldType(VAL_COL, FieldType.Type.STRING))
     .withPrimaryKeys(KEY_COL)
     .build();
-  private final StructuredTable table;
+  private final TransactionRunner transactionRunner;
 
-  public ConfigStore(StructuredTable table) {
-    this.table = table;
-  }
-
-  public static ConfigStore get(StructuredTableContext context) {
-    try {
-      StructuredTable table = context.getTable(TABLE_ID);
-      return new ConfigStore(table);
-    } catch (TableNotFoundException e) {
-      throw new IllegalStateException(String.format(
-        "System table '%s' does not exist. Please check your system environment.", TABLE_ID.getName()), e);
-    }
+  public ConfigStore(TransactionRunner transactionRunner) {
+    this.transactionRunner = transactionRunner;
   }
 
   public void updateConfig(DirectiveConfig config) throws IOException {
-    List<Field<?>> fields = new ArrayList<>(2);
-    fields.add(keyField);
-    fields.add(Fields.stringField(VAL_COL, GSON.toJson(config)));
-    table.upsert(fields);
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      List<Field<?>> fields = new ArrayList<>(2);
+      fields.add(keyField);
+      fields.add(Fields.stringField(VAL_COL, GSON.toJson(config)));
+      table.upsert(fields);
+    }, IOException.class);
   }
 
   public DirectiveConfig getConfig() throws IOException {
-    Optional<StructuredRow> row = table.read(Collections.singletonList(keyField));
-    String configStr = row.map(r -> r.getString(VAL_COL)).orElse("{}");
-    return GSON.fromJson(configStr, DirectiveConfig.class);
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      Optional<StructuredRow> row = table.read(Collections.singletonList(keyField));
+      String configStr = row.map(r -> r.getString(VAL_COL)).orElse("{}");
+      return GSON.fromJson(configStr, DirectiveConfig.class);
+    }, IOException.class);
   }
 }

--- a/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
+++ b/wrangler-transform/src/main/java/io/cdap/wrangler/Wrangler.java
@@ -16,8 +16,11 @@
 
 package io.cdap.wrangler;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
@@ -51,24 +54,26 @@ import io.cdap.wrangler.api.CompileException;
 import io.cdap.wrangler.api.CompileStatus;
 import io.cdap.wrangler.api.Compiler;
 import io.cdap.wrangler.api.Directive;
+import io.cdap.wrangler.api.DirectiveConfig;
+import io.cdap.wrangler.api.DirectiveContext;
 import io.cdap.wrangler.api.DirectiveLoadException;
 import io.cdap.wrangler.api.DirectiveParseException;
 import io.cdap.wrangler.api.EntityCountMetric;
 import io.cdap.wrangler.api.ErrorRecord;
 import io.cdap.wrangler.api.ExecutorContext;
-import io.cdap.wrangler.api.RecipeException;
 import io.cdap.wrangler.api.RecipeParser;
 import io.cdap.wrangler.api.RecipePipeline;
 import io.cdap.wrangler.api.RecipeSymbol;
 import io.cdap.wrangler.api.Row;
-import io.cdap.wrangler.api.TokenGroup;
 import io.cdap.wrangler.api.TransientStore;
 import io.cdap.wrangler.api.TransientVariableScope;
+import io.cdap.wrangler.clients.DataPrepServiceClient;
 import io.cdap.wrangler.executor.RecipePipelineExecutor;
 import io.cdap.wrangler.lineage.LineageOperations;
+import io.cdap.wrangler.parser.ConfigDirectiveContext;
 import io.cdap.wrangler.parser.GrammarBasedParser;
+import io.cdap.wrangler.parser.GrammarWalker;
 import io.cdap.wrangler.parser.MigrateToV2;
-import io.cdap.wrangler.parser.NoOpDirectiveContext;
 import io.cdap.wrangler.parser.RecipeCompiler;
 import io.cdap.wrangler.proto.Contexts;
 import io.cdap.wrangler.registry.CompositeDirectiveRegistry;
@@ -81,10 +86,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -109,15 +114,16 @@ import static io.cdap.wrangler.metrics.Constants.Tags.APP_ENTITY_TYPE_NAME;
 @Description("Wrangler - A interactive tool for data cleansing and transformation.")
 public class Wrangler extends Transform<StructuredRecord, StructuredRecord> implements LinearRelationalTransform {
   private static final Logger LOG = LoggerFactory.getLogger(Wrangler.class);
+  private static final Gson GSON = new Gson();
 
-  // Configuration specifying the dataprep application and service name.
-  private static final String APPLICATION_NAME = "dataprep";
-  private static final String SERVICE_NAME = "service";
-  private static final String CONFIG_METHOD = "config";
   private static final String ON_ERROR_DEFAULT = "fail-pipeline";
   private static final String ON_ERROR_FAIL_PIPELINE = "fail-pipeline";
   private static final String ON_ERROR_PROCEED = "send-to-error-port";
   private static final String ERROR_STRATEGY_DEFAULT = "wrangler.error.strategy.default";
+
+// Runtime argument key used to pass directive config from prepareRun to initialize,
+// avoiding HTTP service calls during task execution.
+  private static final String RUNTIME_ARG_DIRECTIVE_CONFIG = "wrangler.directive.config";
 
   // Directive usage metric
   public static final String DIRECTIVE_METRIC_NAME = "wrangler.directive.count";
@@ -229,21 +235,23 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
             // Create the registry that only interacts with system directives.
             registry = SystemDirectiveRegistry.INSTANCE;
 
-            Iterator<TokenGroup> iterator = symbols.iterator();
-            while (iterator.hasNext()) {
-              TokenGroup group = iterator.next();
-              if (group != null) {
-                String directive = (String) group.get(0).value();
-                DirectiveInfo directiveInfo = registry.get("", directive);
-                if (directiveInfo == null && !dynamicDirectives.contains(directive)) {
-                  collector.addFailure(
-                    String.format("Wrangler plugin has a directive '%s' that does not exist in system or " +
-                                    "user space.", directive),
-                    "Ensure the directive is loaded or the directive name is correct.")
-                    .withConfigProperty(Config.NAME_DIRECTIVES);
-                }
+            // During pipeline configure time, stage runtime context and directive config
+            // from
+            // service/arguments are not yet available. DirectiveConfig.EMPTY is used for
+            // compile-time
+            // grammar validation.
+            DirectiveContext directiveContext = new ConfigDirectiveContext(DirectiveConfig.EMPTY);
+            GrammarWalker walker = new GrammarWalker(new RecipeCompiler(), directiveContext);
+            walker.walk(new MigrateToV2(directives).migrate(), (command, tokenGroup) -> {
+              DirectiveInfo directiveInfo = registry.get("", command);
+              if (directiveInfo == null && !dynamicDirectives.contains(command)) {
+                collector.addFailure(
+                  String.format("Wrangler plugin has a directive '%s' that does not exist in system or " +
+                                  "user space.", command),
+                  "Ensure the directive is loaded or the directive name is correct.")
+                  .withConfigProperty(Config.NAME_DIRECTIVES);
               }
-            }
+            });
           }
         }
       } catch (CompileException e) {
@@ -306,6 +314,12 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
   @Override
   public void prepareRun(StageSubmitterContext context) throws Exception {
     super.prepareRun(context);
+
+    DataPrepServiceClient client = new DataPrepServiceClient();
+    DirectiveConfig systemConfig = client.fetchDirectiveConfig(context);
+    String runtimeArgVal = GSON.toJson(systemConfig);
+    LOG.debug("Configuring wrangler directive runtime arguments.");
+    context.getArguments().set(RUNTIME_ARG_DIRECTIVE_CONFIG, runtimeArgVal);
 
     // Validate input schema. If there is no input schema available then there
     // is no transformations that can be applied to just return.
@@ -392,6 +406,8 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
     try {
       // Create the pipeline executor with context being set.
       pipeline = new RecipePipelineExecutor(recipe, ctx);
+      // Eagerly parse recipe during initialization to enforce directive exclusions before record processing.
+      recipe.parse();
     } catch (Exception e) {
       String errorReason = "Unable to compile the recipe and execute directives.";
       String errorMessage = String.format(
@@ -583,13 +599,13 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
   }
 
   /**
-   * This method creates a {@link CompositeDirectiveRegistry} and initializes the {@link RecipeParser}
-   * with {@link NoOpDirectiveContext}
+   * Creates a {@link CompositeDirectiveRegistry} and initializes the {@link RecipeParser}
+   * with {@link ConfigDirectiveContext} so that directive config is enforced.
    *
-   * @param context
-   * @return
-   * @throws DirectiveLoadException
-   * @throws DirectiveParseException
+   * @param context the stage context
+   * @return a {@link RecipeParser} configured with directive config
+   * @throws DirectiveLoadException if directives cannot be loaded
+   * @throws DirectiveParseException if directives cannot be parsed
    */
   private RecipeParser getRecipeParser(StageContext context) {
 
@@ -607,12 +623,53 @@ public class Wrangler extends Transform<StructuredRecord, StructuredRecord> impl
       directives = String.format("#pragma load-directives %s;%s", config.getUDDs(), config.getDirectives());
     }
 
+    DirectiveConfig directiveConfig = getSystemDirectiveConfigFromRuntimeArgs(context);
+    DirectiveContext directiveContext = new ConfigDirectiveContext(directiveConfig);
+
     try {
-      return new GrammarBasedParser(context.getNamespace(), new MigrateToV2(directives).migrate(), registry);
+      return new GrammarBasedParser(context.getNamespace(), new MigrateToV2(directives).migrate(),
+                                    registry, directiveContext);
     } catch (Exception e) {
       String errorReason = "Unable to parse the directives.";
       throw WranglerErrorUtil.getProgramFailureExceptionDetailsFromChain(e, errorReason, null,
           ErrorType.USER);
+    }
+  }
+
+  /**
+   * Fetches the system-level {@link DirectiveConfig} from pipeline runtime
+   * arguments.
+   *
+   * <p>
+   * This runtime argument is set by {@code prepareRun()} on the master, which
+   * fetches the config via HTTP from the Wrangler service and passes it to
+   * workers.
+   * Reading from runtime arguments avoids workers attempting HTTP calls to the
+   * Wrangler
+   * service where service endpoints are unreachable.
+   * </p>
+   *
+   * @param context the stage context
+   * @return the system-level {@link DirectiveConfig}
+   * @throws IllegalArgumentException if the context is null, or the runtime
+   *                                  argument is missing or invalid
+   */
+  DirectiveConfig getSystemDirectiveConfigFromRuntimeArgs(StageContext context) {
+    String runtimeConfigStr = null;
+    try {
+      Preconditions.checkArgument(context != null, "StageContext cannot be null.");
+      runtimeConfigStr = context.getArguments().get(RUNTIME_ARG_DIRECTIVE_CONFIG);
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(runtimeConfigStr),
+          "Directive configuration runtime argument '%s' is missing or empty.",
+          RUNTIME_ARG_DIRECTIVE_CONFIG);
+      DirectiveConfig configFromArg = GSON.fromJson(runtimeConfigStr, DirectiveConfig.class);
+      LOG.debug("Successfully parsed system directive configuration from runtime argument.");
+      return configFromArg;
+    } catch (JsonSyntaxException e) {
+      throw new IllegalArgumentException(
+          String.format("Failed to parse system directive configuration from pipeline runtime arguments: %s",
+              runtimeConfigStr),
+          e);
     }
   }
 


### PR DESCRIPTION
## Overview

This PR resolves issues with directive exclusions not being enforced in both the CDAP Wrangler service (`wrangler-service`) and the CDAP Wrangler pipeline transform (`wrangler-transform`).

## Problem Statement

Directive exclusions and configuration rules were failing to enforce in two key areas:

1. **CDAP Wrangler Service (`wrangler-service`)**: Directive execution and validation endpoints were not loading the system-level `DirectiveConfig` from backend storage (DB/store). Consequently, directive checks and validations performed via the service did not respect restriction rules.
2. **CDAP Wrangler Transform (`wrangler-transform`)**: The pipeline transform initialized its directive parser (`GrammarBasedParser`) with `NoOpDirectiveContext`, where `isExcluded()` is hardcoded to return `false`. As a result, excluded directives were executed silently on pipeline task workers. Furthermore, in distributed execution mode, worker nodes cannot directly invoke HTTP calls to the system CDAP Wrangler service.

## Solution

### 1. Fix for CDAP Wrangler Service
- Updated service handlers (such as `AbstractDirectiveHandler`) to fetch `DirectiveConfig` from backend storage and bind it to the execution context so that UI interactions and directive evaluations via the service respect exclusions.

### 2. Fix for CDAP Wrangler Transform (Pipeline Runs)
- **Master Node Setup (`prepareRun`)**: During pipeline preparation on the master node, `Wrangler.prepareRun()` calls the system CDAP Wrangler service endpoint (`/config`) via `StageContext.openConnection()` to retrieve the active `DirectiveConfig`.
- **Runtime Argument Propagation**: `prepareRun()` serializes the fetched `DirectiveConfig` as JSON into a CDAP pipeline runtime argument (`pipeline.wrangler.directive.config`).
- **Worker Node Execution (`initialize` & `getRecipeParser`)**: 
  - On worker initialization, `getSystemDirectiveConfigFromRuntimeArgs()` reads the `DirectiveConfig` directly from the CDAP runtime arguments, bypassing the need for worker nodes to perform HTTP calls to the service.
  - Initialized `GrammarBasedParser` with `ConfigDirectiveContext(directiveConfig)` instead of `NoOpDirectiveContext`.
  - Added eager recipe parsing during `initialize()` to fail fast if an excluded or restricted directive is included in the recipe before processing pipeline records.

## Testing

1. Wrangler Interactive UI

<img width="2868" height="1262" alt="image" src="https://github.com/user-attachments/assets/773aa29b-41c9-4f21-9fe0-854f974dbfc3" />


2. Pipeline Preview Run

<img width="3432" height="1452" alt="image" src="https://github.com/user-attachments/assets/3c54674a-ef21-4efb-b6a4-923ada743762" />



3. Pipeline Execution

<img width="3386" height="1436" alt="image" src="https://github.com/user-attachments/assets/446ed078-ce51-4a87-96d8-8cd211858d44" />



#### Unit Testing
- Added unit tests in `WranglerDirectiveExclusionTest`.
- Ran existing unit test suite across `wrangler-api`, `wrangler-service`, and `wrangler-transform` modules.